### PR TITLE
Fix bug when appling operators with opaque arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 This file contains a summary of important user-visible changes.
 
+ethos 0.1.1 prerelease
+======================
+
+- Fixed a bug when applying operators with opaque arguments.
+
 ethos 0.1.0
 ===========
 

--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -470,6 +470,7 @@ Expr ExprParser::parseExpr()
                 break;
               case Attr::IMPLICIT:
                 // the term will not be added as an argument to the parent
+                // note this always comes after VAR due to enum order
                 ret = d_null;
                 break;
               case Attr::REQUIRES:
@@ -480,6 +481,14 @@ Expr ExprParser::parseExpr()
                 ret = d_state.mkRequires(a.second, ret);
                 break;
               case Attr::OPAQUE:
+                if (ret.isNull())
+                {
+                  d_lex.parseError("Cannot mark opaque on implicit argument");
+                }
+                if (ret.getKind()==Kind::EVAL_REQUIRES)
+                {
+                  d_lex.parseError("Cannot combine opaque and requires");
+                }
                 ret = d_state.mkExpr(Kind::OPAQUE_TYPE, {ret});
                 break;
               default:

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -745,8 +745,8 @@ Expr State::mkExpr(Kind k, const std::vector<Expr>& children)
             // higher order
             std::vector<Expr> rchildren;
             rchildren.push_back(op);
-            rchildren.insert(rchildren.end(), children.begin()+2+nargs, children.end());
-            Trace("opaque") << "...return operator" << std::endl;
+            rchildren.insert(rchildren.end(), children.begin()+1+nargs, children.end());
+            Trace("opaque") << "...return operator applied to children" << std::endl;
             return mkExpr(Kind::APPLY, rchildren);
           }
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -125,6 +125,7 @@ set(ethos_test_file_list
     sorry.eo
     disamb-arith.eo
     opaque-inline.eo
+    implicit-then-var.eo
 )
 
 macro(ethos_test file)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -124,6 +124,7 @@ set(ethos_test_file_list
     overloading-binder.eo
     sorry.eo
     disamb-arith.eo
+    opaque-inline.eo
 )
 
 macro(ethos_test file)

--- a/tests/implicit-then-var.eo
+++ b/tests/implicit-then-var.eo
@@ -1,0 +1,4 @@
+
+(declare-const = (-> (! Type :implicit :var T) T T Bool))
+
+(define d () (= true false) :type Bool)

--- a/tests/opaque-inline.eo
+++ b/tests/opaque-inline.eo
@@ -1,0 +1,10 @@
+(declare-type String ())
+(declare-type Int ())
+
+(declare-const @strings_stoi_result (-> (! String :opaque) Int Int))
+
+(declare-const P (-> Int Bool))
+(declare-const s String)
+(declare-const n Int)
+
+(assume @p0 (P (@strings_stoi_result s n)))

--- a/user_manual.md
+++ b/user_manual.md
@@ -258,6 +258,8 @@ In this example, `@purify_fun` is declared as a function with one opaque argumen
 Intuitively, this definition is introducing a new function, indexed by a function, that is of type `(-> Int Int)`.
 After parsing, the term `(@purify_fun f a)` is a function application whose operator is `(@purify_fun f)` and has a single child `a`.
 
+> Opaque arguments should always be expected before other arguments. Otherwise all applications of the given function will be ill-typed.
+
 ## <a name="attributes"></a>Declarations with attributes
 
 The Eunoia language supports term annotations on declared constants, which for instance can allow the user to treat a constant as being variadic, i.e. taking an arbitrary number of arguments. The available annotations in the Ethos for this purpose are:

--- a/user_manual.md
+++ b/user_manual.md
@@ -244,7 +244,8 @@ Intuitively, `d` should be considered an atomic constant symbol, where `A` and `
 In particular, this means that any computation that pattern matches `d` will not consider it to be a function application.
 We give examples of this later in [ex-substitution](#ex-substitution).
 
-Functions can mix opaque and ordinary arguments. These arguments can be passed to the symbol in the order they are given.
+Functions can have both opaque and ordinary arguments, where the opaque arguments are expected to come first.
+The concatentation of the expected arguments can be passed to the symbol in the order they are given.
 For example:
 ```
 (declare-type Int ())

