### PR TITLE
Reduce pairwise and chainable for single arguments to neutral element

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@ ethos 0.1.2 prerelease
 - Adds support for the SMT-LIB `as` annotations for ambiguous datatype constructors, i.e. those whose return type cannot be inferred from its argument types. Following SMT-LIB convention, ambiguous datatype constructors are expected to be annotated with their *return* type using `as`, which internally is treated as a type argument to the constructor.
 - The semantics for `eo::dt_constructors` is extended for instantiated parametric datatypes. For example calling `eo::dt_constructors` on `(List Int)` returns the list containing `cons` and `(as nil (List Int))`.
 - The semantics for `eo::dt_selectors` is extended for annotated constructors. For example calling `eo::dt_selectors` on `(as nil (List Int))` returns the empty list.
+- Changed the semantics of pairwise and chainable operators for a single argument, which now reduces to the neutral element of the combining operator instead of a parse error.
+- Added the option `--stats-all` to track the number of times side conditions are invoked.
 
 ethos 0.1.1
 ===========

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -767,7 +767,15 @@ Expr State::mkExpr(Kind k, const std::vector<Expr>& children)
             Trace("type_checker") << "...return for " << children[0] << std::endl;
             return Expr(curr);
           }
-          // otherwise partial??
+          else
+          {
+            // Otherwise we are applying the operator to zero arguments. This 
+            // can never occur in standard parsing since it is not possible
+            // to apply a function to zero arguments. However, this case may
+            // arise if e.g. a pairwise or chainable operator is applied to
+            // exactly one argument, e.g. (distinct t) is equivalent to true.
+            return consTerm;
+          }
         }
           break;
         case Attr::CHAINABLE:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -140,6 +140,7 @@ set(ethos_test_file_list
     datatypes-split-rule-param.eo
     datatypes-split-rule-param-uinst.eo
     overload-define.eo
+    pairwise-singleton.eo
 )
 
 if(ENABLE_ORACLES)

--- a/tests/pairwise-singleton.eo
+++ b/tests/pairwise-singleton.eo
@@ -1,0 +1,19 @@
+
+(declare-const and (-> Bool Bool Bool) :right-assoc-nil true)
+(declare-const distinct (-> (! Type :var A :implicit) A A Bool) :pairwise and)
+
+(declare-const b Bool)
+
+(declare-const = (-> (! Type :var A :implicit) A A Bool) :chainable and)
+
+(define a () (= b) :type Bool)
+
+; chainable with one argument reduces to the neutral element
+(declare-const c1 (eo::requires a true Bool))
+(define test1 () c1 :type Bool)
+
+(define c () (distinct b) :type Bool)
+
+; pairwise with one argument reduces to the neutral element
+(declare-const c2 (eo::requires c true Bool))
+(define test1 () c2 :type Bool)

--- a/user_manual.md
+++ b/user_manual.md
@@ -503,7 +503,7 @@ In contrast, `(or x)` denotes the `or` whose children are `x` and `false`.
 (declare-type Int ())
 (declare-const and (-> Bool Bool Bool) :right-assoc)
 (declare-const >= (-> Int Int Bool) :chainable and)
-(define ((x Int) (y Int) (z Int)) (>= x y z))
+(define P ((x Int) (y Int) (z Int)) (>= x y z))
 (define Q ((x Int) (y Int)) (>= x y))
 ```
 

--- a/user_manual.md
+++ b/user_manual.md
@@ -502,7 +502,7 @@ In contrast, `(or x)` denotes the `or` whose children are `x` and `false`.
 ```smt
 (declare-type Int ())
 (declare-const and (-> Bool Bool Bool) :right-assoc)
-(declare-const >= (-> Int Int Bool) :chainable)
+(declare-const >= (-> Int Int Bool) :chainable and)
 (define ((x Int) (y Int) (z Int)) (>= x y z))
 (define Q ((x Int) (y Int)) (>= x y))
 ```
@@ -511,23 +511,29 @@ In the above example, `(>= x y z w)` is syntax sugar for `(and (>= x y) (>= y z)
 whereas the term `(>= x y)` is not impacted by the annotation `:chainable` since it has fewer than 3 children.
 
 Note that the type for chainable operators is typically `(-> T T S)` for some types `T` and `S`,
-where the type of its chaining operator is `(-> S S S)`, and that operator has been as variadic via some attribute (e.g. `:right-assoc`).
+where the type of its combining operator is `(-> S S S)`, and that operator has been as variadic via some attribute (e.g. `:right-assoc`).
+
+A chainable operator applied to a single argument reduces to the neutral element of the combining operator.
+For example, `(>= x)` is equivalent to `true`.
 
 #### Pairwise
 
 ```smt
 (declare-type Int ())
 (declare-const and (-> Bool Bool Bool) :right-assoc)
-(declare-const distinct (-> (! Type :var T :implicit) T T Bool)
- :pairwise and)
+(declare-const distinct (-> (! Type :var T :implicit) T T Bool) :pairwise and)
 (define P ((x Int) (y Int) (z Int)) (distinct x y z))
 ```
 
 In the above example, `(distinct x y z)` is treated as `(and (distinct x y) (distinct x z) (distinct y z))`.
 
 Note that the type for pairwise operators is typically `(-> T T S)` for some types `T` and `S`,
-where the type of its pairwise operator is `(-> S S S)`,
+where the type of its combining operator is `(-> S S S)`,
 and that operator has been marked as variadic via some attribute.
+
+Similar to chainable operators,
+a pairwise operator applied to a single argument reduces to the neutral element of the combining operator.
+For example, `(distinct x)` is equivalent to `true`.
 
 <a name="binders"></a>
 

--- a/user_manual.md
+++ b/user_manual.md
@@ -511,7 +511,7 @@ In the above example, `(>= x y z w)` is syntax sugar for `(and (>= x y) (>= y z)
 whereas the term `(>= x y)` is not impacted by the annotation `:chainable` since it has fewer than 3 children.
 
 Note that the type for chainable operators is typically `(-> T T S)` for some types `T` and `S`,
-where the type of its combining operator is `(-> S S S)`, and that operator has been as variadic via some attribute (e.g. `:right-assoc`).
+where the type of its combining operator is `(-> S S S)`, and that operator has been marked as variadic via some attribute (e.g. `:right-assoc`).
 
 A chainable operator applied to a single argument reduces to the neutral element of the combining operator.
 For example, `(>= x)` is equivalent to `true`.


### PR DESCRIPTION
Following the discussion on https://github.com/cvc5/ethos/issues/118.