### PR TITLE
Support ambiguous parameteric datatype constructors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,8 +3,7 @@ This file contains a summary of important user-visible changes.
 ethos 0.1.2 prerelease
 ======================
 
-- Adds support for the SMT-LIB `as`, which is equivalent to `eo::as`.
-- Ambiguous constructors for parametric datatypes are now supported, i.e. those whose return type cannot be inferred from its argument types. Following SMT-LIB convention, ambiguous datatype constructors are expected to be annotated with their *return* type using `as` (or `eo::as`), which internally is treated as a type argument to the constructor.
+- Adds support for the SMT-LIB `as` annotations for ambiguous datatype constructors, i.e. those whose return type cannot be inferred from its argument types. Following SMT-LIB convention, ambiguous datatype constructors are expected to be annotated with their *return* type using `as`, which internally is treated as a type argument to the constructor.
 - The semantics for `eo::dt_constructors` is extended for instantiated parametric datatypes. For example calling `eo::dt_constructors` on `(List Int)` returns the list containing `cons` and `(as nil (List Int))`.
 - The semantics for `eo::dt_selectors` is extended for annotated constructors. For example calling `eo::dt_selectors` on `(as nil (List Int))` returns the empty list.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 This file contains a summary of important user-visible changes.
 
+ethos 0.1.2 prerelease
+======================
+
+- Ambiguous constructors for parametric datatypes are now supported, i.e. those whose return type cannot be inferred from its argument types. Following the SMT-LIB convention, all ambiguous datatype constructors must be given an annotation using `as` or `eo::as`.
+- Adds support for the SMT-LIB `as`, which is equivalent to `eo::as`.
+- The semantics for `eo::dt_constructors` is extended for instantiated parametric datatypes. For example calling `eo::dt_constructors` on `(List Int)` returns the list containing `cons` and `(as nil (List Int))`.
+- The semantics for `eo::dt_selectors` is extended for annotated constructors. For example calling `eo::dt_selectors` on `(as nil (List Int))` returns the empty list.
+
 ethos 0.1.1 prerelease
 ======================
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,8 +3,8 @@ This file contains a summary of important user-visible changes.
 ethos 0.1.2 prerelease
 ======================
 
-- Ambiguous constructors for parametric datatypes are now supported, i.e. those whose return type cannot be inferred from its argument types. Following the SMT-LIB convention, all ambiguous datatype constructors must be given an annotation using `as` or `eo::as`.
 - Adds support for the SMT-LIB `as`, which is equivalent to `eo::as`.
+- Ambiguous constructors for parametric datatypes are now supported, i.e. those whose return type cannot be inferred from its argument types. Ambiguous datatype constructors are expected to be given an annotation using `as` or `eo::as`, which is treated as a type argument to the constructor.
 - The semantics for `eo::dt_constructors` is extended for instantiated parametric datatypes. For example calling `eo::dt_constructors` on `(List Int)` returns the list containing `cons` and `(as nil (List Int))`.
 - The semantics for `eo::dt_selectors` is extended for annotated constructors. For example calling `eo::dt_selectors` on `(as nil (List Int))` returns the empty list.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@ ethos 0.1.2 prerelease
 ======================
 
 - Adds support for the SMT-LIB `as`, which is equivalent to `eo::as`.
-- Ambiguous constructors for parametric datatypes are now supported, i.e. those whose return type cannot be inferred from its argument types. Ambiguous datatype constructors are expected to be given an annotation using `as` or `eo::as`, which is treated as a type argument to the constructor.
+- Ambiguous constructors for parametric datatypes are now supported, i.e. those whose return type cannot be inferred from its argument types. Following SMT-LIB convention, ambiguous datatype constructors are expected to be annotated with their *return* type using `as` (or `eo::as`), which internally is treated as a type argument to the constructor.
 - The semantics for `eo::dt_constructors` is extended for instantiated parametric datatypes. For example calling `eo::dt_constructors` on `(List Int)` returns the list containing `cons` and `(as nil (List Int))`.
 - The semantics for `eo::dt_selectors` is extended for annotated constructors. For example calling `eo::dt_selectors` on `(as nil (List Int))` returns the empty list.
 

--- a/src/attr.cpp
+++ b/src/attr.cpp
@@ -38,6 +38,7 @@ std::ostream& operator<<(std::ostream& o, Attr a)
     case Attr::DATATYPE: o << "DATATYPE"; break;
     case Attr::CODATATYPE: o << "CODATATYPE"; break;
     case Attr::DATATYPE_CONSTRUCTOR: o << "DATATYPE_CONSTRUCTOR"; break;
+    case Attr::AMB_DATAYPE_CONSTRUCTOR: o << "AMB_DATAYPE_CONSTRUCTOR"; break;
     default: o << "UnknownAttr(" << unsigned(a) << ")"; break;
   }
   return o;

--- a/src/attr.cpp
+++ b/src/attr.cpp
@@ -38,7 +38,7 @@ std::ostream& operator<<(std::ostream& o, Attr a)
     case Attr::DATATYPE: o << "DATATYPE"; break;
     case Attr::CODATATYPE: o << "CODATATYPE"; break;
     case Attr::DATATYPE_CONSTRUCTOR: o << "DATATYPE_CONSTRUCTOR"; break;
-    case Attr::AMB_DATAYPE_CONSTRUCTOR: o << "AMB_DATAYPE_CONSTRUCTOR"; break;
+    case Attr::AMB_DATATYPE_CONSTRUCTOR: o << "AMB_DATATYPE_CONSTRUCTOR"; break;
     default: o << "UnknownAttr(" << unsigned(a) << ")"; break;
   }
   return o;

--- a/src/attr.h
+++ b/src/attr.h
@@ -19,7 +19,7 @@ namespace ethos {
 enum class Attr
 {
   NONE = 0,
-  
+
   VAR,
   IMPLICIT,
   REQUIRES,
@@ -34,11 +34,11 @@ enum class Attr
   BINDER,
   LET_BINDER,
   OPAQUE,
-  
+
   // smt3 things that are not strictly supported
   SYNTAX,
   RESTRICT,
-  
+
   // indicate how to construct proof rule steps
   PREMISE_LIST,
 
@@ -53,7 +53,7 @@ enum class Attr
   // datatypes
   DATATYPE,
   DATATYPE_CONSTRUCTOR,
-  AMB_DATAYPE_CONSTRUCTOR, // constructors requiring an opaque type argument
+  AMB_DATAYPE_CONSTRUCTOR,  // constructors requiring an opaque type argument
   CODATATYPE
 };
 

--- a/src/attr.h
+++ b/src/attr.h
@@ -53,7 +53,7 @@ enum class Attr
   // datatypes
   DATATYPE,
   DATATYPE_CONSTRUCTOR,
-  PARAM_DATATYPE_CONSTRUCTOR,
+  AMB_DATAYPE_CONSTRUCTOR, // constructors requiring an opaque type argument
   CODATATYPE
 };
 

--- a/src/attr.h
+++ b/src/attr.h
@@ -53,7 +53,7 @@ enum class Attr
   // datatypes
   DATATYPE,
   DATATYPE_CONSTRUCTOR,
-  AMB_DATAYPE_CONSTRUCTOR,  // constructors requiring an opaque type argument
+  AMB_DATATYPE_CONSTRUCTOR,  // constructors requiring an opaque type argument
   CODATATYPE
 };
 

--- a/src/attr.h
+++ b/src/attr.h
@@ -53,6 +53,7 @@ enum class Attr
   // datatypes
   DATATYPE,
   DATATYPE_CONSTRUCTOR,
