### PR TITLE
Fix segfault when trace tag is missing after -t option

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -99,6 +99,10 @@ int main( int argc, char* argv[] )
     }
     else if (arg=="-t")
     {
+      if (i >= nargs)
+      {
+        EO_FATAL() << "Error: Missing trace tag.";
+      }
       std::string targ(argv[i]);
       i++;
 #ifdef EO_TRACING


### PR DESCRIPTION
Added error handling to check for a missing trace tag after the -t option. Now displays an appropriate error message instead of causing a segmentation fault.