### PR TITLE
Add --stats-all

### DIFF
--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -596,7 +596,7 @@ Expr ExprParser::parseExpr()
               // make the program variable, whose type is abstract
               Expr ftype = d_state.mkFunctionType(fargTypes, atype, false);
               std::stringstream pvname;
-              pvname << "_match_" << hd;
+              pvname << "eo::match_" << hd;
               Expr pv = d_state.mkSymbol(Kind::PROGRAM_CONST, pvname.str(), ftype);
               // process the cases
               std::vector<Expr> cases;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,6 +49,7 @@ int main( int argc, char* argv[] )
     bool isInclude = (arg.compare(0, 10, "--include=") == 0);
     if (isInclude || arg.compare(0, 12, "--reference=") == 0)
     {
+      // defer the inclusion until the options are finalized
       size_t first = arg.find_first_of("=");
       std::string file = arg.substr(first + 1);
       includes.emplace_back(file, isInclude);
@@ -142,6 +143,7 @@ int main( int argc, char* argv[] )
       EO_FATAL() << "Error: mulitple files specified, \"" << file << "\" and \"" << arg << "\"";
     }
   }
+  // options are finalized, now initialize the state and run the includes
   Stats stats;
   State s(opts, stats);
   Plugin* plugin = nullptr;

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -22,6 +22,7 @@ Options::Options()
   d_parseLet = true;
   d_printLet = false;
   d_stats = false;
+  d_statsAll = false;
   d_statsCompact = false;
   d_ruleSymTable = true;
   d_normalizeDecimal = true;
@@ -48,13 +49,16 @@ bool Options::setOption(const std::string& key, bool val)
   {
     d_stats = val;
   }
+  else if (key == "stats-all")
+  {
+    // also implies stats are enabled.
+    d_stats = val ? true : d_stats;
+    d_statsAll = val;
+  }
   else if (key == "stats-compact")
   {
-    if (val)
-    {
-      // also implies stats are enabled.
-      d_stats = val;
-    }
+    // also implies stats are enabled.
+    d_stats = val ? true : d_stats;
     d_statsCompact = val;
   }
   else if (key == "rule-sym-table")
@@ -86,9 +90,9 @@ State::State(Options& opts, Stats& stats)
     : d_hashCounter(0),
       d_hasReference(false),
       d_inGarbageCollection(false),
-      d_tc(*this, opts),
       d_opts(opts),
       d_stats(stats),
