### PR TITLE
Do not permit types that are ground and evaluatable

### DIFF
--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -124,7 +124,7 @@ Expr TypeChecker::getType(Expr& e, std::ostream* out)
             << "TYPE " << Expr(cur) << " : [FAIL] due to evaluatable " << ret << std::endl;
         if (out)
         {
-          (*out) << "Has type " << ret << " that is ground and evaluatable";
+          (*out) << "Has type " << ret << " whose evaluation cannot be reduced";
         }
         return d_null;
       }

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -122,6 +122,10 @@ Expr TypeChecker::getType(Expr& e, std::ostream* out)
       {
         Trace("type_checker")
             << "TYPE " << Expr(cur) << " : [FAIL] due to evaluatable " << ret << std::endl;
+        if (out)
+        {
+          (*out) << "Has type " << ret << " that is ground and evaluatable";
+        }
         return d_null;
       }
       tc[cur] = ret;

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -118,6 +118,12 @@ Expr TypeChecker::getType(Expr& e, std::ostream* out)
             << "TYPE " << Expr(cur) << " : [FAIL]" << std::endl;
         return ret;
       }
+      if (ret.isGround() && ret.isEvaluatable())
+      {
+        Trace("type_checker")
+            << "TYPE " << Expr(cur) << " : [FAIL] due to evaluatable " << ret << std::endl;
+        return d_null;
+      }
       tc[cur] = ret;
       Trace("type_checker")
           << "TYPE " << Expr(cur) << " : " << ret << std::endl;

--- a/user_manual.md
+++ b/user_manual.md
@@ -796,11 +796,11 @@ If on the other hand we defined:
 (declare-const b Int)
 (declare-const x2 (BitVec a))
 (declare-const y2 (BitVec b))
-(define z2 () (concat x2 y2))
+(define z2 () (concat x2 y2) :type (BitVec (eo::add a b)))
 ```
-The type `z2` in the above example is `(BitVec (eo::add a b))`, where the application of `eo::add` does not evaluate.
-Although the above term does not lead to a type checking error, further use of `z2` would lead to errors if given as an argument to a function that did not expect this type verbatim.
-For example, given a function `f` of type `(-> (BitVec (eo::add b a)) T)`, the term `(f z2)` is not well-typed, since `(eo::add a b)` is not syntactically equal to `(eo::add b a)`.
+Based on the definition of `concat`, the return type of `z2` in the above example is `(BitVec (eo::add a b))`, where the application of `eo::add` does not evaluate since `a` and `b` are not values.
+However, any term with a type that is both ground (i.e. containing no parameters) and evaluatable (i.e. containing an application of a program or builtin evaluation operator) is considered ill-typed by Ethos.
+Hence, the above example results in a type checking error.
 
 ### <a name="bv-literals"></a>Example: Type rule for BitVector constants
 
@@ -1707,6 +1707,8 @@ f : (-> U S)  t : T
 for all other (non-Quote) types U.
 
 ```
+
+Note that Ethos additionally requires that all well-typed terms have a type that is either non-ground, or is fully reduced, i.e. contains no unreduced applications of programs or evaluation operators.
 
 The command:
 ```

--- a/user_manual.md
+++ b/user_manual.md
@@ -1708,7 +1708,7 @@ for all other (non-Quote) types U.
 
 ```
 
-Note that Ethos additionally requires that all well-typed terms have a type that is either non-ground, or is fully reduced, i.e. contains no unreduced applications of programs or evaluation operators.
+Note that Ethos additionally requires that all well-typed terms have a type that is either non-ground, or is fully reduced, i.e. contains no irreducible applications of programs or evaluation operators.
 
 The command:
 ```

--- a/user_manual.md
+++ b/user_manual.md
@@ -801,6 +801,7 @@ If on the other hand we defined:
 Based on the definition of `concat`, the return type of `z2` in the above example is `(BitVec (eo::add a b))`, where the application of `eo::add` does not evaluate since `a` and `b` are not values.
 However, any term with a type that is both ground (i.e. containing no parameters) and evaluatable (i.e. containing an application of a program or builtin evaluation operator) is considered ill-typed by Ethos.
 Hence, the above example results in a type checking error.
+This was not the case with `z` in the previous example, whose type prior to evaluation was`(BitVec (eo::add 2 3))`, which evaluates to `(BitVec 5)` which is a legal type.
 
 ### <a name="bv-literals"></a>Example: Type rule for BitVector constants
 


### PR DESCRIPTION
This makes it so that e.g. `(+ true false)` is ill-typed in the cvc5 signature. Its type previously would be `(arith_typeunion Bool Bool)`, which is ground and evaluatable.  This makes the type checker discard any such type.