### PR TITLE
Add support for `eo::dt_constructors` and `eo::dt_selectors` to inspect datatypes and datatype constructors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,8 @@ ethos 0.1.1 prerelease
 - Fixed the disambiguation of overloaded symbols that are not applied to arguments.
 - Fixed the interpretation of operators that combine opaque and ordinary arguments.
 - Fixed a bug in the evaluation of `eo::cons` for left associative operators, which would construct erroneous terms.
-- Adds support for `eo::dt_constructors` which returns the list of constructors associated with a datatype, and `eo::dt_selectors` which returns the list of selectors associated with a datatype constructor.
+- Adds support for `eo::dt_constructors` which returns the list of constructors associated with a datatype, and `eo::dt_selectors` which returns the list of selectors associated with a datatype constructor. These operators make use of a type `eo::List`, which is now part of the background signature assumed by Ethos.
+- Fixed parser for the singleton case of `declare-datatype`.
 
 ethos 0.1.0
 ===========

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ ethos 0.1.1 prerelease
 - Fixed the disambiguation of overloaded symbols that are not applied to arguments.
 - Fixed the interpretation of operators that combine opaque and ordinary arguments.
 - Fixed a bug in the evaluation of `eo::cons` for left associative operators, which would construct erroneous terms.
+- Adds support for `eo::dt_constructors` which returns the list of constructors associated with a datatype, and `eo::dt_selectors` which returns the list of selectors associated with a datatype constructor.
 
 ethos 0.1.0
 ===========

--- a/src/cmd_parser.cpp
+++ b/src/cmd_parser.cpp
@@ -239,14 +239,13 @@ bool CmdParser::parseNextCommand()
     {
       bool isCo = (tok==Token::DECLARE_CODATATYPES || tok==Token::DECLARE_CODATATYPE);
       bool isMulti = (tok==Token::DECLARE_CODATATYPES || tok==Token::DECLARE_DATATYPES);
-      //d_state.checkThatLogicIsSet();
-      d_lex.eatToken(Token::LPAREN);
       std::vector<std::string> dnames;
       std::vector<size_t> arities;
       std::map<const ExprValue*, std::vector<Expr>> dts;
       std::map<const ExprValue*, std::vector<Expr>> dtcons;
       if (isMulti)
       {
+        d_lex.eatToken(Token::LPAREN);
         // parse (<sort_dec>^{n+1})
         // while the next token is LPAREN, exit if RPAREN
         while (d_lex.eatTokenChoice(Token::LPAREN, Token::RPAREN))
@@ -287,7 +286,10 @@ bool CmdParser::parseNextCommand()
         Expr stuple = d_state.mkList(c.second);
         d_state.markConstructorKind(cons, Attr::DATATYPE_CONSTRUCTOR, stuple);
       }
-      d_lex.eatToken(Token::RPAREN);
+      if (isMulti)
+      {
+        d_lex.eatToken(Token::RPAREN);
+      }
     }
     break;
     // (declare-consts <symbol> <sort>)

--- a/src/cmd_parser.cpp
+++ b/src/cmd_parser.cpp
@@ -278,13 +278,13 @@ bool CmdParser::parseNextCommand()
       for (std::pair<const ExprValue* const, std::vector<Expr>>& d : dts)
       {
         Expr dt = Expr(d.first);
-        Expr ctuple = d_state.mkExpr(Kind::TUPLE, d.second);
+        Expr ctuple = d_state.mkList(d.second);
         d_state.markConstructorKind(dt, attr, ctuple);
       }
       for (std::pair<const ExprValue* const, std::vector<Expr>>& c : dtcons)
       {
         Expr cons = Expr(c.first);
-        Expr stuple = d_state.mkExpr(Kind::TUPLE, c.second);
+        Expr stuple = d_state.mkList(c.second);
         d_state.markConstructorKind(cons, Attr::DATATYPE_CONSTRUCTOR, stuple);
       }
       d_lex.eatToken(Token::RPAREN);

--- a/src/kind.cpp
+++ b/src/kind.cpp
@@ -92,6 +92,8 @@ std::ostream& operator<<(std::ostream& o, Kind k)
     case Kind::EVAL_TO_RAT: o << "EVAL_TO_RAT"; break;
     case Kind::EVAL_TO_BIN: o << "EVAL_TO_BIN"; break;
     case Kind::EVAL_TO_STRING: o << "EVAL_TO_STRING"; break;
+    // datatypes
+    case Kind::EVAL_DEF_OF: o << "EVAL_DEF_OF"; break;
     default: o << "UnknownKind(" << unsigned(k) << ")"; break;
   }
   return o;
@@ -167,6 +169,8 @@ std::string kindToTerm(Kind k)
         case Kind::EVAL_TO_RAT: ss << "to_q";break;
         case Kind::EVAL_TO_BIN: ss << "to_bin";break;
         case Kind::EVAL_TO_STRING: ss << "to_str";break;
+        // datatypes
+        case Kind::EVAL_DEF_OF: ss << "def_of"; break;
         default:ss << "[" << k << "]";break;
         }
       }
@@ -256,7 +260,9 @@ bool isLiteralOp(Kind k)
     case Kind::EVAL_TO_INT:
     case Kind::EVAL_TO_RAT:
     case Kind::EVAL_TO_BIN:
