### PR TITLE
Produce a proper error message if typechecking at parsing fails

### DIFF
--- a/src/cmd_parser.cpp
+++ b/src/cmd_parser.cpp
@@ -573,15 +573,20 @@ bool CmdParser::parseNextCommand()
         children.push_back(e);
       }
       // compute the type of applying the rule
+      std::stringstream ss;
       Expr concType;
       if (children.size()>1)
       {
         // check type rule for APPLY directly without constructing the app
-        concType = d_state.getTypeChecker().getTypeApp(children);
+        concType = d_state.getTypeChecker().getTypeApp(children, &ss);
       }
       else
       {
-        concType = d_state.getTypeChecker().getType(rule);
+        concType = d_state.getTypeChecker().getType(rule, &ss);
+      }
+      if (concType == nullptr)
+      {
+        d_lex.parseError(ss.str());
       }
       // ensure proof type, note this is where "proof checking" happens.
       if (concType->getKind()!=Kind::PROOF_TYPE)

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -482,12 +482,12 @@ Expr TypeChecker::evaluate(Expr& e, Ctx& ctx)
     while (!visit.empty())
     {
       cur = visit.back();
-      //std::cout << "visit " << cur << " " << cctx << std::endl;
+      Trace("type_checker") << "visit " << cur << " " << cctx << std::endl;
       // the term will stay the same if it is not evaluatable and either it
       // is ground, or the context is empty.
       if (!cur->isEvaluatable() && (cur->isGround() || cctx.empty()))
       {
-        //std::cout << "...shortcut " << cur << std::endl;
+        Trace("type_checker") << "...shortcut " << cur << std::endl;
         visited[cur] = cur;
         visit.pop_back();
         continue;
@@ -506,7 +506,8 @@ Expr TypeChecker::evaluate(Expr& e, Ctx& ctx)
         visit.pop_back();
         continue;
         // NOTE: this could be an error or warning, variable not filled?
-        //std::cout << "WARNING: unfilled variable " << cur << std::endl;
+        Trace("type_checker")
+            << "WARNING: unfilled variable " << cur << std::endl;
       }
       std::vector<Expr>& children = cur->d_children;
       it = visited.find(cur);
@@ -583,7 +584,8 @@ Expr TypeChecker::evaluate(Expr& e, Ctx& ctx)
                 Ctx newCtx;
                 // see if we evaluate
                 evaluated = evaluateProgramInternal(cchildren, newCtx);
-                //std::cout << "Evaluate prog returned " << evaluated << std::endl;
+                Trace("type_checker")
+                    << "Evaluate prog returned " << evaluated << std::endl;
                 if (evaluated==nullptr || newCtx.empty())
                 {
                   // if the evaluation can be shortcircuited, don't need to


### PR DESCRIPTION
Before there would be a segmentation fault, since the `getKind()` call would be called on a null pointer.  We check for this now and recover the output of the type checker in the error message.

This also reenables some trace messages