### PR TITLE
ci: Build static binaries in CI

### DIFF
--- a/.github/actions/upload-artifact/action.yml
+++ b/.github/actions/upload-artifact/action.yml
@@ -28,10 +28,6 @@ runs:
         cp -r /mingw64/share/licenses/libwinpthread ./artifact/licenses/
         cp -r /mingw64/share/licenses/gcc-libs ./artifact/licenses/
         cp ${{ inputs.binary-dir }}/ethos.exe ./artifact/
-        cp /mingw64/bin/libgcc_s_seh-1.dll ./artifact/
-        cp /mingw64/bin/libstdc++-6.dll ./artifact/
-        cp /mingw64/bin/libwinpthread-1.dll ./artifact/
-        cp /mingw64/bin/libgmp-10.dll ./artifact/
 
     - name: Upload binary
       uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,16 +10,20 @@ jobs:
         build-type: [ release, debug ]
         include:
         - name: linux-x86_64
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           shell: bash
         - name: linux-arm64
           os: ubuntu-22.04-arm
           shell: bash
         - name: macOS-x86_64
           os: macos-13
+          bottle-suffix: monterey
+          gmp-sha256: b04023f65b8c79c45798a4bfd97fdbeb10f1bf9e8416e22e8eeedbd9b2a8c102
           shell: bash
         - name: macOS-arm64
           os: macos-14
+          bottle-suffix: arm64_monterey
+          gmp-sha256: 2115b33b8b4052f91ffb85e476c7fc0388cf4e614af1ce6453b35e6d25473911
           shell: bash
         - name: windows-x86_64
           os: windows-latest
@@ -43,7 +47,17 @@ jobs:
 
     - name: Set MACOSX_DEPLOYMENT_TARGET
       if: runner.os == 'macOS'
-      run: echo "MACOSX_DEPLOYMENT_TARGET=11.0" >> $GITHUB_ENV
+      run: echo "MACOSX_DEPLOYMENT_TARGET=12.0" >> $GITHUB_ENV
+
+    - name: Install Packages (macOS)
+      if: runner.os == 'macOS'
+      run: |
+        # Install GMP 6.3.0 bottle for macOS 12.0 (monterey)
+        # Ensure compatibility with older versions of macOS
+        GMP_BOTTLE=gmp-6.3.0.${{ matrix.bottle-suffix }}.bottle.tar.gz
+        curl -L -H "Authorization: Bearer QQ==" -o $GMP_BOTTLE \
+          https://ghcr.io/v2/homebrew/core/gmp/blobs/sha256:${{ matrix.gmp-sha256 }}
+        brew reinstall -f $GMP_BOTTLE
 
     - name: Install Packages (Linux)
       if: runner.os == 'Linux'
@@ -51,12 +65,6 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y \
           libgmp-dev
-
-    - name: Install Packages (macOS)
-      if: runner.os == 'macOS'
-      run: |
-        brew install \
-          gmp
 
     - name: Install Packages (Windows)
       uses: msys2/setup-msys2@v2
@@ -70,14 +78,22 @@ jobs:
           mingw-w64-x86_64-gcc
           mingw-w64-x86_64-gmp
 
+    - name: Set up num_proc variable
+      run: |
+        if [ "${{ runner.os }}" = "macOS" ]; then
+          echo "num_proc=$(( $(sysctl -n hw.logicalcpu) + 1 ))" >> $GITHUB_ENV
+        else
+          echo "num_proc=$(( $(nproc) + 1 ))" >> $GITHUB_ENV
+        fi
+
     - name: Build
       run: |
-        ./configure.sh ${{ matrix.build-type  }}
+        ./configure.sh ${{ matrix.build-type  }} --static
         cd build
-        make -j2
+        make -j${{ env.num_proc }}
 
     - name: Test
-      run: ctest --output-on-failure
+      run: ctest -j${{ env.num_proc }} --output-on-failure
       working-directory: build
 
     - name: Upload artifact


### PR DESCRIPTION
The binaries built in CI are currently used to publish new releases. It also updates the Ubuntu runner to version 22.04, as 20.04 is now deprecated.