### PR TITLE
Add two minor changes to Ethos output

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -346,6 +346,11 @@ void Expr::printDebugInternal(const Expr& e,
             case Kind::HEXADECIMAL:os << "#x" << l->toString();break;
             case Kind::BINARY:os << "#b" << l->toString();break;
             case Kind::STRING:os << "\"" << l->toString() << "\"";break;
+            case Kind::DECIMAL:
+              // currently don't have a way to print decimals natively, just
+              // use attribute
+              os << "(! " << l->toString() << " :decimal)";
+              break;
             default:
               if (isSymbol(k))
               {

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -646,6 +646,8 @@ Expr State::mkExpr(Kind k, const std::vector<Expr>& children)
           Trace("overload") << "...found overload " << ret << std::endl;
           return vchildren.size()<=2 ? Expr(mkExprInternal(k, vchildren)) : Expr(mkApplyInternal(vchildren));
         }
+        Warning() << "No overload found when constructing application "
+                  << children << std::endl;
       }
       Trace("state-debug") << "Process category " << ai->d_attrCons << " for " << children[0] << std::endl;
       size_t nchild = vchildren.size();


### PR DESCRIPTION
Adds output so that decimal `0.25` is printed as `(! 1/4 :decimal)` instead of silently printing as `1/4`.   This led to confusion on https://github.com/cvc5/ethos/issues/88.

Also throws a warning if overloading fails to find a suitable operator. This warning is currently being thrown on the CPC signature on cvc5 main, which needs to be addressed.