### PR TITLE
Make normalize options apply only to reference files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 This file contains a summary of important user-visible changes.
 
+ethos 0.1.1 prerelease
+======================
+
+- The options `--no-normalize-dec`, `--no-normalize-hex`, `--binder-fresh`, and `--no-parse-let` now only apply when reference parsing. In other words, when parsing Eunoia signatures and proofs, decimals and hexidecimals are never normalized, variables are always unique for their name and type, and let is never treated as a builtin way of specifying macros.
+- Adds a new option `--normalize-num`, which also only applies when reference parsing. This option treats numerals as rationals, which can be used when parsing SMT-LIB inputs in logics where numerals are shorthand for rationals.
+
 ethos 0.1.0
 ===========
 

--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -98,9 +98,9 @@ ExprParser::ExprParser(Lexer& lex, State& state, bool isReference)
   d_strToLiteralKind["<numeral>"] = Kind::NUMERAL;
   d_strToLiteralKind["<decimal>"] = Kind::DECIMAL;
   d_strToLiteralKind["<rational>"] = Kind::RATIONAL;
-  d_strToLiteralKind["<hexadecimal>"] = Kind::HEXADECIMAL;
   d_strToLiteralKind["<binary>"] = Kind::BINARY;
   d_strToLiteralKind["<string>"] = Kind::STRING;
+  d_strToLiteralKind["<hexadecimal>"] = Kind::HEXADECIMAL;
 }
 
 class StackFrame
