### PR TITLE
Fix segfault for overloads

### DIFF
--- a/src/state.cpp
+++ b/src/state.cpp
@@ -242,7 +242,8 @@ void State::popScope()
       Assert (ai->d_overloads.size()>=2);
       // was overloaded, we revert the binding
       ai->d_overloads.pop_back();
-      its->second = ai->d_overloads.back();
+      Expr tmp = ai->d_overloads.back();
+      its->second = tmp;
       continue;
     }
     Trace("overload") << "** unbind " << d_decls[i] << std::endl;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -132,6 +132,7 @@ set(ethos_test_file_list
     singular-datatype.eo
     simul-overload.eo
     bang-lex.eo
+    segfault-98.eo
 )
 
 if(ENABLE_ORACLES)

--- a/tests/segfault-98.eo
+++ b/tests/segfault-98.eo
@@ -1,0 +1,19 @@
+(program check_bind ((ctx Bool) (T Type) (l T) (r T) (l1 T) (r1 T))
+  (Bool T T T T) Bool
+  (
+   ((check_bind ctx l r l1 r1) true)
+  )
+)
+
+(declare-rule bind ((ctx Bool) (old_ctx Bool) (T Type) (l T) (r T) (l1 T) (r1 T))
+  :assumption ctx
+  :conclusion-given
+)
+
+(declare-const @cl (-> Bool Bool Bool) :right-assoc-nil false)
+
+(define ctx1 ( ) true)
+(assume-push context ctx1)
+(assume-push context true)
+(step-pop t5.t4 (@cl true) :rule bind)
+(step-pop t5.t4.2 (@cl true) :rule bind)


### PR DESCRIPTION
Fixes https://github.com/cvc5/ethos/issues/98.

It seems that depending on how line 245 is executed, we could deref the expression and delete `ai` before updating the map. This stores a temporary expression to avoid this issue.