### PR TITLE
Check that the type of the conclusion term is actually "Bool"

### DIFF
--- a/src/cmd_parser.cpp
+++ b/src/cmd_parser.cpp
@@ -831,6 +831,15 @@ bool CmdParser::parseNextCommand()
         ss << "Non-proof conclusion for rule " << ruleName << ", got " << concType;
         d_lex.parseError(ss.str());
       }
+      // Check that the proved term is actually Bool
+      Expr concTerm = concType[0];
+      Expr concTermType = d_eparser.typeCheck(concTerm);
+      if (concTermType.getKind() != Kind::BOOL_TYPE)
+      {
+        std::stringstream ss;
+        ss << "Non-bool conclusion for step, got " << concTermType;
+        d_lex.parseError(ss.str());
+      }
       if (!proven.isNull())
       {
         if (concType[0]!=proven)


### PR DESCRIPTION
This fixes an issue where some nonsensical proofs would pass checking:
```clojure
(declare-type Pair (Type Type))
(declare-const pair (-> (! Type :var U :implicit) (! Type :var T :implicit) U T (Pair U T)))

(declare-rule partialEva
  ((T Type) (x T))
  :args (x)
  :conclusion x
)

(step c1 :rule partialEva :args ( (pair 4 5) ) )
```

While the rule correctly evaluates here, it doesn't evaluate to a Boolean expression, and checking should fail.