@@ -213,7 +213,8 @@ Expr ExprParser::parseExpr()
                   if (ck==Attr::BINDER)
                   {
                     nscopes = 1;
-                    bool isLookup = !d_state.getOptions().d_binderFresh;
+                    // we always do lookups if not parsing reference
+                    bool isLookup = !d_isReference || !d_state.getOptions().d_binderFresh;
                     d_state.pushScope();
                     std::vector<Expr> vs = parseAndBindSortedVarList(isLookup);
                     if (vs.empty())
@@ -283,12 +284,22 @@ Expr ExprParser::parseExpr()
       break;
       case Token::INTEGER_LITERAL:
       {
-        ret = d_state.mkLiteral(Kind::NUMERAL, d_lex.tokenStr());
+        // normalize to rational if reference and option is set
+        if (d_isReference && d_state.getOptions().d_normalizeNumeral)
+        {
+          Rational r(d_lex.tokenStr());
+          ret = d_state.mkLiteral(Kind::RATIONAL, r.toString());
+        }
+        else
+        {
+          ret = d_state.mkLiteral(Kind::NUMERAL, d_lex.tokenStr());
+        }
       }
       break;
       case Token::DECIMAL_LITERAL:
       {
-        if (d_state.getOptions().d_normalizeDecimal)
+        // normalize to rational if reference and option is set
+        if (d_isReference && d_state.getOptions().d_normalizeDecimal)
         {
           // normalize from decimal
           Rational r = Rational::fromDecimal(d_lex.tokenStr());
@@ -321,8 +332,8 @@ Expr ExprParser::parseExpr()
       {
         std::string hexStr = d_lex.tokenStr();
         hexStr = hexStr.substr(2);
-        // must normalize
-        if (d_state.getOptions().d_normalizeHexadecimal)
+        // normalize to binary if reference and option is set
+        if (d_isReference && d_state.getOptions().d_normalizeHexadecimal)
         {
           // normalize from hexadecimal
           BitVector bv(hexStr, 16);

--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -98,9 +98,9 @@ ExprParser::ExprParser(Lexer& lex, State& state, bool isReference)
   d_strToLiteralKind["<numeral>"] = Kind::NUMERAL;
   d_strToLiteralKind["<decimal>"] = Kind::DECIMAL;
   d_strToLiteralKind["<rational>"] = Kind::RATIONAL;
+  d_strToLiteralKind["<hexadecimal>"] = Kind::HEXADECIMAL;
   d_strToLiteralKind["<binary>"] = Kind::BINARY;
   d_strToLiteralKind["<string>"] = Kind::STRING;
-  d_strToLiteralKind["<hexadecimal>"] = Kind::HEXADECIMAL;
 }
 
 class StackFrame

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,6 +60,10 @@ int main( int argc, char* argv[] )
     {
       opts.d_normalizeDecimal = false;
     }
+    else if (arg=="--normalize-num")
+    {
+      opts.d_normalizeNumeral = false;
+    }
     else if (arg=="--no-normalize-hex")
     {
       opts.d_normalizeHexadecimal = false;
@@ -69,6 +73,7 @@ int main( int argc, char* argv[] )
       std::stringstream out;
       out << "     --binder-fresh: binders generate fresh variables when parsed in proof files." << std::endl;
       out << "             --help: displays this message." << std::endl;
+      out << "    --normalize-num: treat numeral literals as syntax sugar for rational literals." << std::endl;
       out << " --no-normalize-dec: do not treat decimal literals as syntax sugar for rational literals." << std::endl;
       out << " --no-normalize-hex: do not treat hexadecimal literals as syntax sugar for binary literals." << std::endl;
       out << "     --no-parse-let: do not treat let as a builtin symbol for specifying terms having shared subterms." << std::endl;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -11,7 +11,7 @@
 namespace ethos {
 
 Parser::Parser(State& s, bool isReference)
-    : d_lex(s.getOptions().d_parseLet),
+    : d_lex(isReference && s.getOptions().d_parseLet),  // only consider let when reference parsing
       d_state(s),
       d_eparser(d_lex, d_state, isReference),
       d_cmdParser(d_lex, d_state, d_eparser, isReference)

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -26,6 +26,7 @@ Options::Options()
   d_ruleSymTable = true;
   d_normalizeDecimal = true;
   d_normalizeHexadecimal = true;
+  d_normalizeNumeral = false;
   d_binderFresh = false;
 }
 

--- a/src/state.h
+++ b/src/state.h
@@ -38,6 +38,8 @@ class Options
   bool d_ruleSymTable;
   bool d_normalizeDecimal;
   bool d_normalizeHexadecimal;
+  /** Treat numerals as rational literals */
+  bool d_normalizeNumeral;
   /** Binders generate fresh variables in proof and reference files */
   bool d_binderFresh;
 };

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -24,15 +24,7 @@ namespace ethos {
 
 TypeChecker::TypeChecker(State& s, Options& opts) : d_state(s), d_plugin(nullptr)
 {
-  std::set<Kind> literalKinds = { Kind::BOOLEAN, Kind::NUMERAL, Kind::RATIONAL, Kind::BINARY, Kind::STRING };
-  if (!opts.d_normalizeDecimal)
-  {
-    literalKinds.insert(Kind::DECIMAL);
-  }  
-  if (!opts.d_normalizeHexadecimal)
-  {
-    literalKinds.insert(Kind::HEXADECIMAL);
-  }
+  std::set<Kind> literalKinds = { Kind::BOOLEAN, Kind::NUMERAL, Kind::RATIONAL, Kind::BINARY, Kind::STRING, Kind::DECIMAL, Kind::HEXADECIMAL };
   // initialize literal kinds 
   for (Kind k : literalKinds)
   {

--- a/tests/arith-eval.eo
+++ b/tests/arith-eval.eo
@@ -2,7 +2,7 @@
 (declare-type Real ())
 
 (declare-consts <numeral> Int)
-(declare-consts <rational> Real)
+(declare-consts <decimal> Real)
 
 (declare-const = (-> (! Type :var T :implicit) T T Bool))
 

--- a/tests/mixed-arith.eo
+++ b/tests/mixed-arith.eo
@@ -58,13 +58,13 @@
 ; should be agnostic to spurious zeroes
 (step a5 (= (= 1.500 1.5) true) :rule eval :args ((= 1.5000 1.5) true))
 ; rationals and decimals are equivalent after normalization
-;(step a6 (= (= 3/2 1.5) true) :rule eval :args ((= 3/2 1.5) true))
+(step a6 (= (= 3/2 (eo::to_q 1.5)) true) :rule eval :args ((= 3/2 (eo::to_q 1.5)) true))
 ; not possible to do rational arithmetic with decimal syntax
 (step a7 (= (= (+ 1/3 1/6) 1/2) true) :rule eval :args ((= (+ 1/3 1/6) 1/2) true))
 
 ; negatives
 (step a8 (= (= (+ 1/3 -1/6) 1/6) true) :rule eval :args ((= (+ 1/3 -1/6) 1/6) true))
-;(step a9 (= -10.5 -21/2) :rule eval :args (-10.5 -21/2))
+(step a9 (= (eo::to_q -10.5) -21/2) :rule eval :args ((eo::to_q -10.5) -21/2))
 (step a10 (= -1 (- 0 1)) :rule eval :args (-1 (- 0 1)))
 
 ; this would fail due to the use of mixed arithmetic:

--- a/tests/mixed-arith.eo
+++ b/tests/mixed-arith.eo
@@ -3,6 +3,7 @@
 
 (declare-consts <numeral> Int)
 (declare-consts <rational> Real)
+(declare-consts <rational> Real)
 
 
 (declare-const = (-> (! Type :var T :implicit) T T Bool))

--- a/tests/mixed-arith.eo
+++ b/tests/mixed-arith.eo
@@ -3,7 +3,7 @@
 
 (declare-consts <numeral> Int)
 (declare-consts <rational> Real)
-(declare-consts <rational> Real)
+(declare-consts <decimal> Real)
 
 
 (declare-const = (-> (! Type :var T :implicit) T T Bool))
@@ -58,13 +58,13 @@
 ; should be agnostic to spurious zeroes
 (step a5 (= (= 1.500 1.5) true) :rule eval :args ((= 1.5000 1.5) true))
 ; rationals and decimals are equivalent after normalization
-(step a6 (= (= 3/2 1.5) true) :rule eval :args ((= 3/2 1.5) true))
+;(step a6 (= (= 3/2 1.5) true) :rule eval :args ((= 3/2 1.5) true))
 ; not possible to do rational arithmetic with decimal syntax
 (step a7 (= (= (+ 1/3 1/6) 1/2) true) :rule eval :args ((= (+ 1/3 1/6) 1/2) true))
 
 ; negatives
 (step a8 (= (= (+ 1/3 -1/6) 1/6) true) :rule eval :args ((= (+ 1/3 -1/6) 1/6) true))
-(step a9 (= -10.5 -21/2) :rule eval :args (-10.5 -21/2))
+;(step a9 (= -10.5 -21/2) :rule eval :args (-10.5 -21/2))
 (step a10 (= -1 (- 0 1)) :rule eval :args (-1 (- 0 1)))
 
 ; this would fail due to the use of mixed arithmetic:

--- a/tests/overloading-arith.eo
+++ b/tests/overloading-arith.eo
@@ -5,7 +5,7 @@
 
 (declare-const = (-> (! Type :var A :implicit) A A Bool))
 (declare-consts <numeral> Int)
-(declare-consts <rational> Real)
+(declare-consts <decimal> Real)
 
 (assume @p0 (= (+ 1.3 1.5) 2.8))
 (assume @p1 (= (+ 1 1) 2))

--- a/tests/overloading-binder.eo
+++ b/tests/overloading-binder.eo
@@ -1,7 +1,7 @@
 (declare-type Int ())
 (declare-consts <numeral> Int)
 (declare-type Real ())
-(declare-consts <rational> Real)
+(declare-consts <decimal> Real)
 (declare-const f (-> Int Int Int))
 
 (declare-const = (-> (! Type :var T :implicit) T T Bool))

--- a/tests/overloading.eo
+++ b/tests/overloading.eo
@@ -20,7 +20,7 @@
 
 
 (declare-consts <numeral> Int)
-(declare-consts <rational> Real)
+(declare-consts <decimal> Real)
 
 
 (assume a1 (= (+ 1.0 1) (+ 2.0 2)))

--- a/tests/typeof.eo
+++ b/tests/typeof.eo
@@ -4,7 +4,7 @@
 (declare-consts <numeral> Int)
 
 (declare-type Real ())
-(declare-consts <rational> Real)
+(declare-consts <decimal> Real)
 
 (declare-const to_real (-> Int Real))
 (declare-const not (-> Bool Bool))

--- a/user_manual.md
+++ b/user_manual.md
@@ -435,6 +435,8 @@ The Eunoia language supports associating SMT-LIB version 3.0 syntactic categorie
 
 When parsing reference files, by default, decimal literals will be treated as syntax sugar for rational literals unless the option `--no-normalize-dec` is enabled.
 Similarly, hexadecimal literals will be treated as syntax sugar for binary literals unless the option `--no-normalize-hex` is enabled.
+Some SMT-LIB logics (e.g. `QF_LRA`) state that numerals should be treated as syntax sugar for rational literals.
+This behavior can be enabled when parsing reference files using the option `--normalize-num`.
 
 In contrast to SMT-LIB version 2, note that rational values can be specified directly using the syntax `5/11, 2/4, 0/1` and so on.
 Rationals are normalized so that e.g. `2/4` and `1/2` are syntactically equivalent after parsing.

--- a/user_manual.md
+++ b/user_manual.md
@@ -1563,8 +1563,9 @@ The user is responsible for ensure that e.g. the proof contains a step with a de
 ## Command line options of ethos
 
 The Ethos command line interface can be invoked by `ethos <option>* <file>` where `<option>` is one of the following:
-- `--binder-fresh`: binders generate fresh variables when parsed in proof files.
+- `--binder-fresh`: binders generate fresh variables when parsed in reference files.
 - `--help`: displays a help message.
+- `--normalize-num`: treat numeral literals as syntax sugar for (integral) rational literals.
 - `--no-normalize-dec`: do not treat decimal literals as syntax sugar for rational literals.
 - `--no-normalize-hex`: do not treat hexadecimal literals as syntax sugar for binary literals.
 - `--no-parse-let`: do not treat `let` as a builtin symbol for specifying terms having shared subterms.
@@ -1686,7 +1687,7 @@ The following signature can be used to define operators that are not required to
 
 ; An arbitrary deterministic comparison of terms. Returns true if a > b based
 ; on this ordering.
-(define eo::com ((T Type :implicit) (U Type :implicit) (a T) (b U))
+(define eo::cmp ((T Type :implicit) (U Type :implicit) (a T) (b U))
   (eo::is_neg (eo::add (eo::hash b) (eo::neg (eo::hash a)))))
 
 ```

--- a/user_manual.md
+++ b/user_manual.md
@@ -412,13 +412,16 @@ A variable list parsed in this way binds the symbol `x` to a variable of type `I
 The variable list passed as the first argument to the binder is determined by applying the specified constructor (in this case `@cons`) to the list of variables, so that `(forall ((x Int)) (P x))` is syntax sugar for `(forall (@cons x) (P x))`.
 The constructor specified in declarations of binders should accept a variable number of arguments, e.g. `@cons` is declared with attribute `:right-assoc-nil`.
 
-Variables introduced when parsing binders are always the same for each (symbol, type) pair unless the option `--binder-fresh` is enabled, in which case the variable is always unique.
+Variables introduced when parsing binders are always the same for each (symbol, type) pair.
 In particular, this means that the definitions of `Q1` and `Q2` are syntactically identical in the above example.
 On the other hand, the definition `Q3` is distinct from both of these, since `y` is a distinct variable from `x`.
 
 Furthermore, note that a binder also may accept an explicit term as its first argument.
 In the above example, `Q4` has `(@cons x)` as its first argument, where `x` was explicitly defined as a variable.
-This means that the definition of `Q4` is also syntactically equivalent to the definition of `Q1` and `Q2`, again assuming that `--binder-fresh` is not enabled.
+This means that the definition of `Q4` is also syntactically equivalent to the definition of `Q1` and `Q2`.
+
+Note that if the option `--binder-fresh` is enabled, then when parsing reference files, the variables in binders are always fresh.
+This option does not impact how binders are parsed in Eunoia files.
 
 ## <a name="literals"></a>Literal types
 
@@ -430,7 +433,7 @@ The Eunoia language supports associating SMT-LIB version 3.0 syntactic categorie
 - `<hexadecimal>` denoting the category of hexadecimal constants `#x<hex-digit>+` where hexdigit is `[0-9] | [a-f] | [A-F]`,
 - `<string>` denoting the category of string literals `"<char>*"`.
 
-By default, decimal literals will be treated as syntax sugar for rational literals unless the option `--no-normalize-dec` is enabled.
+When parsing reference files, by default, decimal literals will be treated as syntax sugar for rational literals unless the option `--no-normalize-dec` is enabled.
 Similarly, hexadecimal literals will be treated as syntax sugar for binary literals unless the option `--no-normalize-hex` is enabled.
 
 In contrast to SMT-LIB version 2, note that rational values can be specified directly using the syntax `5/11, 2/4, 0/1` and so on.
@@ -505,9 +508,9 @@ Core operators:
 - `(eo::is_z t)`
     - Equivalent to `(eo::is_eq (eo::to_z t) t)`.
 - `(eo::is_q t)`
-    - Equivalent to `(eo::is_eq (eo::to_q t) t)`. Note this returns false for decimal literals when `--no-normalize-dec` is enabled.
+    - Equivalent to `(eo::is_eq (eo::to_q t) t)`. Note this returns false for decimal literals.
 - `(eo::is_bin t)`
-    - Equivalent to `(eo::is_eq (eo::to_bin (eo::len t) t) t)`. Note this returns false for hexadecimal literals  when `--no-normalize-hex` is enabled.
+    - Equivalent to `(eo::is_eq (eo::to_bin (eo::len t) t) t)`. Note this returns false for hexadecimal literals.
 - `(eo::is_str t)`
     - Equivalent to `(eo::is_eq (eo::to_str t) t)`.
 - `(eo::is_bool t)`
@@ -607,12 +610,10 @@ The Ethos supports extensions of `eo::and, eo::or, eo::xor, eo::add, eo::mul, eo
 (eo::add 1/2 1/3)           == 5/6
 (eo::add 2 1/3)             == (eo::add 2 1/3)  ; no mixed arithmetic
 (eo::add 2/1 1/3)           == 7/3
-(eo::add 2.0 1/3)           == 7/3  ; with default options
-(eo::add 2.0 1/3)           == (eo::add 2.0 1/3)  ; if --no-normalize-dec is enabled, since no mixed arithmetic
-(eo::add 2.0 2.5)           == 4.5  ; which is not syntactically equal to 9/2 if --no-normalize-dec is enabled
+(eo::add 2.0 1/3)           == (eo::add 2.0 1/3)  ; since no mixed arithmetic
+(eo::add 2.0 2.5)           == 4.5
 (eo::add #b01 #b01)         == #b10
-(eo::add #x1 #b0001)        == #b0002  ; with default options
-(eo::add #x1 #b0001)        == (eo::add #x1 #b0001)  ; if --no-normalize-hex is enabled
+(eo::add #x1 #b0001)        == (eo::add #x1 #b0001)  ; since no mixed arithmetic
 (eo::mul 2 7)               == 14
 (eo::mul 2 2 7)             == 28
 (eo::mul 1/2 1/4)           == 1/8
@@ -620,7 +621,7 @@ The Ethos supports extensions of `eo::and, eo::or, eo::xor, eo::add, eo::mul, eo
 (eo::qdiv 12 6)             == 3/1
 (eo::qdiv 7 2)              == 7/2
 (eo::qdiv 7/1 2/1)          == 7/2
-(eo::qdiv 7.0 2.0)          == 7/2  ; regardless of whether --no-normalize-dec is enabled
+(eo::qdiv 7.0 2.0)          == 7/2
 (eo::qdiv 7 0)              == (eo::qdiv 7 0)  ; no division by zero
 (eo::zdiv 12 3)             == 4
 (eo::zdiv 7 2)              == 3
@@ -1563,12 +1564,7 @@ The user is responsible for ensure that e.g. the proof contains a step with a de
 ## Command line options of ethos
 
 The Ethos command line interface can be invoked by `ethos <option>* <file>` where `<option>` is one of the following:
-- `--binder-fresh`: binders generate fresh variables when parsed in reference files.
 - `--help`: displays a help message.
-- `--normalize-num`: treat numeral literals as syntax sugar for (integral) rational literals.
-- `--no-normalize-dec`: do not treat decimal literals as syntax sugar for rational literals.
-- `--no-normalize-hex`: do not treat hexadecimal literals as syntax sugar for binary literals.
-- `--no-parse-let`: do not treat `let` as a builtin symbol for specifying terms having shared subterms.
 - `--no-print-let`: do not letify the output of terms in error messages and trace messages.
 - `--no-rule-sym-table`: do not use a separate symbol table for proof rules and declared terms.
 - `--show-config`: displays the build information for the given binary.
@@ -1576,6 +1572,13 @@ The Ethos command line interface can be invoked by `ethos <option>* <file>` wher
 - `--stats-compact`: print statistics in a compact format.
 - `-t <tag>`: enables the given trace tag (for debugging).
 - `-v`: verbose mode, enable all standard trace messages.
+
+The following options impact how reference files are parsed:
+- `--binder-fresh`: binders generate fresh variables.
+- `--normalize-num`: treat numeral literals as syntax sugar for (integral) rational literals.
+- `--no-normalize-dec`: do not treat decimal literals as syntax sugar for rational literals.
+- `--no-normalize-hex`: do not treat hexadecimal literals as syntax sugar for binary literals.
+- `--no-parse-let`: do not treat `let` as a builtin symbol for specifying terms having shared subterms.
 
 ## Full syntax for Eunoia commands
 


### PR DESCRIPTION
This makes the options `--no-normalize-dec`, `--no-normalize-hex`, `--binder-fresh`, and `--no-parse-let` apply only when reference parsing.

It simplifies the user manual to explain evaluation in terms of the core operators and not based on the syntax/options.

It adds a new option `--normalize-num` which will allow us to do SMT-LIB-compliant reference checking for QF_LRA, where numerals should be parsed as rationals.  Like the above options, this applies only to reference parsing.

This is a simpler alternative to https://github.com/cvc5/ethos/pull/66.