-    case Kind::EVAL_TO_STRING:return true; break;
+    case Kind::EVAL_TO_STRING:
+    // datatypes
+    case Kind::EVAL_DEF_OF: return true; break;
     default: break;
   }
   return false;

--- a/src/kind.cpp
+++ b/src/kind.cpp
@@ -170,7 +170,7 @@ std::string kindToTerm(Kind k)
         case Kind::EVAL_TO_BIN: ss << "to_bin";break;
         case Kind::EVAL_TO_STRING: ss << "to_str";break;
         // datatypes
-        case Kind::EVAL_DEF_OF: ss << "def_of"; break;
+        case Kind::EVAL_DEF_OF: ss << "defof"; break;
         default:ss << "[" << k << "]";break;
         }
       }

--- a/src/kind.cpp
+++ b/src/kind.cpp
@@ -93,7 +93,8 @@ std::ostream& operator<<(std::ostream& o, Kind k)
     case Kind::EVAL_TO_BIN: o << "EVAL_TO_BIN"; break;
     case Kind::EVAL_TO_STRING: o << "EVAL_TO_STRING"; break;
     // datatypes
-    case Kind::EVAL_DEF_OF: o << "EVAL_DEF_OF"; break;
+    case Kind::EVAL_DT_CONSTRUCTORS: o << "EVAL_DT_CONSTRUCTORS"; break;
+    case Kind::EVAL_DT_SELECTORS: o << "EVAL_DT_SELECTORS"; break;
     default: o << "UnknownKind(" << unsigned(k) << ")"; break;
   }
   return o;
@@ -170,7 +171,8 @@ std::string kindToTerm(Kind k)
         case Kind::EVAL_TO_BIN: ss << "to_bin";break;
         case Kind::EVAL_TO_STRING: ss << "to_str";break;
         // datatypes
-        case Kind::EVAL_DEF_OF: ss << "defof"; break;
+        case Kind::EVAL_DT_CONSTRUCTORS: ss << "dt_constructors"; break;
+        case Kind::EVAL_DT_SELECTORS: ss << "dt_selectors"; break;
         default:ss << "[" << k << "]";break;
         }
       }
@@ -262,7 +264,8 @@ bool isLiteralOp(Kind k)
     case Kind::EVAL_TO_BIN:
     case Kind::EVAL_TO_STRING:
     // datatypes
-    case Kind::EVAL_DEF_OF: return true; break;
+    case Kind::EVAL_DT_CONSTRUCTORS:
+    case Kind::EVAL_DT_SELECTORS: return true; break;
     default: break;
   }
   return false;

--- a/src/kind.h
+++ b/src/kind.h
@@ -19,7 +19,7 @@ namespace ethos {
 enum class Kind
 {
   NONE = 0,
-  
+
   // types
   TYPE,
   FUNCTION_TYPE,
@@ -27,8 +27,8 @@ enum class Kind
   ABSTRACT_TYPE,
   BOOL_TYPE,
   QUOTE_TYPE,
-  OPAQUE_TYPE, // an argument marked :opaque, temporary during parsing
-  
+  OPAQUE_TYPE,  // an argument marked :opaque, temporary during parsing
+
   // terms
   APPLY,
   LAMBDA,

--- a/src/kind.h
+++ b/src/kind.h
@@ -103,7 +103,8 @@ enum class Kind
   EVAL_TO_BIN,
   EVAL_TO_STRING,
   // datatypes
-  EVAL_DEF_OF
+  EVAL_DT_CONSTRUCTORS,
+  EVAL_DT_SELECTORS
 };
 
 /** Print a kind to the stream, for debugging */

--- a/src/kind.h
+++ b/src/kind.h
@@ -101,7 +101,9 @@ enum class Kind
   EVAL_TO_INT,
   EVAL_TO_RAT,
   EVAL_TO_BIN,
-  EVAL_TO_STRING
+  EVAL_TO_STRING,
+  // datatypes
+  EVAL_DEF_OF
 };
 
 /** Print a kind to the stream, for debugging */

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -145,6 +145,8 @@ State::State(Options& opts, Stats& stats)
   bindBuiltinEval("concat", Kind::EVAL_CONCAT);
   bindBuiltinEval("extract", Kind::EVAL_EXTRACT);
   bindBuiltinEval("find", Kind::EVAL_FIND);
+  // datatypes
+  bindBuiltinEval("def_of", Kind::EVAL_DEF_OF);
 
   // as
   bindBuiltinEval("as", Kind::AS);
@@ -970,6 +972,18 @@ Expr State::mkLiteral(Kind k, const std::string& s)
 Expr State::mkParameterized(const ExprValue* hd, const std::vector<Expr>& params)
 {
   return mkExpr(Kind::PARAMETERIZED, {mkExpr(Kind::TUPLE, params), Expr(hd)});
+}
+
+Expr State::mkList(const std::vector<Expr>& args)
+{
+  if (args.empty())
+  {
+    return d_listNil;
+  }
+  std::vector<Expr> largs;
+  largs.push_back(d_listCons);
+  largs.insert(largs.end(), args.begin(), args.end());
+  return mkExpr(Kind::APPLY, largs);
 }
 
 ExprValue* State::mkLiteralInternal(Literal& l)

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -146,7 +146,7 @@ State::State(Options& opts, Stats& stats)
   bindBuiltinEval("extract", Kind::EVAL_EXTRACT);
   bindBuiltinEval("find", Kind::EVAL_FIND);
   // datatypes