+      d_tc(*this, opts),
       d_plugin(nullptr)
 {
   ExprValue::d_state = this;

--- a/src/state.h
+++ b/src/state.h
@@ -38,6 +38,7 @@ class Options
   /** 'let' is lexed as the SMT-LIB syntax for a dag term specified by a let */
   bool d_parseLet;
   bool d_stats;
+  bool d_statsAll;
   bool d_statsCompact;
   bool d_ruleSymTable;
   bool d_normalizeDecimal;
@@ -332,12 +333,12 @@ class State
   /** Are we in garbage collection? */
   bool d_inGarbageCollection;
   //--------------------- utilities
-  /** Type checker */
-  TypeChecker d_tc;
   /** Options */
   Options& d_opts;
   /** Stats */
   Stats& d_stats;
+  /** Type checker */
+  TypeChecker d_tc;
   /** Plugin, if using one */
   Plugin* d_plugin;
 };

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -93,7 +93,7 @@ std::string Stats::toString(State& s, bool compact, bool all) const
   std::stringstream ss;
   if (!compact)
   {
-    ss << "========================================================================" << std::endl;
+    ss << "====================================================================================" << std::endl;
   }
   ss << "mkExprCount = " << d_mkExprCount << std::endl;
   ss << "newExprCount = " << d_exprCount << std::endl;

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -42,8 +42,8 @@ void RuleStat::increment(Stats& s)
 std::string RuleStat::toString(std::time_t totalTime) const
 {
   std::stringstream ss;
-  ss << std::left << std::setw(7) << d_count;
   std::stringstream st;
+  ss << std::left << std::setw(7) << d_count;
   double pct = static_cast<double>(100*d_time)/static_cast<double>(totalTime);
   st << d_time << " (" << std::fixed << std::setprecision(1) << pct << "%)";
   ss << std::left << std::setw(17) << st.str();
@@ -150,8 +150,8 @@ std::string Stats::toString(State& s, bool compact, bool all) const
       itr = rs.find(e);
       Assert (itr!=rs.end());
       const RuleStat& rs = itr->second;
-      std::stringstream sss;
-      sss << Expr(e);
+      std::stringstream ssExpr;
+      ssExpr << Expr(e);
       if (compact)
       {
         if (firstTime)
@@ -164,14 +164,14 @@ std::string Stats::toString(State& s, bool compact, bool all) const
           ssCheck << ", ";
           ssMkExpr << ", ";
         }
-        ssCount << sss.str() << ": " << rs.d_count;
-        ssCheck << sss.str() << ": " << rs.d_time;
-        ssMkExpr << sss.str() << ": " << rs.d_mkExprCount;
+        ssCount << ssExpr.str() << ": " << rs.d_count;
+        ssCheck << ssExpr.str() << ": " << rs.d_time;
+        ssMkExpr << ssExpr.str() << ": " << rs.d_mkExprCount;
       }
       else
       {
-        sss << ": ";
-        ss << std::right << std::setw(40) << sss.str();
+        ssExpr << ": ";
+        ss << std::right << std::setw(40) << ssExpr.str();
         if (i==0)
         {
           ss << rs.toString(totalTime) << std::endl;

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -42,13 +42,11 @@ void RuleStat::increment(Stats& s)
 std::string RuleStat::toString(std::time_t totalTime) const
 {
   std::stringstream ss;
+  ss << std::left << std::setw(7) << d_count;
   std::stringstream st;
   double pct = static_cast<double>(100*d_time)/static_cast<double>(totalTime);
   st << d_time << " (" << std::fixed << std::setprecision(1) << pct << "%)";
   ss << std::left << std::setw(17) << st.str();
-  std::stringstream sc;
-  sc << d_count;
-  ss << std::left << std::setw(7) << sc.str();
   // time per rule
   double timePerRule = static_cast<double>(d_time)/static_cast<double>(d_count);
   std::stringstream sp;
@@ -65,6 +63,9 @@ Stats::Stats() : d_mkExprCount(0), d_exprCount(0), d_deleteExprCount(0), d_symCo
   d_startTime = getCurrentTime();
 }
 
+/**
+ * Either sorts by time or by counts
+ */
 struct SortRuleTime
 {
   SortRuleTime(const std::map<const ExprValue*, RuleStat>& rs) : d_rstats(rs)
@@ -79,7 +80,11 @@ struct SortRuleTime
     std::map<const ExprValue*, RuleStat>::const_iterator itrj;
     itrj = d_rstats.find(j);
     Assert (itrj!=d_rstats.end());
-    return itri->second.d_time>itrj->second.d_time;
+    if (itri->second.d_time>itrj->second.d_time)
+    {
+      return true;
+    }
+    return itri->second.d_count>itrj->second.d_count;
   }
 };
 
@@ -97,38 +102,46 @@ std::string Stats::toString(State& s, bool compact) const
   ss << "litCount = " << d_litCount << std::endl;
   std::time_t totalTime = (getCurrentTime()-d_startTime);
   ss << "time = " << totalTime << std::endl;
-  if (!d_rstats.empty())
+  for (size_t i=0; i<2; i++)
   {
+    const std::map<const ExprValue*, RuleStat>& rs = i==0 ? d_rstats : d_pstats;
+    if (rs.empty())
+    {
+      continue;
+    }
     if (!compact)
     {
       ss << "========================================================================" << std::endl;
-      ss << std::right << std::setw(28) << "Rule  ";
-      ss << std::left << std::setw(17) << "t";
+      ss << std::right << std::setw(28) << (i==0 ? "Rule  " : "Program  ");
       ss << std::left << std::setw(7) << "#";
-      ss << std::left << std::setw(10) << "t/#";
-      ss << std::left << std::setw(10) << "#mkExpr";
+      if (i==1)
+      {
+        ss << std::left << std::setw(17) << "t";
+        ss << std::left << std::setw(10) << "t/#";
+        ss << std::left << std::setw(10) << "#mkExpr";
+      }
       ss << std::endl;
       ss << "========================================================================" << std::endl;
     }
     // display stats for each rule
     std::vector<const ExprValue*> sortedStats;
-    for (const std::pair<const ExprValue* const, RuleStat>& r : d_rstats)
+    for (const std::pair<const ExprValue* const, RuleStat>& r : rs)
     {
       sortedStats.push_back(r.first);
     }
     // sort based on time
-    SortRuleTime srt(d_rstats);
+    SortRuleTime srt(rs);
     std::sort(sortedStats.begin(), sortedStats.end(), srt);    
     std::map<const ExprValue*, RuleStat>::const_iterator itr;
+    std::stringstream ssCount;
     std::stringstream ssCheck;
     std::stringstream ssMkExpr;
     bool firstTime = true;
     for (const ExprValue* e : sortedStats)
     {
-      itr = d_rstats.find(e);
-      Assert (itr!=d_rstats.end());
+      itr = rs.find(e);
+      Assert (itr!=rs.end());
       const RuleStat& rs = itr->second;
-      Assert (e->getKind()==Kind::PROOF_RULE);
       std::stringstream sss;
       sss << Expr(e);
       if (compact)
@@ -139,22 +152,36 @@ std::string Stats::toString(State& s, bool compact) const
         }
         else
         {
+          ssCount << ", ";
           ssCheck << ", ";
           ssMkExpr << ", ";
         }
+        ssCount << sss.str() << ": " << rs.d_count;
         ssCheck << sss.str() << ": " << rs.d_time;
         ssMkExpr << sss.str() << ": " << rs.d_mkExprCount;
       }
       else
       {
         sss << ": ";
-        ss << std::right << std::setw(28) << sss.str() << rs.toString(totalTime) << std::endl;
+        ss << std::right << std::setw(28) << sss.str();
+        if (i==0)
+        {
+          ss << rs.toString(totalTime) << std::endl;
+        }
+        else
+        {
+          ss << rs.d_count << std::endl;
+        }
       }
     }
     if (compact)
     {
-      ss << "checkTime = { " << ssCheck.str() << " }" << std::endl;
-      ss << "mkExpr = { " << ssMkExpr.str() << " }" << std::endl;
+      ss << (i==0 ? "rule" : "prog") << "Count = { " << ssCount.str() << " }" << std::endl;
+      if (i==0)
+      {
+        ss << "checkTime = { " << ssCheck.str() << " }" << std::endl;
+        ss << "mkExpr = { " << ssMkExpr.str() << " }" << std::endl;
+      }
     }
   }
   return ss.str();

