### PR TITLE
Make std::filesystem code work again

### DIFF
--- a/src/util/filesystem.cpp
+++ b/src/util/filesystem.cpp
@@ -52,6 +52,11 @@ Filepath::Filepath(const char* rawPath)
 #endif
 }
 
+#ifdef USE_CPP_FILESYSTEM
+Filepath::Filepath(std::filesystem::path rawPath)
+: rawPath(rawPath) {}
+#endif
+
 Filepath::~Filepath() {}
 
 bool Filepath::isAbsolute() const
@@ -200,7 +205,13 @@ Filepath Filepath::parentPath() const
 #endif
 }
 
-std::string Filepath::getRawPath() const { return this->rawPath; }
+std::string Filepath::getRawPath() const {
+#ifndef USE_CPP_FILESYSTEM
+  return rawPath;
+#else
+  return rawPath.string();
+#endif
+}
 
 bool operator<(const Filepath& a, const Filepath& b)
 {

--- a/src/util/filesystem.h
+++ b/src/util/filesystem.h
@@ -39,6 +39,13 @@ class Filepath
    */
   Filepath(const char* rawPath);
 
+#ifdef USE_CPP_FILESYSTEM
+  /**
+   * @param rawPath A C++17 filepath.
+   */
+  Filepath(std::filesystem::path rawPath);
+#endif
+
   ~Filepath();
 
   /**


### PR DESCRIPTION
This is a prerequisite for supporting Windows builds.