### PR TITLE
Explicitly #include cstdint.h for GCC 15

### DIFF
--- a/src/expr.h
+++ b/src/expr.h
@@ -9,6 +9,7 @@
 #ifndef EXPR_H
 #define EXPR_H
 
+#include <cstdint>
 #include <map>
 #include <unordered_set>
 #include <vector>

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -10,6 +10,7 @@
 #define LEXER_H
 
 #include <array>
+#include <cstdint>
 #include <fstream>
 #include <iosfwd>
 #include <string>


### PR DESCRIPTION
GCC 15 has streamlined some headers, with the result that cstdint.h is no longer implicitly included in some places where it used to be.  The ethos build fails with error messages such as this:
```
In file included from /builddir/build/BUILD/ethos-0.1.1-build/ethos-ethos-0.1.1/src/lexer.cpp:9:
/builddir/build/BUILD/ethos-0.1.1-build/ethos-ethos-0.1.1/src/lexer.h:28:3: error: ‘uint32_t’ does not name a type
   28 |   uint32_t d_line;
      |   ^~~~~~~~
/builddir/build/BUILD/ethos-0.1.1-build/ethos-ethos-0.1.1/src/lexer.h:21:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
```