-  bindBuiltinEval("def_of", Kind::EVAL_DEF_OF);
+  bindBuiltinEval("defof", Kind::EVAL_DEF_OF);
 
   // as
   bindBuiltinEval("as", Kind::AS);

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -161,7 +161,7 @@ State::State(Options& opts, Stats& stats)
   bind("true", d_true);
   d_false = Expr(new Literal(false));
   bind("false", d_false);
-  
+
   // builtin lists
   d_listType = Expr(mkSymbolInternal(Kind::CONST, "eo::List", d_type));
   bind("eo::List", d_listType);
@@ -175,14 +175,15 @@ State::State(Options& opts, Stats& stats)
   d_listCons = Expr(mkSymbolInternal(Kind::CONST, "eo::List::cons", consType));
   bind("eo::List::cons", d_listCons);
   markConstructorKind(d_listCons, Attr::RIGHT_ASSOC_NIL, d_listNil);
-  
+
   // we do not export eo::null
   // for now, eo::? is (undocumented) syntax for abstract type
   bind("eo::?", d_absType);
   // self is a distinguished parameter
   d_self = Expr(mkSymbolInternal(Kind::PARAM, "eo::self", d_absType));
   bind("eo::self", d_self);
-  d_conclusion = Expr(mkSymbolInternal(Kind::PARAM, "eo::conclusion", d_boolType));
+  d_conclusion =
+      Expr(mkSymbolInternal(Kind::PARAM, "eo::conclusion", d_boolType));
   // eo::conclusion is not globally bound, since it can only appear
   // in :requires.
 }
@@ -554,10 +555,7 @@ Expr State::mkBoolType()
   return d_boolType;
 }
 
-Expr State::mkListType()
-{
-  return d_listType;
-}
+Expr State::mkListType() { return d_listType; }
 
 Expr State::mkProofType(const Expr& proven)
 {

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -148,16 +148,6 @@ State::State(Options& opts, Stats& stats)
 
   // as
   bindBuiltinEval("as", Kind::AS);
-  
-  // we do not export eo::null
-  // for now, eo::? is (undocumented) syntax for abstract type
-  bind("eo::?", mkAbstractType());
-  // self is a distinguished parameter
-  d_self = Expr(mkSymbolInternal(Kind::PARAM, "eo::self", mkAbstractType()));
-  bind("eo::self", d_self);
-  d_conclusion = Expr(mkSymbolInternal(Kind::PARAM, "eo::conclusion", mkBoolType()));
-  // eo::conclusion is not globally bound, since it can only appear
-  // in :requires.
 
   // note we don't allow parsing (Proof ...), (Quote ...), or (quote ...).
 
@@ -168,6 +158,30 @@ State::State(Options& opts, Stats& stats)
   bind("true", d_true);
   d_false = Expr(new Literal(false));
   bind("false", d_false);
+  
+  // builtin lists
+  d_listType = Expr(mkSymbolInternal(Kind::CONST, "eo::List", d_type));
+  bind("eo::List", d_listType);
+  d_listNil = Expr(mkSymbolInternal(Kind::CONST, "eo::List::nil", d_listType));
+  bind("eo::List::nil", d_listNil);
+  Expr t = Expr(mkSymbolInternal(Kind::PARAM, "T", d_type));
+  std::vector<Expr> argTypes;
+  argTypes.push_back(t);
+  argTypes.push_back(d_listType);
+  Expr consType = mkFunctionType(argTypes, d_listType);
+  d_listCons = Expr(mkSymbolInternal(Kind::CONST, "eo::List::cons", consType));
+  bind("eo::List::cons", d_listCons);
+  markConstructorKind(d_listCons, Attr::RIGHT_ASSOC_NIL, d_listNil);
+  
+  // we do not export eo::null
+  // for now, eo::? is (undocumented) syntax for abstract type
+  bind("eo::?", d_absType);
+  // self is a distinguished parameter
+  d_self = Expr(mkSymbolInternal(Kind::PARAM, "eo::self", d_absType));
+  bind("eo::self", d_self);
+  d_conclusion = Expr(mkSymbolInternal(Kind::PARAM, "eo::conclusion", d_boolType));
+  // eo::conclusion is not globally bound, since it can only appear
+  // in :requires.
 }
 
 State::~State() {}

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -146,7 +146,8 @@ State::State(Options& opts, Stats& stats)
   bindBuiltinEval("extract", Kind::EVAL_EXTRACT);
   bindBuiltinEval("find", Kind::EVAL_FIND);
   // datatypes
-  bindBuiltinEval("defof", Kind::EVAL_DEF_OF);
+  bindBuiltinEval("dt_constructors", Kind::EVAL_DT_CONSTRUCTORS);
+  bindBuiltinEval("dt_selectors", Kind::EVAL_DT_SELECTORS);
 
   // as
   bindBuiltinEval("as", Kind::AS);