--- a/user_manual.md
+++ b/user_manual.md
@@ -216,6 +216,33 @@ The second annotation indicates that `(eo::is_neg w)` must evaluate to `false`, 
 
 > Internally, `(! T :requires (t s))` is syntax sugar for `(eo::requires t s T)` where `eo::requires` is an operator that evalutes to its third argument if and only if its first two arguments are equivalent (details on this operator are given in [computation](#computation)). Furthermore, the function type `(-> (eo::requires t s T) S)` is treated as `(-> T (eo::requires t s S))`. The Ethos rewrites all types of the former to the latter.
 
+## <a name="opaque"></a>The :opaque annotation
+
+The attribute `:opaque` can be used to denote that an argument to a function should not be considered a child of that function, but instead intuitively considered to be an index of that function.
+An example of this annotation is the following:
+
+```
+(declare-type Array (Type Type))
+(declare-const @array_deq_diff
+   (-> (! Type :var T :implicit) (! Type :var U :implicit)
+   (! (Array T U) :opaque)
+   (! (Array T U) :opaque)
+   T))
+
+(declare-type Int ())
+(declare-const A (Array Int Int))
+(declare-const B (Array Int Int))
+(define d () (@array_deq_diff A B) :type Int)
+```
+
+The above example declares a function `@array_deq_diff` symbol. 
+This has two implicit type arguments `T` and `U` followed by two opaque array arguments and has `T` as a return type.
+In the remainder of the example, we define `d` to be this function applied to the arrays `A` and `B`, where `d` has type `Int`.
+
+Intuitively, `d` should be considered an atomic constant symbol, where `A` and `B` are its indices and not its children.
+In particular, this means that any computation that pattern matches `d` will not consider it to be a function application.
+We give an example of this later in [ex-substitution](#ex-substitution).
+
 ## <a name="attributes"></a>Declarations with attributes
 
 The Eunoia language supports term annotations on declared constants, which for instance can allow the user to treat a constant as being variadic, i.e. taking an arbitrary number of arguments. The available annotations in the Ethos for this purpose are:
@@ -1231,7 +1258,7 @@ The Ethos will reject this definition since it implies that a computational oper
 In particular, the term `(or x xs)` is equivalent to `(eo::list_concat or x xs)` after desugaring.
 Thus, the third case of the program, `(contains (eo::list_concat or x xs) l)`, is not a legal pattern.
 
-### Example: Substitution
+### <a name="ex-substitution"></a>Example: Substitution
 
 ```
 (program substitute
@@ -1250,6 +1277,10 @@ Note that this side condition is fully general and does not depend on the shape 
 In detail, recall that the Ethos treats all function applications as curried (unary) applications.
 In particular, this implies that `(f a)` matches any application term, since both `f` and `a` are parameters.
 Thus, the side condition is written in three cases: either `t` is `x` in which case we return `y`, `t` is a function application in which case we recurse, or otherwise `t` is a constant not equal to `x` and we return itself.
+
+This method will not replace subterms inside of opaque arguments (see [opaque](#opaque)).
+In particular, a term such as `(@array_deq_diff A B)` will remain unchanged for a substitution e.g. replacing `A` with `B`, since `(@array_deq_diff A B)` is not a function application.
+Hence when `t` is `(@array_deq_diff A B)`, we fall into the third case of the method above for any call to `substitute` where `x` is not `(@array_deq_diff A B)` itself.
 
 ### Example: Term evaluator
 

--- a/user_manual.md
+++ b/user_manual.md
@@ -243,6 +243,20 @@ Intuitively, `d` should be considered an atomic constant symbol, where `A` and `
 In particular, this means that any computation that pattern matches `d` will not consider it to be a function application.
 We give an example of this later in [ex-substitution](#ex-substitution).
 
+Functions can mix opaque and ordinary arguments. These arguments can be passed to the symbol in the order they are given.
+For example:
+```
+(declare-type Int ())
+(declare-const @purify_fun (-> (! (-> Int Int) :opaque) Int Int))
+
+(declare-const f (-> Int Int))
+(declare-const a Int)
+(define d () (@purify_fun f a) :type Int)
+```
+In this example, `@purify_fun` is declared as a function with one opaque argument, and ordinary integer argument, and returns an integer.
+Intuitively, this definition is introducing a new function, indexed by a function, that is of type `(-> Int Int)`.
+After parsing, the term `(@purify_fun f a)` is a function application whose operator is `(@purify_fun f)` and has a single child `a`.
+
 ## <a name="attributes"></a>Declarations with attributes
 
 The Eunoia language supports term annotations on declared constants, which for instance can allow the user to treat a constant as being variadic, i.e. taking an arbitrary number of arguments. The available annotations in the Ethos for this purpose are:


### PR DESCRIPTION
Also adds documentation to the user manual about `:opaque`.  

This bug occurs when using the syntax `(<opaque-op> <index>* <child>*)`.

This did not impact cvc5 1.2.0 since we always use the style `(_ (<opaque-op> <index>*) <child>*)`.  However, this may change soon.