### PR TITLE
Distinguish signature parsing from proof parsing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@ This file contains a summary of important user-visible changes.
 ethos 0.1.1 prerelease
 ======================
 
-- When parsing Eunoia signatures, decimals and hexidecimals are never normalized, variables in binders are always unique for their name and type, and let is never treated as a builtin way of specifying macros. The options `--no-normalize-dec`, `--no-normalize-hex`, `--binder-fresh`, and `--no-parse-let` now only apply when reference parsing.
+- When parsing Eunoia signatures, decimals and hexidecimals are never normalized, variables in binders are always unique for their name and type, and let is never treated as a builtin way of specifying macros. The options `--no-normalize-dec`, `--no-normalize-hex`, `--binder-fresh`, and `--no-parse-let` now only apply when parsing proofs and reference files.
 - Adds a new option `--normalize-num`, which also only applies when reference parsing. This option treats numerals as rationals, which can be used when parsing SMT-LIB inputs in logics where numerals are shorthand for rationals.
 - Fixed a bug when applying operators with opaque arguments.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@ This file contains a summary of important user-visible changes.
 ethos 0.1.1 prerelease
 ======================
 
-- When parsing Eunoia signatures and proofs, decimals and hexidecimals are never normalized, variables in binders are always unique for their name and type, and let is never treated as a builtin way of specifying macros. The options `--no-normalize-dec`, `--no-normalize-hex`, `--binder-fresh`, and `--no-parse-let` now only apply when reference parsing.
+- When parsing Eunoia signatures, decimals and hexidecimals are never normalized, variables in binders are always unique for their name and type, and let is never treated as a builtin way of specifying macros. The options `--no-normalize-dec`, `--no-normalize-hex`, `--binder-fresh`, and `--no-parse-let` now only apply when reference parsing.
 - Adds a new option `--normalize-num`, which also only applies when reference parsing. This option treats numerals as rationals, which can be used when parsing SMT-LIB inputs in logics where numerals are shorthand for rationals.
 - Fixed a bug when applying operators with opaque arguments.
 

--- a/src/cmd_parser.cpp
+++ b/src/cmd_parser.cpp
@@ -650,7 +650,8 @@ bool CmdParser::parseNextCommand()
       {
         referenceNf = d_eparser.parseExpr();
       }