+  PARAM_DATATYPE_CONSTRUCTOR,
   CODATATYPE
 };
 

--- a/src/cmd_parser.cpp
+++ b/src/cmd_parser.cpp
@@ -282,9 +282,10 @@ bool CmdParser::parseNextCommand()
       }
       for (std::pair<const ExprValue* const, std::vector<Expr>>& c : dtcons)
       {
+        Attr ac = Attr::DATATYPE_CONSTRUCTOR;
         Expr cons = Expr(c.first);
         Expr stuple = d_state.mkList(c.second);
-        d_state.markConstructorKind(cons, Attr::DATATYPE_CONSTRUCTOR, stuple);
+        d_state.markConstructorKind(cons, ac, stuple);
       }
       if (isMulti)
       {

--- a/src/cmd_parser.cpp
+++ b/src/cmd_parser.cpp
@@ -243,6 +243,7 @@ bool CmdParser::parseNextCommand()
       std::vector<size_t> arities;
       std::map<const ExprValue*, std::vector<Expr>> dts;
       std::map<const ExprValue*, std::vector<Expr>> dtcons;
+      std::unordered_set<const ExprValue*> ambCons;
       if (isMulti)
       {
         d_lex.eatToken(Token::LPAREN);
@@ -268,7 +269,7 @@ bool CmdParser::parseNextCommand()
         std::string name = d_eparser.parseSymbol();
         dnames.push_back(name);
       }
-      if (!d_eparser.parseDatatypesDef(dnames, arities, dts, dtcons))
+      if (!d_eparser.parseDatatypesDef(dnames, arities, dts, dtcons, ambCons))
       {
         d_lex.parseError("Failed to bind symbols for datatype definition");
       }
@@ -282,7 +283,8 @@ bool CmdParser::parseNextCommand()
       }
       for (std::pair<const ExprValue* const, std::vector<Expr>>& c : dtcons)
       {
-        Attr ac = Attr::DATATYPE_CONSTRUCTOR;
+        // may be ambiguous
+        Attr ac = ambCons.find(c.first)!=ambCons.end() ? Attr::AMB_DATAYPE_CONSTRUCTOR : Attr::DATATYPE_CONSTRUCTOR;
         Expr cons = Expr(c.first);
         Expr stuple = d_state.mkList(c.second);
         d_state.markConstructorKind(cons, ac, stuple);

--- a/src/cmd_parser.cpp
+++ b/src/cmd_parser.cpp
@@ -284,7 +284,9 @@ bool CmdParser::parseNextCommand()
       for (std::pair<const ExprValue* const, std::vector<Expr>>& c : dtcons)
       {
         // may be ambiguous
-        Attr ac = ambCons.find(c.first)!=ambCons.end() ? Attr::AMB_DATAYPE_CONSTRUCTOR : Attr::DATATYPE_CONSTRUCTOR;
+        Attr ac = ambCons.find(c.first) != ambCons.end()
+                      ? Attr::AMB_DATAYPE_CONSTRUCTOR
+                      : Attr::DATATYPE_CONSTRUCTOR;
         Expr cons = Expr(c.first);
         Expr stuple = d_state.mkList(c.second);
         d_state.markConstructorKind(cons, ac, stuple);

--- a/src/cmd_parser.cpp
+++ b/src/cmd_parser.cpp
@@ -285,7 +285,7 @@ bool CmdParser::parseNextCommand()
       {
         // may be ambiguous
         Attr ac = ambCons.find(c.first) != ambCons.end()
-                      ? Attr::AMB_DATAYPE_CONSTRUCTOR
+                      ? Attr::AMB_DATATYPE_CONSTRUCTOR
                       : Attr::DATATYPE_CONSTRUCTOR;
         Expr cons = Expr(c.first);
         Expr stuple = d_state.mkList(c.second);

--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -1449,7 +1449,6 @@ Expr ExprParser::findFreeVar(const Expr& e, const std::vector<Expr>& bvs)
 void ExprParser::ensureBound(const Expr& e, const std::vector<Expr>& bvs)
 {
   Expr v = findFreeVar(e, bvs);
-  std::vector<Expr> efv = Expr::getVariables(e);
   if (!v.isNull())
   {
     std::stringstream msg;

--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -1005,7 +1005,6 @@ void ExprParser::parseConstructorDefinitionList(
     if (!params.empty())
     {
       Expr odt = d_state.mkQuoteType(dt);
-      odt = d_state.mkExpr(Kind::OPAQUE_TYPE, {odt});
       typelist.push_back(odt);
     }
     // parse another selector or close the current constructor

--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -962,7 +962,8 @@ bool ExprParser::parseDatatypesDef(
       dti = d_state.mkExpr(Kind::APPLY, dapp);
     }
     std::vector<std::pair<std::string, Expr>> toBind;
-    parseConstructorDefinitionList(dti, dts[dt.getValue()], dtcons, toBind);
+    std::vector<Expr>& clist = dts[dt.getValue()];
+    parseConstructorDefinitionList(dti, clist, dtcons, toBind, params);
     if (pushedScope)
     {
       d_lex.eatToken(Token::RPAREN);
@@ -990,7 +991,8 @@ void ExprParser::parseConstructorDefinitionList(
     Expr& dt,
     std::vector<Expr>& conslist,
     std::map<const ExprValue*, std::vector<Expr>>& dtcons,
-    std::vector<std::pair<std::string, Expr>>& toBind)
+    std::vector<std::pair<std::string, Expr>>& toBind,
+    const std::vector<Expr>& params)
 {
   d_lex.eatToken(Token::LPAREN);
   Expr boolType = d_state.mkBoolType();
@@ -1000,6 +1002,12 @@ void ExprParser::parseConstructorDefinitionList(
     std::string name = parseSymbol();
     std::vector<Expr> typelist;
     std::vector<Expr> sels;
+    if (!params.empty())
+    {
+      Expr odt = d_state.mkQuoteType(dt);
+      odt = d_state.mkExpr(Kind::OPAQUE_TYPE, {odt});
+      typelist.push_back(odt);
+    }
     // parse another selector or close the current constructor
     while (d_lex.eatTokenChoice(Token::LPAREN, Token::RPAREN))
     {

--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -1030,7 +1030,8 @@ void ExprParser::parseConstructorDefinitionList(
       std::vector<Expr> pargs = Expr::getVariables(tup);
       Expr fv = findFreeVar(dt, pargs);
       Trace("param-dt") << "Parameteric datatype constructor: " << name;
-      Trace("param-dt") << (fv.isNull() ? " un" : " ") << "ambiguous" << std::endl;
+      Trace("param-dt") << (fv.isNull() ? " un" : " ") << "ambiguous"
+                        << std::endl;
       if (!fv.isNull())
       {
         Expr odt = d_state.mkQuoteType(dt);

--- a/src/expr_parser.h
+++ b/src/expr_parser.h
@@ -149,7 +149,7 @@ class ExprParser
   /** Bind, or throw error otherwise */
   void bind(const std::string& name, Expr& e);
   /**
-   * @return a variable from the free variables of e that is not in bvs
+   * @return a variable from the free variables of e that is not in bvs if
    * one exists, or the null expression otherwise.
    */
   Expr findFreeVar(const Expr& e, const std::vector<Expr>& bvs);

--- a/src/expr_parser.h
+++ b/src/expr_parser.h
@@ -85,7 +85,7 @@ class ExprParser
    * datatype_dec :=
    *   (<constructor_dec>+) | (par (<symbol>+) (<constructor_dec>+))
    * constructor_dec := (<symbol> (<symbol> <sort>)∗)
-   * 
+   *
    * @param dnames The names of the datatypes.
    * @param arities The arities of the datatypes given by the names dnames.
    * @param dts Mapping from datatypes to their constructor symbols.

--- a/src/expr_parser.h
+++ b/src/expr_parser.h
@@ -164,7 +164,8 @@ class ExprParser
       Expr& dt,
       std::vector<Expr>& conslist,
       std::map<const ExprValue*, std::vector<Expr>>& dtcons,
-      std::vector<std::pair<std::string, Expr>>& toBind);
+      std::vector<std::pair<std::string, Expr>>& toBind,
+      const std::vector<Expr>& params);
   /** Return the unsigned for the current token string. */
   uint32_t tokenStrToUnsigned();
   /**

--- a/src/expr_parser.h
+++ b/src/expr_parser.h
@@ -139,7 +139,14 @@ class ExprParser
   Expr getProofRule(const std::string& name);
   /** Bind, or throw error otherwise */
   void bind(const std::string& name, Expr& e);
-  /** Ensure bound */
+  /**
+   * @return a variable from bvs that is not in the free variables of e if
+   * one exists, or the null expression otherwise.
+   */
+  Expr findFreeVar(const Expr& e, const std::vector<Expr>& bvs);
+  /**
+   * Throw an exception if bvs are not contained in the free variables of e.
+   */
   void ensureBound(const Expr& e, const std::vector<Expr>& bvs);
   //-------------------------- end checking
   /**

--- a/src/expr_parser.h
+++ b/src/expr_parser.h
@@ -85,11 +85,20 @@ class ExprParser
    * datatype_dec :=
    *   (<constructor_dec>+) | (par (<symbol>+) (<constructor_dec>+))
    * constructor_dec := (<symbol> (<symbol> <sort>)∗)
+   * 
+   * @param dnames The names of the datatypes.
+   * @param arities The arities of the datatypes given by the names dnames.
+   * @param dts Mapping from datatypes to their constructor symbols.
+   * @param dtcons Mapping from constructors to their selector symbols.
+   * @param ambCons The subset of constructors in the domain of dtcons that are
+   * ambiguous constructors, i.e. require their return type as the first
+   * argument.
    */
   bool parseDatatypesDef(const std::vector<std::string>& dnames,
                          const std::vector<size_t>& arities,
                          std::map<const ExprValue*, std::vector<Expr>>& dts,
-                         std::map<const ExprValue*, std::vector<Expr>>& dtcons);
+                         std::map<const ExprValue*, std::vector<Expr>>& dtcons,
+                         std::unordered_set<const ExprValue*>& ambCons);
   /**
    * Parses ':X', returns 'X'
    */
@@ -140,12 +149,12 @@ class ExprParser
   /** Bind, or throw error otherwise */
   void bind(const std::string& name, Expr& e);
   /**
-   * @return a variable from bvs that is not in the free variables of e if
+   * @return a variable from the free variables of e that is not in bvs
    * one exists, or the null expression otherwise.
    */
   Expr findFreeVar(const Expr& e, const std::vector<Expr>& bvs);
   /**
-   * Throw an exception if bvs are not contained in the free variables of e.
+   * Throw an exception if the free variables of e are not in bvs.
    */
   void ensureBound(const Expr& e, const std::vector<Expr>& bvs);
   //-------------------------- end checking
@@ -166,12 +175,19 @@ class ExprParser
   /**
    * Parse constructor definition list, add to declaration type. The expected
    * syntax is '(<constructor_dec>+)'.
+   * @param dt The datatype this constructor list is for.
+   * @param conslist Populated with the constructors of dt.
+   * @param dtcons Mapping from constructors to their selector symbols.
+   * @param toBind The symbols to bind.
+   * @param ambCons The subset of conslist that are ambiguous constructors.
+   * @param param The parameters of dt.
    */
   void parseConstructorDefinitionList(
       Expr& dt,
       std::vector<Expr>& conslist,
       std::map<const ExprValue*, std::vector<Expr>>& dtcons,
       std::vector<std::pair<std::string, Expr>>& toBind,
+      std::unordered_set<const ExprValue*>& ambCons,
       const std::vector<Expr>& params);
   /** Return the unsigned for the current token string. */
   uint32_t tokenStrToUnsigned();

--- a/src/kind.cpp
+++ b/src/kind.cpp
@@ -119,6 +119,7 @@ std::string kindToTerm(Kind k)
     case Kind::LAMBDA: ss << "lambda"; break;
     case Kind::PROGRAM: ss << "program"; break;
     case Kind::AS: ss << "eo::as"; break;
+    case Kind::AS_RETURN: ss << "as"; break;
     case Kind::PARAMETERIZED: ss << "eo::_"; break;
     // operations on literals
     default:

--- a/src/kind.cpp
+++ b/src/kind.cpp
@@ -36,6 +36,7 @@ std::ostream& operator<<(std::ostream& o, Kind k)
     case Kind::TUPLE: o << "TUPLE"; break;
     case Kind::PROGRAM: o << "PROGRAM"; break;
     case Kind::AS: o << "AS"; break;
+    case Kind::AS_RETURN: o << "AS_RETURN"; break;
     case Kind::PARAMETERIZED: o << "PARAMETERIZED"; break;
     case Kind::APPLY_OPAQUE: o << "APPLY_OPAQUE"; break;
     // literals

--- a/src/kind.h
+++ b/src/kind.h
@@ -34,7 +34,7 @@ enum class Kind
   LAMBDA,
   TUPLE,
   PROGRAM,
-  AS,   // (eo::as t T), where T is the type of t
+  AS,         // (eo::as t T), where T is the type of t
   AS_RETURN,  // SMT-LIB (as t T), where T is the return type of t
   PARAMETERIZED,
   APPLY_OPAQUE,

--- a/src/kind.h
+++ b/src/kind.h
@@ -34,7 +34,8 @@ enum class Kind
   LAMBDA,
   TUPLE,
   PROGRAM,
-  AS,
+  AS,   // (eo::as t T), where T is the type of t
+  AS_RETURN,  // SMT-LIB (as t T), where T is the return type of t
   PARAMETERIZED,
   APPLY_OPAQUE,
 

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -564,6 +564,9 @@ Expr State::mkBoolType()
 
 Expr State::mkListType() { return d_listType; }
 
+Expr State::mkListCons() { return d_listCons; }
+Expr State::mkListNil() { return d_listNil; }
+  
 Expr State::mkProofType(const Expr& proven)
 {
   return Expr(mkExprInternal(Kind::PROOF_TYPE, {proven.getValue()}));

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -919,11 +919,12 @@ Expr State::mkExpr(Kind k, const std::vector<Expr>& children)
   else if (k==Kind::AS_RETURN)
   {
     // (as nil (List Int)) --> (_ nil (List Int))
-    if (getConstructorKind(vchildren[0]) == Attr::AMB_DATATYPE_CONSTRUCTOR)
+    if (getConstructorKind(vchildren[0]) == Attr::AMB_DATATYPE_CONSTRUCTOR && children.size()==2)
     {
       Trace("overload") << "...type arg for ambiguous constructor" << std::endl;
       return mkExpr(Kind::APPLY_OPAQUE, {children[0], children[1]});
     }
+    // note we don't support other uses of `as` for symbol disambiguation yet
   }
   else if (k==Kind::AS)
   {

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1508,7 +1508,11 @@ Expr State::getOverloadInternal(const std::vector<Expr>& overloads,
       tmp = mkExpr(Kind::APPLY_OPAQUE, {cons, rt});
       vchildren[0] = tmp.getValue();
     }
-    Expr x = vchildren.size()==1 ? Expr(vchildren[0]) : ( Expr(vchildren.size()>2 ? mkApplyInternal(vchildren) : mkExprInternal(Kind::APPLY, vchildren)));
+    Expr x = vchildren.size() == 1
+                 ? Expr(vchildren[0])
+                 : (Expr(vchildren.size() > 2
+                             ? mkApplyInternal(vchildren)
+                             : mkExprInternal(Kind::APPLY, vchildren)));
     Trace("overload") << "...check type of " << x << std::endl;
     Expr t = d_tc.getType(x);
     Trace("overload") << "...has type " << t << std::endl;

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -925,12 +925,13 @@ Expr State::mkExpr(Kind k, const std::vector<Expr>& children)
       Trace("overload") << "...type arg for ambiguous constructor" << std::endl;
       return mkExpr(Kind::APPLY_OPAQUE, {children[0], children[1]});
     }
-    // note we don't support other uses of `as` for symbol disambiguation yet
+    // note we don't support other uses of `as` for symbol disambiguation yet,
+    // we fallthrough and construct the bogus term of kind AS_RETURN.
   }
   else if (k==Kind::AS)
   {
-    // if it has 2 children, process it, otherwise we make the bogus term
-    // below
+    // if it has 2 children, process it, otherwise we make the bogus term of
+    // kind AS below
     if (vchildren.size()==2)
     {
       Trace("overload") << "process eo::as " << children[0] << " " << children[1] << std::endl;

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -566,7 +566,7 @@ Expr State::mkListType() { return d_listType; }
 
 Expr State::mkListCons() { return d_listCons; }
 Expr State::mkListNil() { return d_listNil; }
-  
+
 Expr State::mkProofType(const Expr& proven)
 {
   return Expr(mkExprInternal(Kind::PROOF_TYPE, {proven.getValue()}));

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1504,7 +1504,7 @@ Expr State::getOverloadInternal(const std::vector<Expr>& overloads,
     // it does not distinguish a symbol but instead annotates the constructor
     // symbol. This is done as an *opaque* argument to ensure type annotations
     // are not in ordinary positions.
-    if (getConstructorKind(vchildren[0]) == Attr::AMB_DATAYPE_CONSTRUCTOR)
+    if (getConstructorKind(vchildren[0]) == Attr::AMB_DATATYPE_CONSTRUCTOR)
     {
       Trace("overload") << "...type arg for ambiguous constructor" << std::endl;
       Expr cons(vchildren[0]);

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -916,10 +916,11 @@ Expr State::mkExpr(Kind k, const std::vector<Expr>& children)
                 << ", " << children.size() << " arguments" << std::endl;
     }
   }
-  else if (k==Kind::AS_RETURN)
+  else if (k == Kind::AS_RETURN)
   {
     // (as nil (List Int)) --> (_ nil (List Int))
-    if (getConstructorKind(vchildren[0]) == Attr::AMB_DATATYPE_CONSTRUCTOR && children.size()==2)
+    if (getConstructorKind(vchildren[0]) == Attr::AMB_DATATYPE_CONSTRUCTOR
+        && children.size() == 2)
     {
       Trace("overload") << "...type arg for ambiguous constructor" << std::endl;
       return mkExpr(Kind::APPLY_OPAQUE, {children[0], children[1]});

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -150,6 +150,7 @@ State::State(Options& opts, Stats& stats)
   bindBuiltinEval("dt_selectors", Kind::EVAL_DT_SELECTORS);
 
   // as
+  bindBuiltin("as", Kind::AS);
   bindBuiltinEval("as", Kind::AS);
 
   // note we don't allow parsing (Proof ...), (Quote ...), or (quote ...).

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1508,7 +1508,7 @@ Expr State::getOverloadInternal(const std::vector<Expr>& overloads,
       tmp = mkExpr(Kind::APPLY_OPAQUE, {cons, rt});
       vchildren[0] = tmp.getValue();
     }
-    Expr x = Expr(vchildren.size()>2 ? mkApplyInternal(vchildren) : mkExprInternal(Kind::APPLY, vchildren));
+    Expr x = vchildren.size()==1 ? Expr(vchildren[0]) : ( Expr(vchildren.size()>2 ? mkApplyInternal(vchildren) : mkExprInternal(Kind::APPLY, vchildren)));
     Trace("overload") << "...check type of " << x << std::endl;
     Expr t = d_tc.getType(x);
     Trace("overload") << "...has type " << t << std::endl;
@@ -1516,7 +1516,7 @@ Expr State::getOverloadInternal(const std::vector<Expr>& overloads,
     if (!t.isNull() && (retType==nullptr || retType==t.getValue()))
     {
       // return the operator, do not check the remainder
-      return overloads[ii];
+      return Expr(vchildren[0]);
     }
   }
   // otherwise, none found, return null

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -831,21 +831,6 @@ Expr State::mkExpr(Kind k, const std::vector<Expr>& children)
             return mkExpr(Kind::APPLY, rchildren);
           }
         }
-        case Attr::DATATYPE_CONSTRUCTOR:
-        {
-          // determine how many opaque children
-          Expr hdt = Expr(hd);
-          Expr t = d_tc.getType(hdt);
-          std::vector<Expr> cchildren(children.begin(), children.end());
-          if (t.getKind()==Kind::FUNCTION_TYPE && t[0].getKind()==Kind::QUOTE_TYPE)
-          {
-            // since it was not given an annotation
-            Expr rt = t.getFunctionType().second;
-            Expr ohd = mkExpr(Kind::APPLY_OPAQUE, {children[0], rt});
-            vchildren[0] = ohd.getValue();
-            return Expr(mkApplyInternal(vchildren));
-          }
-        }
         default:
           break;
       }

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -831,6 +831,21 @@ Expr State::mkExpr(Kind k, const std::vector<Expr>& children)
             return mkExpr(Kind::APPLY, rchildren);
           }
         }
+        case Attr::DATATYPE_CONSTRUCTOR:
+        {
+          // determine how many opaque children
+          Expr hdt = Expr(hd);
+          Expr t = d_tc.getType(hdt);
+          std::vector<Expr> cchildren(children.begin(), children.end());
+          if (t.getKind()==Kind::FUNCTION_TYPE && t[0].getKind()==Kind::QUOTE_TYPE)
+          {
+            // since it was not given an annotation
+            Expr rt = t.getFunctionType().second;
+            Expr ohd = mkExpr(Kind::APPLY_OPAQUE, {children[0], rt});
+            vchildren[0] = ohd.getValue();
+            return Expr(mkApplyInternal(vchildren));
+          }
+        }
         default:
           break;
       }

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1499,7 +1499,7 @@ Expr State::getOverloadInternal(const std::vector<Expr>& overloads,
   }
   // try overloads in order until one is found
   Expr tmp;
-  const ExprValue* retTypeExpect;
+  const ExprValue* rtExpect;
   for (size_t i=0, noverloads = overloads.size(); i<noverloads; i++)
   {
     // search in reverse order, i.e. the last bound symbol takes precendence
@@ -1516,12 +1516,12 @@ Expr State::getOverloadInternal(const std::vector<Expr>& overloads,
       Expr rt(retType);
       tmp = mkExpr(Kind::APPLY_OPAQUE, {cons, rt});
       vchildren[0] = tmp.getValue();
-      // don't expect type to match, as it may have arguments
-      retTypeExpect = nullptr;
+      // don't expect type to match, as it may be a functional type
+      rtExpect = nullptr;
     }
     else
     {
-      retTypeExpect = retType;
+      rtExpect = retType;
     }
     Expr x = vchildren.size() == 1
                  ? Expr(vchildren[0])
@@ -1532,7 +1532,7 @@ Expr State::getOverloadInternal(const std::vector<Expr>& overloads,
     Expr t = d_tc.getType(x);
     Trace("overload") << "...has type " << t << std::endl;
     // if term is well-formed, and matches the return type if it exists
-    if (!t.isNull() && (retTypeExpect==nullptr || retTypeExpect==t.getValue()))
+    if (!t.isNull() && (rtExpect==nullptr || rtExpect==t.getValue()))
     {
       // return the operator, do not check the remainder
       return Expr(vchildren[0]);

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1500,7 +1500,7 @@ Expr State::getOverloadInternal(const std::vector<Expr>& overloads,
     // search in reverse order, i.e. the last bound symbol takes precendence
     size_t ii = (noverloads-1)-i;
     vchildren[0] = overloads[ii].getValue();
-    if (getConstructorKind(vchildren[0]) == Attr::DATATYPE_CONSTRUCTOR)
+    if (getConstructorKind(vchildren[0]) == Attr::AMB_DATAYPE_CONSTRUCTOR)
     {
       Trace("overload") << "...maybe needs type argument?" << std::endl;
       Expr cons(vchildren[0]);

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1500,9 +1500,13 @@ Expr State::getOverloadInternal(const std::vector<Expr>& overloads,
     // search in reverse order, i.e. the last bound symbol takes precendence
     size_t ii = (noverloads-1)-i;
     vchildren[0] = overloads[ii].getValue();
+    // The syntax e.g. (eo::as nil (List Int)) has a different behavior.
+    // it does not distinguish a symbol but instead annotates the constructor
+    // symbol. This is done as an *opaque* argument to ensure type annotations
+    // are not in ordinary positions.
     if (getConstructorKind(vchildren[0]) == Attr::AMB_DATAYPE_CONSTRUCTOR)
     {
-      Trace("overload") << "...maybe needs type argument?" << std::endl;
+      Trace("overload") << "...type arg for ambiguous constructor" << std::endl;
       Expr cons(vchildren[0]);
       Expr rt(retType);
       tmp = mkExpr(Kind::APPLY_OPAQUE, {cons, rt});

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1494,13 +1494,24 @@ Expr State::getOverloadInternal(const std::vector<Expr>& overloads,
     vchildren.push_back(c.getValue());
   }
   // try overloads in order until one is found
+  Expr tmp;
   for (size_t i=0, noverloads = overloads.size(); i<noverloads; i++)
   {
     // search in reverse order, i.e. the last bound symbol takes precendence
     size_t ii = (noverloads-1)-i;
     vchildren[0] = overloads[ii].getValue();
+    if (getConstructorKind(vchildren[0]) == Attr::DATATYPE_CONSTRUCTOR)
+    {
+      Trace("overload") << "...maybe needs type argument?" << std::endl;
+      Expr cons(vchildren[0]);
+      Expr rt(retType);
+      tmp = mkExpr(Kind::APPLY_OPAQUE, {cons, rt});
+      vchildren[0] = tmp.getValue();
+    }
     Expr x = Expr(vchildren.size()>2 ? mkApplyInternal(vchildren) : mkExprInternal(Kind::APPLY, vchildren));
+    Trace("overload") << "...check type of " << x << std::endl;
     Expr t = d_tc.getType(x);
+    Trace("overload") << "...has type " << t << std::endl;
     // if term is well-formed, and matches the return type if it exists
     if (!t.isNull() && (retType==nullptr || retType==t.getValue()))
     {

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1499,6 +1499,7 @@ Expr State::getOverloadInternal(const std::vector<Expr>& overloads,
   }
   // try overloads in order until one is found
   Expr tmp;
+  const ExprValue* retTypeExpect;
   for (size_t i=0, noverloads = overloads.size(); i<noverloads; i++)
   {
     // search in reverse order, i.e. the last bound symbol takes precendence
@@ -1515,6 +1516,12 @@ Expr State::getOverloadInternal(const std::vector<Expr>& overloads,
       Expr rt(retType);
       tmp = mkExpr(Kind::APPLY_OPAQUE, {cons, rt});
       vchildren[0] = tmp.getValue();
+      // don't expect type to match, as it may have arguments
+      retTypeExpect = nullptr;
+    }
+    else
+    {
+      retTypeExpect = retType;
     }
     Expr x = vchildren.size() == 1
                  ? Expr(vchildren[0])
@@ -1525,7 +1532,7 @@ Expr State::getOverloadInternal(const std::vector<Expr>& overloads,
     Expr t = d_tc.getType(x);
     Trace("overload") << "...has type " << t << std::endl;
     // if term is well-formed, and matches the return type if it exists
-    if (!t.isNull() && (retType==nullptr || retType==t.getValue()))
+    if (!t.isNull() && (retTypeExpect==nullptr || retTypeExpect==t.getValue()))
     {
       // return the operator, do not check the remainder
       return Expr(vchildren[0]);

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1532,7 +1532,7 @@ Expr State::getOverloadInternal(const std::vector<Expr>& overloads,
     Expr t = d_tc.getType(x);
     Trace("overload") << "...has type " << t << std::endl;
     // if term is well-formed, and matches the return type if it exists
-    if (!t.isNull() && (rtExpect==nullptr || rtExpect==t.getValue()))
+    if (!t.isNull() && (rtExpect == nullptr || rtExpect == t.getValue()))
     {
       // return the operator, do not check the remainder
       return Expr(vchildren[0]);

--- a/src/state.h
+++ b/src/state.h
@@ -105,6 +105,10 @@ class State
   Expr mkBoolType();
   /** eo::List */
   Expr mkListType();
+  /** eo::List::cons */
+  Expr mkListCons();
+  /** eo::List::nil */
+  Expr mkListNil();
   /** (Proof <proven>) */
   Expr mkProofType(const Expr& proven);
   /** (Quote <term>) */

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -298,11 +298,12 @@ Expr TypeChecker::getTypeInternal(ExprValue* e, std::ostream* out)
     }
       break;
     case Kind::AS:
+    case Kind::AS_RETURN:
     {
       // constructing an application of AS means the type was incorrect.
       if (out)
       {
-        (*out) << "Encountered bad type for eo::as";
+        (*out) << "Encountered bad type for " << kindToTerm(k);
       }
       return d_null;
     }

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -1218,7 +1218,7 @@ Expr TypeChecker::evaluateLiteralOpInternal(
     case Kind::EVAL_DT_SELECTORS:
     {
       Expr sym(args[0]);
-      sym = sym.getKind()==Kind::APPLY_OPAQUE ? sym[0] : sym;
+      sym = sym.getKind() == Kind::APPLY_OPAQUE ? sym[0] : sym;
       AppInfo* ac = d_state.getAppInfo(sym.getValue());
       if (ac != nullptr)
       {

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -1217,6 +1217,8 @@ Expr TypeChecker::evaluateLiteralOpInternal(
     case Kind::EVAL_DT_CONSTRUCTORS:
     case Kind::EVAL_DT_SELECTORS:
     {
+      // it may be an ambiguous constructor with an annotation, in which
+      // case we extract the underlying symbol
       Expr sym(args[0]);
       sym = sym.getKind() == Kind::APPLY_OPAQUE ? sym[0] : sym;
       AppInfo* ac = d_state.getAppInfo(sym.getValue());

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -1217,7 +1217,9 @@ Expr TypeChecker::evaluateLiteralOpInternal(
     case Kind::EVAL_DT_CONSTRUCTORS:
     case Kind::EVAL_DT_SELECTORS:
     {
-      AppInfo* ac = d_state.getAppInfo(args[0]);
+      Expr sym(args[0]);
+      sym = sym.getKind()==Kind::APPLY_OPAQUE ? sym[0] : sym;
+      AppInfo* ac = d_state.getAppInfo(sym.getValue());
       if (ac != nullptr)
       {
         Assert(args[0]->isGround());

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -1225,7 +1225,8 @@ Expr TypeChecker::evaluateLiteralOpInternal(
       {
         Assert(args[0]->isGround());
         Attr a = ac->d_attrCons;
-        if (a == Attr::DATATYPE_CONSTRUCTOR || a == Attr::AMB_DATATYPE_CONSTRUCTOR)
+        if (a == Attr::DATATYPE_CONSTRUCTOR
+            || a == Attr::AMB_DATATYPE_CONSTRUCTOR)
         {
           return ac->d_attrConsTerm;
         }
@@ -1238,13 +1239,13 @@ Expr TypeChecker::evaluateLiteralOpInternal(
       // It might be a parametric datatype? We check if it is an apply and
       // that it is fully applied (i.e. its type is Type).
       bool isParam = false;
-      if (sym.getKind()==Kind::APPLY && getType(sym)==d_state.mkType())
+      if (sym.getKind() == Kind::APPLY && getType(sym) == d_state.mkType())
       {
         isParam = true;
         do
         {
           sym = sym[0];
-        }while (sym.getKind()==Kind::APPLY);
+        } while (sym.getKind() == Kind::APPLY);
       }
       AppInfo* ac = d_state.getAppInfo(sym.getValue());
       if (ac != nullptr && ac->d_attrCons == Attr::DATATYPE)
@@ -1255,12 +1256,16 @@ Expr TypeChecker::evaluateLiteralOpInternal(
         {
           std::vector<ExprValue*> cargs;
           Expr cop = d_state.mkListCons();
-          getNAryChildren(ac->d_attrConsTerm.getValue(), cop.getValue(), nullptr, cargs, false);
+          getNAryChildren(ac->d_attrConsTerm.getValue(),
+                          cop.getValue(),
+                          nullptr,
+                          cargs,
+                          false);
           std::vector<Expr> cargsp;
           for (ExprValue* c : cargs)
           {
             Expr ce(c);
-            if (d_state.getConstructorKind(c)==Attr::AMB_DATATYPE_CONSTRUCTOR)
+            if (d_state.getConstructorKind(c) == Attr::AMB_DATATYPE_CONSTRUCTOR)
             {
               Expr dt(args[0]);
               ce = d_state.mkExpr(Kind::APPLY_OPAQUE, {ce, dt});

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -1227,7 +1227,7 @@ Expr TypeChecker::evaluateLiteralOpInternal(
         Assert(args[0]->isGround());
         Attr a = ac->d_attrCons;
         if ((a == Attr::DATATYPE && k == Kind::EVAL_DT_CONSTRUCTORS)
-            || (a == Attr::DATATYPE_CONSTRUCTOR
+            || ((a == Attr::DATATYPE_CONSTRUCTOR || a == Attr::AMB_DATATYPE_CONSTRUCTOR)
                 && k == Kind::EVAL_DT_SELECTORS))
         {
           return ac->d_attrConsTerm;

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -1235,12 +1235,22 @@ Expr TypeChecker::evaluateLiteralOpInternal(
     case Kind::EVAL_DT_CONSTRUCTORS:
     {
       Expr sym(args[0]);
-      // might be a parametric datatype?
+      // It might be a parametric datatype? We check if it is an apply and
+      // that it is fully applied (i.e. its type is Type).
       bool isParam = false;
+      if (sym.getKind()==Kind::APPLY && getType(sym)==d_state.mkType())
+      {
+        isParam = true;
+        do
+        {
+          sym = sym[0];
+        }while (sym.getKind()==Kind::APPLY);
+      }
       AppInfo* ac = d_state.getAppInfo(sym.getValue());
       if (ac != nullptr && ac->d_attrCons == Attr::DATATYPE)
       {
-        // if parametric, add opaque argument annotations
+        // if parametric, add opaque argument annotations to constructors
+        // that are marked as AMB_DATATYPE_CONSTRUCTOR.
         if (isParam)
         {
           std::vector<ExprValue*> cargs;

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -1246,7 +1246,6 @@ Expr TypeChecker::evaluateLiteralOpInternal(
           sym = sym[0];
         }while (sym.getKind()==Kind::APPLY);
       }
-      Trace("ajr-temp") << "Get constructors " << Expr(args[0]) << " " << sym << ", isParam=" << isParam << std::endl;
       AppInfo* ac = d_state.getAppInfo(sym.getValue());
       if (ac != nullptr && ac->d_attrCons == Attr::DATATYPE)
       {

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -1246,6 +1246,7 @@ Expr TypeChecker::evaluateLiteralOpInternal(
           sym = sym[0];
         }while (sym.getKind()==Kind::APPLY);
       }
+      Trace("ajr-temp") << "Get constructors " << Expr(args[0]) << " " << sym << ", isParam=" << isParam << std::endl;
       AppInfo* ac = d_state.getAppInfo(sym.getValue());
       if (ac != nullptr && ac->d_attrCons == Attr::DATATYPE)
       {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -133,6 +133,7 @@ set(ethos_test_file_list
     simul-overload.eo
     bang-lex.eo
     segfault-98.eo
+    param-dt-parse.eo
 )
 
 if(ENABLE_ORACLES)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -134,6 +134,7 @@ set(ethos_test_file_list
     bang-lex.eo
     segfault-98.eo
     param-dt-parse.eo
+    param-dt-parse-amb-fun.eo
     datatypes-split-rule-param.eo
     datatypes-split-rule-param-uinst.eo
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -134,6 +134,8 @@ set(ethos_test_file_list
     bang-lex.eo
     segfault-98.eo
     param-dt-parse.eo
+    datatypes-split-rule-param.eo
+    datatypes-split-rule-param-uinst.eo
 )
 
 if(ENABLE_ORACLES)

--- a/tests/datatypes-split-rule-param-uinst.eo
+++ b/tests/datatypes-split-rule-param-uinst.eo
@@ -1,3 +1,6 @@
+; This version of the signature assumes testers are written e.g. (_ is nil), for the uninstantiated version of the constructor
+
+; helper method to get the *uninstantiated* form of the list of constructors of a datatype
 (program $dt_get_constructors ((D Type) (T Type) (DC (-> Type Type)))
   (Type) eo::List
   (
@@ -46,7 +49,7 @@
       (= x 
          (eo::define ((U (eo::typeof x)))
          ($mk_dt_inst (eo::dt_selectors c) x
-            ; start with the *instantiated* version of the constructor
+            ; start with the *instantiated* version of the constructor, which is at the same index
             (eo::list_nth 
               eo::List::cons 
               (eo::dt_constructors U) 

--- a/tests/datatypes-split-rule-param-uinst.eo
+++ b/tests/datatypes-split-rule-param-uinst.eo
@@ -57,4 +57,4 @@
 )
 
 (step @p1 (= (is cons x) (= x (cons (head x) (tail x)))) :rule dt-inst :args (cons x))
-(step @p1 (= (is nil x) (= x (eo::as nil (Lst Int)))) :rule dt-inst :args (nil x))
+(step @p1 (= (is nil x) (= x (as nil (Lst Int)))) :rule dt-inst :args (nil x))

--- a/tests/datatypes-split-rule-param-uinst.eo
+++ b/tests/datatypes-split-rule-param-uinst.eo
@@ -1,0 +1,57 @@
+(program $dt_get_constructors ((D Type) (T Type) (DC (-> Type Type)))
+  (Type) eo::List
+  (
+    (($dt_get_constructors (DC T))        ($dt_get_constructors DC))   ; user-defined parameteric datatypes, traverse
+    (($dt_get_constructors D)             (eo::dt_constructors D))     ; ordinary user-defined datatypes
+  )
+)
+
+(declare-type Int ())
+(declare-datatypes ((Lst 1)) ((par (X)((cons (head X) (tail (Lst X))) (nil)))))
+
+
+(declare-const is (-> (! Type :var C :implicit) (! Type :var D :implicit) C D Bool))
+(declare-const or (-> Bool Bool Bool) :right-assoc-nil false)
+(declare-const = (-> (! Type :var T :implicit) T T Bool))
+
+(program $mk_dt_split ((D Type) (x D) (T Type) (c T) (xs eo::List :list))
+  (eo::List D) Bool
+  (
+    (($mk_dt_split eo::List::nil x)          false)
+    (($mk_dt_split (eo::List::cons c xs) x)  (eo::cons or (is c x) ($mk_dt_split xs x)))
+  )
+)
+
+(declare-rule dt-split ((D Type) (x D))
+  :args (x)
+  :conclusion ($mk_dt_split ($dt_get_constructors (eo::typeof x)) x)
+)
+
+(declare-const x (Lst Int))
+
+(step @p0 (or (is cons x) (is nil x)) :rule dt-split :args (x))
+
+
+(program $mk_dt_inst ((D Type) (x D) (T Type) (t T) (S Type) (s S) (xs eo::List :list))
+  (eo::List D T) Bool
+  (
+    (($mk_dt_inst eo::List::nil x t)          t)
+    (($mk_dt_inst (eo::List::cons s xs) x t)  ($mk_dt_inst xs x (t (s x))))
+  )
+)
+
+(declare-rule dt-inst ((D Type) (T Type) (c T) (x D))
+  :args (c x)
+  :conclusion (= (is c x) 
+      (= x 
+         (eo::define ((U (eo::typeof x)))
+         ($mk_dt_inst (eo::dt_selectors c) x
+            ; start with the *instantiated* version of the constructor
+            (eo::list_nth 
+              eo::List::cons 
+              (eo::dt_constructors U) 
+              (eo::list_find eo::List::cons ($dt_get_constructors U) c))))))
+)
+
+(step @p1 (= (is cons x) (= x (cons (head x) (tail x)))) :rule dt-inst :args (cons x))
+(step @p1 (= (is nil x) (= x (eo::as nil (Lst Int)))) :rule dt-inst :args (nil x))

--- a/tests/datatypes-split-rule-param.eo
+++ b/tests/datatypes-split-rule-param.eo
@@ -1,3 +1,4 @@
+; This version of the signature assumes testers are written e.g. (_ is (as nil (Lst Int))), for the instantiated version of the constructor
 
 ; use SMT-LIB syntax for eo::as
 ;(define as ((T Type :implicit) (x T) (S Type)) (eo::as x S))

--- a/tests/datatypes-split-rule-param.eo
+++ b/tests/datatypes-split-rule-param.eo
@@ -1,0 +1,45 @@
+
+; use SMT-LIB syntax for eo::as
+;(define as ((T Type :implicit) (x T) (S Type)) (eo::as x S))
+
+(declare-type Int ())
+(declare-datatypes ((Lst 1)) ((par (X)((cons (head X) (tail (Lst X))) (nil)))))
+
+
+(declare-const is (-> (! Type :var C :implicit) (! Type :var D :implicit) C D Bool))
+(declare-const or (-> Bool Bool Bool) :right-assoc-nil false)
+(declare-const = (-> (! Type :var T :implicit) T T Bool))
+
+(program $mk_dt_split ((D Type) (x D) (T Type) (c T) (xs eo::List :list))
+  (eo::List D) Bool
+  (
+    (($mk_dt_split eo::List::nil x)          false)
+    (($mk_dt_split (eo::List::cons c xs) x)  (eo::cons or (is c x) ($mk_dt_split xs x)))
+  )
+)
+
+(declare-rule dt-split ((D Type) (x D))
+  :args (x)
+  :conclusion ($mk_dt_split (eo::dt_constructors (eo::typeof x)) x)
+)
+
+(declare-const x (Lst Int))
+
+(step @p0 (or (is cons x) (is (eo::as nil (Lst Int)) x)) :rule dt-split :args (x))
+
+
+(program $mk_dt_inst ((D Type) (x D) (T Type) (t T) (S Type) (s S) (xs eo::List :list))
+  (eo::List D T) Bool
+  (
+    (($mk_dt_inst eo::List::nil x t)          t)
+    (($mk_dt_inst (eo::List::cons s xs) x t)  ($mk_dt_inst xs x (t (s x))))
+  )
+)
+
+(declare-rule dt-inst ((D Type) (T Type) (c T) (x D))
+  :args (c x)
+  :conclusion (= (is c x) (= x ($mk_dt_inst (eo::dt_selectors c) x c)))
+)
+
+(step @p1 (= (is cons x) (= x (cons (head x) (tail x)))) :rule dt-inst :args (cons x))
+(step @p1 (= (is (eo::as nil (Lst Int)) x) (= x (eo::as nil (Lst Int)))) :rule dt-inst :args ((eo::as nil (Lst Int)) x))

--- a/tests/datatypes-split-rule-param.eo
+++ b/tests/datatypes-split-rule-param.eo
@@ -1,7 +1,7 @@
 ; This version of the signature assumes testers are written e.g. (_ is (as nil (Lst Int))), for the instantiated version of the constructor
 
-; use SMT-LIB syntax for eo::as
-;(define as ((T Type :implicit) (x T) (S Type)) (eo::as x S))
+; use SMT-LIB syntax for as
+;(define as ((T Type :implicit) (x T) (S Type)) (as x S))
 
 (declare-type Int ())
 (declare-datatypes ((Lst 1)) ((par (X)((cons (head X) (tail (Lst X))) (nil)))))
@@ -26,7 +26,7 @@
 
 (declare-const x (Lst Int))
 
-(step @p0 (or (is cons x) (is (eo::as nil (Lst Int)) x)) :rule dt-split :args (x))
+(step @p0 (or (is cons x) (is (as nil (Lst Int)) x)) :rule dt-split :args (x))
 
 
 (program $mk_dt_inst ((D Type) (x D) (T Type) (t T) (S Type) (s S) (xs eo::List :list))
@@ -43,4 +43,4 @@
 )
 
 (step @p1 (= (is cons x) (= x (cons (head x) (tail x)))) :rule dt-inst :args (cons x))
-(step @p1 (= (is (eo::as nil (Lst Int)) x) (= x (eo::as nil (Lst Int)))) :rule dt-inst :args ((eo::as nil (Lst Int)) x))
+(step @p1 (= (is (as nil (Lst Int)) x) (= x (as nil (Lst Int)))) :rule dt-inst :args ((as nil (Lst Int)) x))

--- a/tests/param-dt-parse-amb-fun.eo
+++ b/tests/param-dt-parse-amb-fun.eo
@@ -1,0 +1,14 @@
+
+(declare-type Int ())
+(declare-consts <numeral> Int)
+
+(declare-const @test (-> (! Type :opaque :var T) Int T))
+
+(define t () (@test Bool 0) :type Bool)
+
+(declare-datatypes ( (List 1) ) (
+(par ( X ) ( (nil (data Int)) (cons (head X) (tail (List X)))))
+))
+
+(define d1 () (_ (as nil (List Int)) 0) :type (List Int))
+(define d2 () (cons 0 d1) :type (List Int))

--- a/tests/param-dt-parse.eo
+++ b/tests/param-dt-parse.eo
@@ -10,4 +10,5 @@
 (par ( X ) ( (nil) (cons (head X) (tail (List X)))))
 ))
 
-(define d () (eo::as nil (List Int)) :type (List Int))
+(define d1 () (eo::as nil (List Int)) :type (List Int))
+(define d2 () (cons 0 d1) :type (List Int))

--- a/tests/param-dt-parse.eo
+++ b/tests/param-dt-parse.eo
@@ -1,0 +1,13 @@
+
+(declare-type Int ())
+(declare-consts <numeral> Int)
+
+(declare-const @test (-> (! Type :opaque :var T) Int T))
+
+(define t () (@test Bool 0) :type Bool)
+
+(declare-datatypes ( (List 1) ) (
+(par ( X ) ( (nil) (cons (head X) (tail (List X)))))
+))
+
+(define d () (eo::as nil (List Int)) :type (List Int))

--- a/tests/param-dt-parse.eo
+++ b/tests/param-dt-parse.eo
@@ -10,5 +10,5 @@
 (par ( X ) ( (nil) (cons (head X) (tail (List X)))))
 ))
 
-(define d1 () (eo::as nil (List Int)) :type (List Int))
+(define d1 () (as nil (List Int)) :type (List Int))
 (define d2 () (cons 0 d1) :type (List Int))

--- a/user_manual.md
+++ b/user_manual.md
@@ -1238,9 +1238,9 @@ Instances of ambiguous datatype constructors are expected to be annotated with t
 This denotes a constant (e.g. a term with zero arguments), whose type is `(Tree Int)`.
 
 > __Note:__ Internally, all ambiguous datatype constructors are instead defined to be of type `(-> (Quote T) T1 ... Tn T)`
-This is done automatically, so that for the aforementioned datatype, `(eo::typeof leaf) == (-> (Quote (Tree X)) (Tree X))`.
+This is done automatically, so that for the aforementioned datatype, the type of `leaf` is `(-> (Quote (Tree X)) (Tree X))`.
 Ethos interprets `(as leaf (Tree Int))` as `(_ leaf (Tree Int))`, where this is an "opaque" application (see [opaque](#opaque)).
-Conceptually, this means that (_ leaf (Tree Int)) is a constant symbol that is indexed by its type.
+Conceptually, this means that `(_ leaf (Tree Int))` is a constant symbol (with no children) that is indexed by its type.
 
 The semantics of `eo::dt_constructors` and `eo::dt_selectors` is overloaded to handle (annotated) constructors and (instantiated) parameteric datatypes.
 For example, given the previous definition, note the following:

--- a/user_manual.md
+++ b/user_manual.md
@@ -1226,14 +1226,14 @@ In detail, we say a datatype constructor is "ambiguous" if it of type:
 ```
 (-> T1 ... Tn T)
 ```
-where some free parameter of T is not contained in the free parameters of `T1, ..., Tn`. (Note n may be 0).
+where some free parameter of T is not contained in the free parameters of `T1, ..., Tn`. (Note `n` may be 0).
 
 All ambiguous datatype constructors are required to be annotated using the SMT-LIB 2.6 syntax `(as <constructor> <type>)`.
 For example:
 ```
 (declare-datatypes ((Tree 1)) ((par (X) (((node (left Tree) (data X) (right Tree)) (leaf))))))
 ```
-In the above example, `leaf` is an ambiguous datatype constructor, while `node` is not.
+In the this example, `leaf` is an ambiguous datatype constructor, while `node` is not.
 Instances of ambiguous datatype constructors are expected to be annotated with their return type using the syntax e.g. `(as leaf (Tree Int))`.
 This denotes a constant (e.g. a term with zero arguments), whose type is `(Tree Int)`.
 

--- a/user_manual.md
+++ b/user_manual.md
@@ -1257,6 +1257,8 @@ For example, given the previous definition, note the following:
 In particular, the constructors of a *fully* instantiated parameteric datatype are such that its ambiguous constructors are annotated in the return value, and its unambiguous constructors are included as-is.
 The selectors of a constructor (which are never ambiguous) are returned independently of whether the constructor is annotated.
 
+> __Note:__ Note that `eo::dt_constructors` does not evaluate on parametric types that are partially applied, e.g. `(eo::dt_constructors (Pair Int))` does not evaluate, where `Pair` expects two type parameters.
+
 ## Declaring Proof Rules
 
 The generic syntax for a `declare-rule` command accepted by `ethos` is:


### PR DESCRIPTION
This PR ensures ethos can properly parse and type check ambiguous datatype constructors in the SMT-LIB 2.X standard.

Say a datatype constructor is "ambiguous" if it of type:
```
(-> T1 ... Tn T)
```
where some free parameter of T is not contained in the free parameters of T1...Tn. (Note n may be 0).

To support ambiguous datatype constructors in Eunoia/Ethos, we require several things.

**(1) Their declared type is made unambiguous.**

In particular, all ambiguous datatype constructors are instead defined to be of type:
```
(-> (Quote T) T1 ... Tn T)
```
This is done automatically, so that for:
```
(declare-datatypes ((List 1)) ((par (X)((nil) (cons (head X) (tail (List X)))))))
```
If the user asked for the types of the constructors, they would get:
```
(eo::typeof nil) == (-> (Quote (List X)) (List X))
(eo::typeof cons) == (-> X (List X) (List X))
```

**(2) Type annotations on datatype constructors are treated as opaque applications.**

We expect `(as nil (List Int))` to be a constant of type `(List Int)`.

This is implemented by parsing `(as nil (List Int))` as `(_ nil (List Int))`, where this is an "opaque" application.

Effectively, this means that `(_ nil (List Int))` is a constant symbol that is indexed by its type.

Note in this understanding, Ethos is overloading the meaning of the `as` operator in SMT-LIB for two purposes. First, for overloaded symbols which is a way of determining which symbol is being referred to, and for parameteric datatypes where it is interpreted as being an (opaque) argument. Only the latter is implemented currently.

**(3) Extend the semantics of eo::dt_selectors.**

Currently, `(eo::dt_selectors c)` evaluates the list of selectors only if c is a constructor constant.

To handle ambiguous datatype constructors, we also say that `(eo::dt_selectors (_ c T))` evaluates to the list of selectors of `c`.

Example:
```
(eo::dt_selectors (as nil (List Int))) == eo::List::nil
```

**(4) Extend the semantics of eo::dt_constructors.**

Currently, `(eo::dt_constructors T)` evaluates the list of constructors only if `T` is an (uninstantiated) datatype type.

We extend this for instantiated datatypes to automatically apply the appropriate annotations. For example, 
```
(eo::dt_constructors List) == (eo::List::cons nil (eo::List::cons cons eo::List::nil))
(eo::dt_constructors (List T)) == (eo::List::cons (as nil (List T)) (eo::List::cons cons eo::List::nil))
```

**(5) The SMT-LIB syntax `as` is now parsed in Ethos (in all contexts).**

Note this only is processed when applied to ambiguous datatype constructors. Processing `as` for symbol disambiguation is still TODO.