### PR TITLE
Fix out of range error in file extension check

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -163,7 +163,7 @@ int main( int argc, char* argv[] )
   else
   {
     // whether it is a signature is determined by file extension *.eo.
-    bool isSignature = (file.substr(file.size()-3)==".eo");
+    bool isSignature = (file.size() >= 3 && file.substr(file.size()-3)==".eo");
     // include the file
     if (!s.includeFile(file, isSignature))
     {


### PR DESCRIPTION
This pull request fixes an issue where attempting to check the file extension using substr could cause an out of range error if the file name is shorter than 3 characters.
Added a condition to ensure the file name length is at least 3 before performing the substr operation.
It will prevent potential crashes or undefined behavior when handling short file names.