-      if (!d_state.includeFile(file, isReference, referenceNf))
+      // if not reference, we assume it is a signature
+      if (!d_state.includeFile(file, !isReference, isReference, referenceNf))
       {
         std::stringstream ss;
         ss << "Cannot include file " << file;

--- a/src/cmd_parser.cpp
+++ b/src/cmd_parser.cpp
@@ -650,7 +650,7 @@ bool CmdParser::parseNextCommand()
       {
         referenceNf = d_eparser.parseExpr();
       }
-      // if not reference, we assume it is a signature
+      // if not reference, it is a signature
       if (!d_state.includeFile(file, !isReference, isReference, referenceNf))
       {
         std::stringstream ss;

--- a/src/cmd_parser.h
+++ b/src/cmd_parser.h
@@ -27,7 +27,6 @@ class CmdParser
   CmdParser(Lexer& lex,
             State& state,
             ExprParser& eparser,
-            bool isSignature,
             bool isReference);
   virtual ~CmdParser() {}
   /**

--- a/src/cmd_parser.h
+++ b/src/cmd_parser.h
@@ -27,6 +27,7 @@ class CmdParser
   CmdParser(Lexer& lex,
             State& state,
             ExprParser& eparser,
+            bool isSignature,
             bool isReference);
   virtual ~CmdParser() {}
   /**

--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -73,8 +73,8 @@ enum class ParseCtx
   TERM_ANNOTATE_BODY
 };
 
-ExprParser::ExprParser(Lexer& lex, State& state, bool isReference)
-    : d_lex(lex), d_state(state), d_isReference(isReference)
+ExprParser::ExprParser(Lexer& lex, State& state, bool isSignature)
+    : d_lex(lex), d_state(state), d_isSignature(isSignature)
 {
   d_strToAttr[":var"] = Attr::VAR;
   d_strToAttr[":implicit"] = Attr::IMPLICIT;
@@ -213,8 +213,8 @@ Expr ExprParser::parseExpr()
                   if (ck==Attr::BINDER)
                   {
                     nscopes = 1;
-                    // we always do lookups if not parsing reference
-                    bool isLookup = !d_isReference || !d_state.getOptions().d_binderFresh;
+                    // we always do lookups if parsing signature
+                    bool isLookup = d_isSignature || !d_state.getOptions().d_binderFresh;
                     d_state.pushScope();
                     std::vector<Expr> vs = parseAndBindSortedVarList(isLookup);
                     if (vs.empty())
@@ -284,8 +284,8 @@ Expr ExprParser::parseExpr()
       break;
       case Token::INTEGER_LITERAL:
       {
-        // normalize to rational if reference and option is set
-        if (d_isReference && d_state.getOptions().d_normalizeNumeral)
+        // normalize to rational if not signature and option is set
+        if (!d_isSignature && d_state.getOptions().d_normalizeNumeral)
         {
           Rational r(d_lex.tokenStr());
           ret = d_state.mkLiteral(Kind::RATIONAL, r.toString());
@@ -298,8 +298,8 @@ Expr ExprParser::parseExpr()
       break;
       case Token::DECIMAL_LITERAL:
       {
-        // normalize to rational if reference and option is set
-        if (d_isReference && d_state.getOptions().d_normalizeDecimal)
+        // normalize to rational if not signature and option is set
+        if (!d_isSignature && d_state.getOptions().d_normalizeDecimal)
         {
           // normalize from decimal
           Rational r = Rational::fromDecimal(d_lex.tokenStr());
@@ -332,8 +332,8 @@ Expr ExprParser::parseExpr()
       {
         std::string hexStr = d_lex.tokenStr();
         hexStr = hexStr.substr(2);
-        // normalize to binary if reference and option is set
-        if (d_isReference && d_state.getOptions().d_normalizeHexadecimal)
+        // normalize to binary if not signature and option is set
+        if (!d_isSignature && d_state.getOptions().d_normalizeHexadecimal)
         {
           // normalize from hexadecimal
           BitVector bv(hexStr, 16);

--- a/src/expr_parser.h
+++ b/src/expr_parser.h
@@ -24,7 +24,7 @@ namespace ethos {
 class ExprParser
 {
  public:
-  ExprParser(Lexer& lex, State& state, bool isSignature, bool isReference);
+  ExprParser(Lexer& lex, State& state, bool isSignature);
   virtual ~ExprParser() {}
 
   /** Parses an SMT-LIB term <term> */

--- a/src/expr_parser.h
+++ b/src/expr_parser.h
@@ -24,7 +24,7 @@ namespace ethos {
 class ExprParser
 {
  public:
-  ExprParser(Lexer& lex, State& state, bool isReference);
+  ExprParser(Lexer& lex, State& state, bool isSignature, bool isReference);
   virtual ~ExprParser() {}
 
   /** Parses an SMT-LIB term <term> */
@@ -184,8 +184,8 @@ class ExprParser
   Lexer& d_lex;
   /** The state */
   State& d_state;
-  /** */
-  bool d_isReference;
+  /** Are we parsing a signature file? */
+  bool d_isSignature;
   /** Strings to attributes */
   std::map<std::string, Attr> d_strToAttr;
   /** Mapping symbols to literal kinds */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -161,6 +161,7 @@ int main( int argc, char* argv[] )
       EO_FATAL() << "Error: no input specified.";
     }
     // parse from std::cin.
+    // we assume this is a proof (not signature, not reference)
     Parser p(s, false, false);
     p.setStreamInput(std::cin);
     // parse commands until finished

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -161,7 +161,7 @@ int main( int argc, char* argv[] )
       EO_FATAL() << "Error: no input specified.";
     }
     // parse from std::cin.
-    Parser p(s, false);
+    Parser p(s, false, false);
     p.setStreamInput(std::cin);
     // parse commands until finished
     while (p.parseNextCommand())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -170,8 +170,10 @@ int main( int argc, char* argv[] )
   }
   else
   {
+    // whether it is a signature is determined by file extension *.eo.
+    bool isSignature = (file.substr(file.size()-3)==".eo");
     // include the file
-    if (!s.includeFile(file))
+    if (!s.includeFile(file, isSignature))
     {
       EO_FATAL() << "Error: cannot include file " << file;
     }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -10,10 +10,10 @@
 
 namespace ethos {
 
-Parser::Parser(State& s, bool isReference)
-    : d_lex(isReference && s.getOptions().d_parseLet),  // only consider let when reference parsing
+Parser::Parser(State& s, bool isSignature, bool isReference)
+    : d_lex(!isSignature && s.getOptions().d_parseLet),  // only consider let when reference parsing
       d_state(s),
-      d_eparser(d_lex, d_state, isReference),
+      d_eparser(d_lex, d_state, isSignature),
       d_cmdParser(d_lex, d_state, d_eparser, isReference)
 {
 }

--- a/src/parser.h
+++ b/src/parser.h
@@ -27,9 +27,10 @@ class Parser
  public:
   /**
    * @param s The state to populate
+   * @param isSignature Whether we are parsing a signature file
    * @param isReference Whether we are parsing a reference file
    */
-  Parser(State& s, bool isReference = false);
+  Parser(State& s, bool isSignature = false, bool isReference = false);
   virtual ~Parser() {}
   
   /** Set the input for the given file.

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -197,11 +197,11 @@ void State::popAssumptionScope()
   // pop the parsing scope
   popScope();
 }
-bool State::includeFile(const std::string& s)
+bool State::includeFile(const std::string& s, bool isSignature)
 {
-  return includeFile(s, false, d_null);
+  return includeFile(s, isSignature, false, d_null);
 }
-bool State::includeFile(const std::string& s, bool isReference, const Expr& referenceNf)
+bool State::includeFile(const std::string& s, bool isSignature, bool isReference, const Expr& referenceNf)
 {
   Filepath inputPath;
   Filepath file(s);
@@ -237,7 +237,7 @@ bool State::includeFile(const std::string& s, bool isReference, const Expr& refe
   }
   Trace("state") << "Include " << inputPath << std::endl;
   Assert (getAssumptionLevel()==0);
-  Parser p(*this, isReference);
+  Parser p(*this, isSignature, isReference);
   p.setFileInput(inputPath.getRawPath());
   bool parsedCommand;
   do

--- a/src/state.h
+++ b/src/state.h
@@ -67,9 +67,9 @@ class State
   /** Pop assumption scope */
   void popAssumptionScope();
   /** include file, if not already done, return false if error */
-  bool includeFile(const std::string& s);
+  bool includeFile(const std::string& s, bool isSignature);
   /** include file, possibly as a reference */
-  bool includeFile(const std::string& s, bool isReference, const Expr& referenceNf);
+  bool includeFile(const std::string& s, bool isSignature, bool isReference, const Expr& referenceNf);
   /** add assumption */
   bool addAssumption(const Expr& a);
   /** add reference assert */

--- a/user_manual.md
+++ b/user_manual.md
@@ -1660,6 +1660,7 @@ Their expected syntax is `<smtlib2-command>*`.
 - *Signature files* are files that given via command line option that do have extension `*.eo`, or those that are included via the command `include`.
 
 As mentioned, the first two kinds of file inputs take into account options concerning the normalization of terms (e.g. `--normalize-num`), while signature files do not.
+When streaming input to Ethos, we assume the input is being given for a proof file.
 
 ```
 ;;;

--- a/user_manual.md
+++ b/user_manual.md
@@ -1657,7 +1657,7 @@ We distinguish three kinds of file inputs:
 Their expected syntax is `<eo-command>*`.
 - *Reference files* are files included via the `reference` command.
 Their expected syntax is `<smtlib2-command>*`.
-- *Signature files* are files that given via command line option that do have extension `*.eo`, or those that are included via the command `include`.
+- *Signature files* are files that given via command line option that have extension `*.eo`, or those that are included via the command `include`.
 
 As mentioned, the first two kinds of file inputs take into account options concerning the normalization of terms (e.g. `--normalize-num`), while signature files do not.
 When streaming input to Ethos, we assume the input is being given for a proof file.

--- a/user_manual.md
+++ b/user_manual.md
@@ -481,7 +481,7 @@ The Eunoia language supports associating SMT-LIB version 3.0 syntactic categorie
 When parsing reference files, by default, decimal literals will be treated as syntax sugar for rational literals unless the option `--no-normalize-dec` is enabled.
 Similarly, hexadecimal literals will be treated as syntax sugar for binary literals unless the option `--no-normalize-hex` is enabled.
 Some SMT-LIB logics (e.g. `QF_LRA`) state that numerals should be treated as syntax sugar for rational literals.
-This behavior can be enabled when parsing reference files using the option `--normalize-num`.
+This behavior can be enabled when parsing proofs and reference files using the option `--normalize-num`.
 
 In contrast to SMT-LIB version 2, note that rational values can be specified directly using the syntax `5/11, 2/4, 0/1` and so on.
 Rationals are normalized so that e.g. `2/4` and `1/2` are syntactically equivalent after parsing.
@@ -1536,7 +1536,7 @@ The Ethos supports the following commands for file inclusion:
 
 ## Validation Proofs via Reference Inputs
 
-When the Ethos encounters a command of the form `(reference <string>)`, the checker enables a further set of checks that ensures that all assumptions in proofs correspond to assertions from the reference file.
+When the Ethos encounters a command of the form `(reference <string>)`, the checker enables a further set of checks that ensures that all assumptions in proofs correspond to assertions from the file referenced by the given string.
 
 In particular, when the command `(reference "file.smt2")` is read, the Ethos will parse `file.smt2`.
 The definitions and declaration commands in this file will be treated as normal, that is, they will populate the symbol table of the Ethos as they normally would if they were to appear in an `*.eo` input.
@@ -1640,16 +1640,26 @@ The Ethos command line interface can be invoked by `ethos <option>* <file>` wher
 - `-t <tag>`: enables the given trace tag (for debugging).
 - `-v`: verbose mode, enable all standard trace messages.
 
-The following options impact how reference files are parsed:
+The following options impact how proof files and reference files are parsed only (for details on classifications of files, see [full-syntax](#full-syntax). 
+They do not impact how signature files (*.eo) are parsed:
 - `--binder-fresh`: binders generate fresh variables.
 - `--normalize-num`: treat numeral literals as syntax sugar for (integral) rational literals.
 - `--no-normalize-dec`: do not treat decimal literals as syntax sugar for rational literals.
 - `--no-normalize-hex`: do not treat hexadecimal literals as syntax sugar for binary literals.
-- `--no-parse-let`: do not treat `let` as a builtin symbol for specifying terms having shared subterms.
+- `--no-parse-let`: do not treat `let` as a builtin symbol for specifying a macro.
 
-## Full syntax for Eunoia commands
+## <a name="full-syntax"></a> Full syntax for Eunoia commands
 
-Valid inputs to the Ethos are `<eo-command>*`, where:
+Below defines the syntax accepted by the Ethos parser.
+
+We distinguish three kinds of file inputs:
+- *Proof files* are files that are given via command line option that do *not* have extension `*.eo`.
+Their expected syntax is `<eo-command>*`.
+- *Reference files* are files included via the `reference` command.
+Their expected syntax is `<smtlib2-command>*`.
+- *Signature files* are files that given via command line option that do have extension `*.eo`, or those that are included via the command `include`.
+
+As mentioned, the first two kinds of file inputs take into account options concerning the normalization of terms (e.g. `--normalize-num`), while signature files do not.
 
 ```
 ;;;
@@ -1716,9 +1726,6 @@ Valid inputs to the Ethos are `<eo-command>*`, where:
 <reqs>            ::= :requires ((<term> <term>)*)
 
 ```
-
-Moreover, a valid input for a file included by the Eunoia command `<reference>` is `<smtlib2-command>*`;
-a valid input for a file included by the Eunoia command `<include>` is `<eo-command>*`.
 
 ### <a name="non-core-eval"></a>Definitions of Non-Core Evaluation Operators
 

--- a/user_manual.md
+++ b/user_manual.md
@@ -478,7 +478,7 @@ The Eunoia language supports associating SMT-LIB version 3.0 syntactic categorie
 - `<hexadecimal>` denoting the category of hexadecimal constants `#x<hex-digit>+` where hexdigit is `[0-9] | [a-f] | [A-F]`,
 - `<string>` denoting the category of string literals `"<char>*"`.
 
-When parsing reference files, by default, decimal literals will be treated as syntax sugar for rational literals unless the option `--no-normalize-dec` is enabled.
+When parsing proofs and reference files, by default, decimal literals will be treated as syntax sugar for rational literals unless the option `--no-normalize-dec` is enabled.
 Similarly, hexadecimal literals will be treated as syntax sugar for binary literals unless the option `--no-normalize-hex` is enabled.
 Some SMT-LIB logics (e.g. `QF_LRA`) state that numerals should be treated as syntax sugar for rational literals.
 This behavior can be enabled when parsing proofs and reference files using the option `--normalize-num`.


### PR DESCRIPTION
This makes the command line options apply to "proof files".

It distinguishes this as a 3rd type of input in the user manual.