@@ -552,6 +553,12 @@ Expr State::mkBoolType()
 {
   return d_boolType;
 }
+
+Expr State::mkListType()
+{
+  return d_listType;
+}
+
 Expr State::mkProofType(const Expr& proven)
 {
   return Expr(mkExprInternal(Kind::PROOF_TYPE, {proven.getValue()}));

--- a/src/state.h
+++ b/src/state.h
@@ -138,6 +138,9 @@ class State
    * Make parameterized with given parameters
    */
   Expr mkParameterized(const ExprValue* hd, const std::vector<Expr>& params);
+  /**
+   */
+  Expr mkList(const std::vector<Expr>& args);
   //--------------------------------------
   /** Get the constructor kind for symbol v */
   Attr getConstructorKind(const ExprValue* v) const;

--- a/src/state.h
+++ b/src/state.h
@@ -205,6 +205,9 @@ class State
   Expr d_self;
   Expr d_conclusion;
   Expr d_fail;
+  Expr d_listType;
+  Expr d_listNil;
+  Expr d_listCons;
   /** Get base operator */
   const ExprValue* getBaseOperator(const ExprValue * v) const;
   /** Mark that file s was included */

--- a/src/state.h
+++ b/src/state.h
@@ -103,6 +103,8 @@ class State
   Expr mkAbstractType();
   /** Bool */
   Expr mkBoolType();
+  /** eo::List */
+  Expr mkListType();
   /** (Proof <proven>) */
   Expr mkProofType(const Expr& proven);
   /** (Quote <term>) */
@@ -139,6 +141,7 @@ class State
    */
   Expr mkParameterized(const ExprValue* hd, const std::vector<Expr>& params);
   /**
+   * Make (eo::List::Cons <args>) if args is non-empty or eo::List::nil otherwise.
    */
   Expr mkList(const std::vector<Expr>& args);
   //--------------------------------------

--- a/src/state.h
+++ b/src/state.h
@@ -141,7 +141,8 @@ class State
    */
   Expr mkParameterized(const ExprValue* hd, const std::vector<Expr>& params);
   /**
-   * Make (eo::List::Cons <args>) if args is non-empty or eo::List::nil otherwise.
+   * Make (eo::List::Cons <args>) if args is non-empty or eo::List::nil
+   * otherwise.
    */
   Expr mkList(const std::vector<Expr>& args);
   //--------------------------------------

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -178,7 +178,8 @@ bool TypeChecker::checkArity(Kind k, size_t nargs, std::ostream* out)
     case Kind::EVAL_IS_STR:
     case Kind::EVAL_IS_BOOL:
     case Kind::EVAL_IS_VAR:
-    case Kind::EVAL_DEF_OF:
+    case Kind::EVAL_DT_CONSTRUCTORS:
+    case Kind::EVAL_DT_SELECTORS:
       ret = (nargs==1);
       break;
     case Kind::EVAL_NIL:
@@ -1174,14 +1175,16 @@ Expr TypeChecker::evaluateLiteralOpInternal(
       }
     }
     break;
