### PR TITLE
Check if head is in list form before evaluating eo::list_find

### DIFF
--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -1347,7 +1347,12 @@ Expr TypeChecker::evaluateLiteralOpInternal(
       break;
     case Kind::EVAL_LIST_FIND:
     {
-      getNAryChildren(args[1], op, nil, hargs, isLeft);
+      ExprValue* a = getNAryChildren(args[1], op, nil, hargs, isLeft);
+      if (a==nullptr)
+      {
+        Trace("type_checker") << "...head not in list form" << std::endl;
+        return d_null;
+      }
       std::vector<ExprValue*>::iterator it = std::find(hargs.begin(), hargs.end(), args[2]);
       if (it==hargs.end())
       {


### PR DESCRIPTION
For example, before this commit (eo::list_find or (and a b b) a) == -1