--- a/src/stats.h
+++ b/src/stats.h
@@ -47,7 +47,7 @@ public:
   std::time_t d_startTime;
   std::map<const ExprValue*, RuleStat> d_rstats;
   std::map<const ExprValue*, RuleStat> d_pstats;
-  std::string toString(State& s, bool compact) const;
+  std::string toString(State& s, bool compact, bool all) const;
 
   static std::time_t getCurrentTime();
 };

--- a/src/stats.h
+++ b/src/stats.h
@@ -46,6 +46,7 @@ public:
   size_t d_litCount;
   std::time_t d_startTime;
   std::map<const ExprValue*, RuleStat> d_rstats;
+  std::map<const ExprValue*, RuleStat> d_pstats;
   std::string toString(State& s, bool compact) const;
 
   static std::time_t getCurrentTime();

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -936,7 +936,11 @@ Expr TypeChecker::evaluateProgramInternal(
     Expr prog = d_state.getProgram(hd);
     if (d_statsEnabled)
     {
-      d_sts.d_pstats[prog.getValue()].d_count++;
+      Trace("type_checker") << "increment stat " << Expr(hd) << std::endl;
+      RuleStat * ps = &d_sts.d_pstats[hd];
+      Trace("type_checker") << "rule " << ps << std::endl;
+      ps->d_count++;
+      Trace("type_checker") << "...finish" << std::endl;
     }
     Assert (!prog.isNull());
     if (!prog.isNull())

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -936,11 +936,8 @@ Expr TypeChecker::evaluateProgramInternal(
     Expr prog = d_state.getProgram(hd);
     if (d_statsEnabled)
     {
-      Trace("type_checker") << "increment stat " << Expr(hd) << std::endl;
       RuleStat * ps = &d_sts.d_pstats[hd];
-      Trace("type_checker") << "rule " << ps << std::endl;
       ps->d_count++;
-      Trace("type_checker") << "...finish" << std::endl;
     }
     Assert (!prog.isNull());
     if (!prog.isNull())

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -24,7 +24,7 @@
 
 namespace ethos {
 
-TypeChecker::TypeChecker(State& s, Options& opts) : d_state(s), d_plugin(nullptr)
+TypeChecker::TypeChecker(State& s, Options& opts) : d_state(s), d_plugin(nullptr), d_sts(s.getStats())
 {
   std::set<Kind> literalKinds = { Kind::BOOLEAN, Kind::NUMERAL, Kind::RATIONAL, Kind::BINARY, Kind::STRING, Kind::DECIMAL, Kind::HEXADECIMAL };
   // initialize literal kinds 
@@ -32,6 +32,7 @@ TypeChecker::TypeChecker(State& s, Options& opts) : d_state(s), d_plugin(nullptr
   {
     d_literalTypeRules[k] = d_null;
   }
+  d_statsEnabled = opts.d_stats;
 }
 
 TypeChecker::~TypeChecker()
@@ -908,6 +909,21 @@ Expr TypeChecker::evaluateProgramInternal(
     // do not evaluate on non-ground
     return d_null;
   }
+  // Note we abort here, which changed in Ethos versions >=0.1.2.
+  // The motivation is to disallow unintuitive behaviors of Ethos,
+  // which includes:
+  // - Passing (unapplied) user programs, user oracles or builtin
+  // operators, which we do not support in this current version.
+  // - Passing stuck terms, where we chose to propagate the failure,
+  // e.g. (<program> t) is also stuck if t is stuck.
+  size_t nargs = children.size();
+  for (size_t j=1; j<nargs; j++)
+  {
+    if (children[j]->isEvaluatable())
+    {
+      return d_null;
+    }
+  }
   ExprValue* hd = children[0];
   Kind hk = hd->getKind();
   if (hk==Kind::PROGRAM_CONST)
@@ -917,8 +933,11 @@ Expr TypeChecker::evaluateProgramInternal(
       Trace("type_checker") << "RUN program " << children << std::endl;
       return d_plugin->evaluateProgram(hd, children, newCtx);
     }
-    size_t nargs = children.size();
     Expr prog = d_state.getProgram(hd);
+    if (d_statsEnabled)
+    {
+      d_sts.d_pstats[prog.getValue()].d_count++;
+    }
     Assert (!prog.isNull());
     if (!prog.isNull())
     {
@@ -939,20 +958,9 @@ Expr TypeChecker::evaluateProgramInternal(
           return d_null;
         }
         bool matchSuccess = true;
-        for (size_t i=1; i<nargs; i++)
+        for (size_t j = 1; j<nargs; j++)
         {
-          // Note we abort here, which changed in Ethos versions >=0.1.2.
-          // The motivation is to disallow unintuitive behaviors of Ethos,
-          // which includes:
-          // - Passing (unapplied) user programs, user oracles or builtin
-          // operators, which we do not support in this current version.
-          // - Passing stuck terms, where we chose to propagate the failure,
-          // e.g. (<program> t) is also stuck if t is stuck.
-          if (children[i]->isEvaluatable())
-          {
-            return d_null;
-          }
-          if (!match(hchildren[i], children[i], newCtx))
+          if (!match(hchildren[j], children[j], newCtx))
           {
             matchSuccess = false;
             break;
@@ -978,10 +986,9 @@ Expr TypeChecker::evaluateProgramInternal(
       return d_null;
     }
     int retVal;
-#if 1
     std::stringstream call_content;
     call_content << "(" << std::endl;
-    for (size_t i = 1, nchildren = children.size(); i < nchildren; i++)
+    for (size_t i = 1; i < nargs; i++)
     {
       call_content << Expr(children[i]) << std::endl;
     }
@@ -992,20 +999,6 @@ Expr TypeChecker::evaluateProgramInternal(
     Trace("oracles") << "```" << std::endl;
     std::stringstream response;
     retVal = run(ocmd, call_content.str(), response);
-#else
-    std::stringstream call;
-    call << ocmd;
-    for (size_t i = 1, nchildren = children.size(); i < nchildren; i++)
-    {
-      call << " " << Expr(children[i]);
-    }
-    Trace("oracles") << "Call oracle " << ocmd << " with content:" << std::endl;
-    Trace("oracles") << "```" << std::endl;
-    Trace("oracles") << call.str() << std::endl;
-    Trace("oracles") << "```" << std::endl;
-    std::stringstream response;
-    retVal = runFile(call.str(), response);
-#endif
     if (retVal!=0)
     {
       Trace("oracles") << "...failed to run" << std::endl;

--- a/src/type_checker.h
+++ b/src/type_checker.h
@@ -18,6 +18,7 @@
 namespace ethos {
 
 class State;
+class Stats;
 class Options;
 class Plugin;
 
@@ -123,6 +124,10 @@ class TypeChecker
   /** The null expression */
   Expr d_null;
   Expr d_negOne;
+  /** Stats enabled? */
+  bool d_statsEnabled;
+  /** Reference to the stats */
+  Stats& d_sts;
 };
 
 }  // namespace ethos

--- a/user_manual.md
+++ b/user_manual.md
@@ -1942,6 +1942,7 @@ The Ethos command line interface can be invoked by `ethos <option>* <file>` wher
 - `--reference=X`: includes the file specified by `X` as a reference file.
 - `--show-config`: displays the build information for the given binary.
 - `--stats`: enables detailed statistics.
+- `--stats-all`: enables all available statistics, including program invocations.
 - `--stats-compact`: print statistics in a compact format.
 - `-t <tag>`: enables the given trace tag (for debugging).
 - `-v`: verbose mode, enable all standard trace messages.


### PR DESCRIPTION
This adds a new class of statistics that counts the number of calls to programs, which can enable more fine grained profiling.

This also corrects a minor inconsistency in oracles/programs introduced in https://github.com/cvc5/ethos/pull/110, where the check for "stuck" terms should be applied uniformly for programs and oracles.

Example output:

```
========================================================================
mkExprCount = 793
newExprCount = 700
deleteExprCount = 69
symCount = 226
litCount = 7
time = 23904
====================================================================================
                                  Rule  #      t                t/#       #mkExpr   
====================================================================================
                          arith_sum_ub: 1      1565 (6.5%)      1565      46        
                        arith_mult_neg: 1      753 (3.2%)       753       25        
                        arith_mult_pos: 1      262 (1.1%)       262       22        
====================================================================================
                               Program  #      
====================================================================================
                         is_arith_type: 18
                  arith_typeunion_nary: 13
                       mk_arith_sum_ub: 4
                         arith_rel_sum: 3
                  mk_arith_sum_ub_step: 3
                         arith_rel_inv: 1
                     mk_arith_mult_pos: 1
                     mk_arith_mult_neg: 1