-    case Kind::EVAL_DEF_OF:
+    case Kind::EVAL_DT_CONSTRUCTORS:
+    case Kind::EVAL_DT_SELECTORS:
     {
       AppInfo* ac = d_state.getAppInfo(args[0]);
       if (ac!=nullptr)
       {
         Assert (args[0]->isGround());
         Attr a = ac->d_attrCons;
-        if (a==Attr::DATATYPE || a==Attr::DATATYPE_CONSTRUCTOR)
+        if ((a==Attr::DATATYPE && k==Kind::EVAL_DT_CONSTRUCTORS) ||
+            (a==Attr::DATATYPE_CONSTRUCTOR && k==Kind::EVAL_DT_SELECTORS))
         {
           return ac->d_attrConsTerm;
         }
@@ -1455,6 +1458,9 @@ ExprValue* TypeChecker::getLiteralOpType(Kind k,
       return getOrSetLiteralTypeRule(Kind::STRING);
     case Kind::EVAL_TO_BIN:
       return getOrSetLiteralTypeRule(Kind::BINARY);
+    case Kind::EVAL_DT_CONSTRUCTORS:
+    case Kind::EVAL_DT_SELECTORS:
+      return d_state.mkListType().getValue();
     default:break;
   }
   if (out)

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -179,9 +179,7 @@ bool TypeChecker::checkArity(Kind k, size_t nargs, std::ostream* out)
     case Kind::EVAL_IS_BOOL:
     case Kind::EVAL_IS_VAR:
     case Kind::EVAL_DT_CONSTRUCTORS:
-    case Kind::EVAL_DT_SELECTORS:
-      ret = (nargs==1);
-      break;
+    case Kind::EVAL_DT_SELECTORS: ret = (nargs == 1); break;
     case Kind::EVAL_NIL:
       ret = (nargs>=1);
       break;
@@ -1179,12 +1177,13 @@ Expr TypeChecker::evaluateLiteralOpInternal(
     case Kind::EVAL_DT_SELECTORS:
     {
       AppInfo* ac = d_state.getAppInfo(args[0]);
-      if (ac!=nullptr)
+      if (ac != nullptr)
       {
-        Assert (args[0]->isGround());
+        Assert(args[0]->isGround());
         Attr a = ac->d_attrCons;
-        if ((a==Attr::DATATYPE && k==Kind::EVAL_DT_CONSTRUCTORS) ||
-            (a==Attr::DATATYPE_CONSTRUCTOR && k==Kind::EVAL_DT_SELECTORS))
+        if ((a == Attr::DATATYPE && k == Kind::EVAL_DT_CONSTRUCTORS)
+            || (a == Attr::DATATYPE_CONSTRUCTOR
+                && k == Kind::EVAL_DT_SELECTORS))
         {
           return ac->d_attrConsTerm;
         }
@@ -1459,8 +1458,7 @@ ExprValue* TypeChecker::getLiteralOpType(Kind k,
     case Kind::EVAL_TO_BIN:
       return getOrSetLiteralTypeRule(Kind::BINARY);
     case Kind::EVAL_DT_CONSTRUCTORS:
-    case Kind::EVAL_DT_SELECTORS:
-      return d_state.mkListType().getValue();
+    case Kind::EVAL_DT_SELECTORS: return d_state.mkListType().getValue();
     default:break;
   }
   if (out)

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -178,6 +178,7 @@ bool TypeChecker::checkArity(Kind k, size_t nargs, std::ostream* out)
     case Kind::EVAL_IS_STR:
     case Kind::EVAL_IS_BOOL:
     case Kind::EVAL_IS_VAR:
+    case Kind::EVAL_DEF_OF:
       ret = (nargs==1);
       break;
     case Kind::EVAL_NIL:
@@ -1169,6 +1170,20 @@ Expr TypeChecker::evaluateLiteralOpInternal(
         {
           const Literal* l = args[0]->asLiteral();
           return d_state.getBoundVar(l->d_str.toString(), type);
+        }
+      }
+    }
+    break;
+    case Kind::EVAL_DEF_OF:
+    {
+      AppInfo* ac = d_state.getAppInfo(args[0]);
+      if (ac!=nullptr)
+      {
+        Assert (args[0]->isGround());
+        Attr a = ac->d_attrCons;
+        if (a==Attr::DATATYPE || a==Attr::DATATYPE_CONSTRUCTOR)
+        {
+          return ac->d_attrConsTerm;
         }
       }
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -129,6 +129,7 @@ set(ethos_test_file_list
     left-cons.eo
     overload-standalone.eo
     datatypes-split-rule.eo
+    singular-datatype.eo
 )
 
 if(ENABLE_ORACLES)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -128,6 +128,7 @@ set(ethos_test_file_list
     simple-lra-reference.eo
     left-cons.eo
     overload-standalone.eo
+    datatypes-split-rule.eo
 )
 
 if(ENABLE_ORACLES)

--- a/tests/datatypes-split-rule.eo
+++ b/tests/datatypes-split-rule.eo
@@ -1,0 +1,23 @@
+(declare-type Int ())
+(declare-datatypes ((Lst 0)) (((cons (head Int) (tail Lst)) (nil))))
+
+
+(declare-const is (-> (! Type :var C :implicit) (! Type :var D :implicit) C D Bool))
+(declare-const or (-> Bool Bool Bool) :right-assoc-nil false)
+
+(program $mk_split ((D Type) (x D) (T Type) (c T) (xs eo::List :list))
+  (eo::List D) Bool
+  (
+    (($mk_split eo::List::nil x)          false)
+    (($mk_split (eo::List::cons c xs) x)  (eo::cons or (is c x) ($mk_split xs x)))
+  )
+)
+
+(declare-rule dt-split ((D Type) (x D))
+  :args (x)
+  :conclusion ($mk_split (eo::defof (eo::typeof x)) x)
+)
+
+(declare-const x Lst)
+
+(step @p0 (or (is cons x) (is nil x)) :rule dt-split :args (x))

--- a/tests/datatypes-split-rule.eo
+++ b/tests/datatypes-split-rule.eo
@@ -1,5 +1,11 @@
+; (declare-type eo::List ())
+; (declare-const eo::List::nil eo::List)
+; (declare-const eo::List::cons (-> (! Type :var T :implicit) T eo::List eo::List))
+
 (declare-type Int ())
 (declare-datatypes ((Lst 0)) (((cons (head Int) (tail Lst)) (nil))))
+
+
 
 
 (declare-const is (-> (! Type :var C :implicit) (! Type :var D :implicit) C D Bool))
@@ -16,7 +22,7 @@
 
 (declare-rule dt-split ((D Type) (x D))
   :args (x)
-  :conclusion ($mk_dt_split (eo::defof (eo::typeof x)) x)
+  :conclusion ($mk_dt_split (eo::dt_constructors (eo::typeof x)) x)
 )
 
 (declare-const x Lst)
@@ -34,7 +40,7 @@
 
 (declare-rule dt-inst ((D Type) (T Type) (c T) (x D))
   :args (c x)
-  :conclusion (= (is c x) (= x ($mk_dt_inst (eo::defof c) x c)))
+  :conclusion (= (is c x) (= x ($mk_dt_inst (eo::dt_selectors c) x c)))
 )
 
 (step @p1 (= (is cons x) (= x (cons (head x) (tail x)))) :rule dt-inst :args (cons x))

--- a/tests/datatypes-split-rule.eo
+++ b/tests/datatypes-split-rule.eo
@@ -4,20 +4,38 @@
 
 (declare-const is (-> (! Type :var C :implicit) (! Type :var D :implicit) C D Bool))
 (declare-const or (-> Bool Bool Bool) :right-assoc-nil false)
+(declare-const = (-> (! Type :var T :implicit) T T Bool))
 
-(program $mk_split ((D Type) (x D) (T Type) (c T) (xs eo::List :list))
+(program $mk_dt_split ((D Type) (x D) (T Type) (c T) (xs eo::List :list))
   (eo::List D) Bool
   (
-    (($mk_split eo::List::nil x)          false)
-    (($mk_split (eo::List::cons c xs) x)  (eo::cons or (is c x) ($mk_split xs x)))
+    (($mk_dt_split eo::List::nil x)          false)
+    (($mk_dt_split (eo::List::cons c xs) x)  (eo::cons or (is c x) ($mk_dt_split xs x)))
   )
 )
 
 (declare-rule dt-split ((D Type) (x D))
   :args (x)
-  :conclusion ($mk_split (eo::defof (eo::typeof x)) x)
+  :conclusion ($mk_dt_split (eo::defof (eo::typeof x)) x)
 )
 
 (declare-const x Lst)
 
 (step @p0 (or (is cons x) (is nil x)) :rule dt-split :args (x))
+
+
+(program $mk_dt_inst ((D Type) (x D) (T Type) (t T) (S Type) (s S) (xs eo::List :list))
+  (eo::List D T) Bool
+  (
+    (($mk_dt_inst eo::List::nil x t)          t)
+    (($mk_dt_inst (eo::List::cons s xs) x t)  ($mk_dt_inst xs x (t (s x))))
+  )
+)
+
+(declare-rule dt-inst ((D Type) (T Type) (c T) (x D))
+  :args (c x)
+  :conclusion (= (is c x) (= x ($mk_dt_inst (eo::defof c) x c)))
+)
+
+(step @p1 (= (is cons x) (= x (cons (head x) (tail x)))) :rule dt-inst :args (cons x))
+(step @p1 (= (is nil x) (= x nil)) :rule dt-inst :args (nil x))

--- a/tests/singular-datatype.eo
+++ b/tests/singular-datatype.eo
@@ -1,0 +1,1 @@
+(declare-datatype a ((b)))

--- a/user_manual.md
+++ b/user_manual.md
@@ -1155,7 +1155,7 @@ In detail, for the purposes of representing the return value of these operators,
 > __Note:__ `eo::List` is not itself a datatype type.
 
 The constructor `eo::List::cons` is heterogeneous in that terms of any type can be included in the same list.
-Given a datatype with constructors `c_1, \ldots, c_n`, the `eo::dt_constructors` will return the term `(eo::List::cons c_1 \ldots c_n)`.
+Given a datatype with constructors `c_1 ... c_n`, the `eo::dt_constructors` will return the term `(eo::List::cons c_1 ... c_n)`.
 Examples of these operators are given below.
 
 ```smt
@@ -1181,7 +1181,7 @@ We assume the declaration of a generic `is` predicate (often called a "tester" p
 
 ```smt
 
-; (is c x) is true iff x is an application of constructor c
+; The constraint (is c x) is true iff x is an application of constructor c
 (declare-const is (-> (! Type :var C :implicit) (! Type :var D :implicit) C D Bool))
 (declare-const or (-> Bool Bool Bool) :right-assoc-nil false)
 

--- a/user_manual.md
+++ b/user_manual.md
@@ -1159,7 +1159,7 @@ Given a datatype with constructors `c_1 ... c_n`, the `eo::dt_constructors` will
 Examples of these operators are given below.
 
 ```smt
-(declare-datatypes ((myList 0)) (((myCons (head Int) (tail Lst)) (myNil))))
+(declare-datatypes ((myList 0)) (((myCons (head Int) (tail myList)) (myNil))))
 
 (eo::dt_constructors myList)  == (eo::List::cons myCons (eo::List::cons myNil eo::List::nil))
 (eo::dt_selectors myCons)     == (eo::List::cons head (eo::List::cons tail eo::List::nil))
@@ -1199,14 +1199,14 @@ We assume the declaration of a generic `is` predicate (often called a "tester" p
 )
 
 (declare-type Int ())
-(declare-datatypes ((myList 0)) (((myCons (head Int) (tail Lst)) (myNil))))
+(declare-datatypes ((myList 0)) (((myCons (head Int) (tail myList)) (myNil))))
 
 (declare-const x myList)
 (step @p0 (or (is myCons x) (is myNil x)) :rule dt-split :args (x))
 
 (declare-datatypes ((Color 0)) (((red) (green) (blue))))
 (declare-const y Color)
-(step @p0 (or (is red y) (is green y) (is blue y)) :rule dt-split :args (y))
+(step @p1 (or (is red y) (is green y) (is blue y)) :rule dt-split :args (y))
 ```
 
 In this example, after declaring our tester predicate `is`, we introduce a side condition `$mk_dt_split` that is used for defining a proof rule `dt-split`.

--- a/user_manual.md
+++ b/user_manual.md
@@ -11,6 +11,7 @@ To build ethos, run:
 mkdir build
 cd build
 cmake ..
+make
 ```
 
 The `ethos` binary will be available in `build/src/`.
@@ -20,9 +21,10 @@ The `ethos` binary will be available in `build/src/`.
 By default, the above will be a production build of `ethos`. To build a debug version of `ethos`, that is significantly slower but has assertions and trace messages enabled, run:
 
 ```shell
-mkdir build -DCMAKE_BUILD_TYPE=Debug
+mkdir build
 cd build
-cmake ..
+cmake -DCMAKE_BUILD_TYPE=Debug ..
+make
 ```
 
 The `ethos` binary will be available in `build/src/`.
@@ -39,8 +41,8 @@ The set of available options `<option>` are given in the appendix. Note the comm
 
 Ethos will either emit an error message indicating:
 
-- the kind of failure (type checking, proof checking, lexer error),
-- the line and column of the failure,
+- the kind of failure (type checking, proof checking, lexer error)
+- the line and column of the failure
 
 or will print a [successful response](#responses) when it finished parsing all commands in the file or encounters and `exit` command.
 Further output can be given by user-provided `echo` commands.
@@ -122,7 +124,7 @@ The following commands are supported for declaring and defining types and terms.
 
 The Eunoia language contains further commands for declaring symbols that are not standard SMT-LIB version 3.0:
 
-- `(define <symbol> (<typed-param>*) <term> <attr>*)`, defines `<symbol>` to be a lambda term whose arguments and body and given by the command, or the body if the argument list is empty. Note that in contrast to the SMT-LIB command `define-fun`, a return type is not provided. The provided attributes may instruct the checker to perform e.g. type checking on the given term see [type checking define](#tcdefine).
+- `(define <symbol> (<typed-param>*) <term> <attr>*)`, defines `<symbol>` to be a lambda term whose arguments and body are given by the command, or the body if the argument list is empty. Note that in contrast to the SMT-LIB command `define-fun`, a return type is not provided. The provided attributes may instruct the checker to perform e.g. type checking on the given term see [type checking define](#tcdefine).
 
 - `(declare-parameterized-const <symbol> (<typed-param>*) <type> <attr>*)` declares a globally scoped variable named `<symbol>` whose type is `<type>`.
 
@@ -151,7 +153,7 @@ Observe that despite the use of different syntax in their declarations, the type
 ```smt
 (declare-const not (-> Bool Bool))
 (define id ((x Bool)) x)
-(define notId ((x Int)) (not (id x)))
+(define notId ((x Bool)) (not (id x)))
 ```
 
 In the example above, `not` is declared to be a unary function over Booleans. Two defined functions are given, the first being an identity function over Booleans, and the second returning the negation of the first.
@@ -163,7 +165,7 @@ In other words, the following sequence of commands is equivalent to the one abov
 ```smt
 (declare-const not (-> Bool Bool))
 (define id ((x Bool)) x)
-(define notId ((x Int)) (not x))
+(define notId ((x Bool)) (not x))
 ```
 
 #### Example: Polymorphic types
@@ -906,7 +908,7 @@ The terms on both sides of the given evaluation are written in their form prior 
 
 (eo::list_find or (or a b a) b)          == 1
 (eo::list_find or (or a b a) true)       == -1
-(eo::list_find or (and a b b) a)         == (eo::find or (and a b b) a)      ; since (and a b b) is not an or-list
+(eo::list_find or (and a b b) a)         == (eo::list_find or (and a b b) a)      ; since (and a b b) is not an or-list
 ```
 
 ### Nil terminator with additional arguments
@@ -1360,7 +1362,7 @@ The following program (recursively) computes whether a formula `l` is contained 
     (
         ((contains false l)     false)
         ((contains (or l xs) l) true)
-        ((contains (or x xs) l) (contains l xs))
+        ((contains (or x xs) l) (contains xs l))
     )
 )
 ```
@@ -1369,15 +1371,15 @@ First, we declare the parameters `l, x, xs`, each of type `Bool`.
 These parameters are used for defining the body of the program, but do _not_ necessarily coincide with the expected arguments to the program.
 We then declare the type of the program `(Bool Bool) Bool`, i.e. the type of `contains` is a function expecting two Booleans and returning a Boolean.
 The body of the program is then given in three cases.
-First, terms of the form `(contains false l)` evaluate to `false`, that is, we failed to find `l` in the second argument.
-Second, terms of the form `(contains (or l xs) l)` evaluate to `true`, that is we found `l` in the first position of the second argument.
+First, terms of the form `(contains false l)` evaluate to `false`, that is, we failed to find `l` in the first argument.
+Second, terms of the form `(contains (or l xs) l)` evaluate to `true`, that is we found `l` in the first position of the first argument.
 Otherwise, terms of the form `(contains (or x xs) l)` evaluate in one step to `(contains xs l)`, in other words, we make a recursive call to find `l` in the tail of the list `xs`.
 
 In this example, since `xs` was marked with `:list`, the terms `(or l xs)` and `(or x xs)` are desugared to terms where `xs` is matched with the tail of the input.
 The next two examples show variants where an incorrect definition of this program is defined.
 
 > __Note:__ As mentioned in [list-computation](#list-computation), Eunoia has dedicated support for operators over lists.
-For the definition of `contains` in the above example, the term `(contains l c)` is equivalent to `(eo::not (eo::is_neg (eo::find or c l)))`.
+For the definition of `contains` in the above example, the term `(contains c l)` is equivalent to `(eo::not (eo::is_neg (eo::list_find or c l)))`.
 Computing the latter is significantly faster in practice in Ethos.
 
 ### Example: Finding a child in an `or` term (incorrect version)
@@ -1390,7 +1392,7 @@ Computing the latter is significantly faster in practice in Ethos.
     (
         ((contains false l)     false)
         ((contains (or l xs) l) true)
-        ((contains (or x xs) l) (contains l xs))
+        ((contains (or x xs) l) (contains xs l))
     )
 )
 ```
@@ -1410,7 +1412,7 @@ However, `(contains (or a b c) a)` does not evaluate in this example.
     (
         ((contains false l)     false)
         ((contains (or l xs) l) true)
-        ((contains (or x xs) l) (contains l xs))
+        ((contains (or x xs) l) (contains xs l))
     )
 )
 ```

--- a/user_manual.md
+++ b/user_manual.md
@@ -1159,11 +1159,11 @@ Given a datatype with constructors `c_1 ... c_n`, the `eo::dt_constructors` will
 Examples of these operators are given below.
 
 ```smt
-(declare-datatypes ((myList 0)) (((myCons (head Int) (tail myList)) (myNil))))
+(declare-datatypes ((Tree 0)) (((node (left Tree) (right Tree)) (leaf))))
 
-(eo::dt_constructors myList)  == (eo::List::cons myCons (eo::List::cons myNil eo::List::nil))
-(eo::dt_selectors myCons)     == (eo::List::cons head (eo::List::cons tail eo::List::nil))
-(eo::dt_selectors myNil)      == eo::List::nil
+(eo::dt_constructors Tree)  == (eo::List::cons node (eo::List::cons leaf eo::List::nil))
+(eo::dt_selectors node)     == (eo::List::cons left (eo::List::cons right eo::List::nil))
+(eo::dt_selectors leaf)      == eo::List::nil
 
 (declare-datatypes ((Color 0)) (((red) (green) (blue))))
 
@@ -1183,6 +1183,7 @@ We assume the declaration of a generic `is` predicate (often called a "tester" p
 
 ; The constraint (is c x) is true iff x is an application of constructor c
 (declare-const is (-> (! Type :var C :implicit) (! Type :var D :implicit) C D Bool))
+
 (declare-const or (-> Bool Bool Bool) :right-assoc-nil false)
 
 (program $mk_dt_split ((D Type) (x D) (T Type) (c T) (xs eo::List :list))

--- a/user_manual.md
+++ b/user_manual.md
@@ -1199,11 +1199,10 @@ We assume the declaration of a generic `is` predicate (often called a "tester" p
   :conclusion ($mk_dt_split (eo::dt_constructors (eo::typeof x)) x)
 )
 
-(declare-type Int ())
-(declare-datatypes ((myList 0)) (((myCons (head Int) (tail myList)) (myNil))))
+(declare-datatypes ((Tree 0)) (((node (left Tree) (right Tree)) (leaf))))
 
-(declare-const x myList)
-(step @p0 (or (is myCons x) (is myNil x)) :rule dt-split :args (x))
+(declare-const x Tree)
+(step @p0 (or (is node x) (is leaf x)) :rule dt-split :args (x))
 
 (declare-datatypes ((Color 0)) (((red) (green) (blue))))
 (declare-const y Color)
@@ -1214,9 +1213,9 @@ In this example, after declaring our tester predicate `is`, we introduce a side 
 The side condition recurses over a list of constructors, which was obtained in the definition of the proof rule from applying `eo::dt_constructors` to the type of `x`.
 For each constructor `c` in this list, we prepend a disjunct `(is c x)` to a recursive call to this method.
 
-As part of the example, we see a particular definition of a list, called `myList`.
-Applying the proof rule `dt-split` to a variable `x` of type `myList` allows us to conclude that `x` must either be an application of `myCons` or `myNil`.
-Note that the definitino of `dt-split` is applicable to *any* datatype definition, not just lists.
+As part of the example, we see a particular definition of a list, called `Tree`.
+Applying the proof rule `dt-split` to a variable `x` of type `Tree` allows us to conclude that `x` must either be an application of `node` or `leaf`.
+Note that the definitino of `dt-split` is applicable to *any* datatype definition.
 In particular, as a second example, we see the rule applied to a term `y` of type `Color` gives us a conclusion with three disjuncts.
 
 ## Declaring Proof Rules


### PR DESCRIPTION
This adds a way `eo::dt_constructors` to extract the definition of datatypes (their corresponding list of constructors) and `eo::dt_selectors` to extract the definition of datatype constructors (their corresponding list of selectors).  It adds an ordinary type `eo::List` that is part of the assumed background signature for this purpose.

Also fixes the parser for `declare-datatype` (the singular form of datatypes, which had not been tested).