### PR TITLE
Dagify output by default, change syntax to eo::define

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ ethos 0.1.2 prerelease
 - Adds support for the SMT-LIB `as` annotations for ambiguous datatype constructors, i.e. those whose return type cannot be inferred from its argument types. Following SMT-LIB convention, ambiguous datatype constructors are expected to be annotated with their *return* type using `as`, which internally is treated as a type argument to the constructor.
 - The semantics for `eo::dt_constructors` is extended for instantiated parametric datatypes. For example calling `eo::dt_constructors` on `(List Int)` returns the list containing `cons` and `(as nil (List Int))`.
 - The semantics for `eo::dt_selectors` is extended for annotated constructors. For example calling `eo::dt_selectors` on `(as nil (List Int))` returns the empty list.
+- The option `--print-let` has been renamed to `--print-dag` and is now enabled by default. The printer is changed to use `eo::define` instead of `let`.
 
 ethos 0.1.1
 ===========

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -364,7 +364,7 @@ void Expr::printDebug(const Expr& e, std::ostream& os)
 {
   std::map<const ExprValue*, size_t> lbind;
   std::string cparen;
-  if (ExprValue::d_state->getOptions().d_printLet)
+  if (ExprValue::d_state->getOptions().d_printDag)
   {
     std::vector<Expr> ll;
     lbind = computeLetBinding(e, ll);
@@ -373,7 +373,7 @@ void Expr::printDebug(const Expr& e, std::ostream& os)
     {
       const ExprValue* lv = l.getValue();
       size_t id = lbind[lv];
-      os << "(let ((_v" << id << " ";
+      os << "(eo::define ((_v" << id << " ";
       lbind.erase(lv);
       printDebugInternal(l, os, lbind);
       lbind[lv] = id;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,7 +65,7 @@ int main( int argc, char* argv[] )
       out << " --no-normalize-dec: do not treat decimal literals as syntax sugar for rational literals." << std::endl;
       out << " --no-normalize-hex: do not treat hexadecimal literals as syntax sugar for binary literals." << std::endl;
       out << "     --no-parse-let: do not treat let as a builtin symbol for specifying terms having shared subterms." << std::endl;
-      out << "     --no-print-let: do not letify the output of terms in error messages and trace messages." << std::endl;
+      out << "     --no-print-dag: do not dagify the output of terms in error messages and trace messages." << std::endl;
       out << "--no-rule-sym-table: do not use a separate symbol table for proof rules and declared terms." << std::endl;
       out << "      --reference=X: includes the file specified by X as a reference file." << std::endl;
       out << "      --show-config: displays the build information for this binary." << std::endl;

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -20,7 +20,7 @@ namespace ethos {
 Options::Options()
 {
   d_parseLet = true;
-  d_printLet = false;
+  d_printDag = true;
   d_stats = false;
   d_statsAll = false;
   d_statsCompact = false;
@@ -41,9 +41,9 @@ bool Options::setOption(const std::string& key, bool val)
   {
     d_parseLet = val;
   }
-  else if (key == "print-let")
+  else if (key == "print-dag")
   {
-    d_printLet = val;
+    d_printDag = val;
   }
   else if (key == "stats")
   {

--- a/src/state.h
+++ b/src/state.h
@@ -34,7 +34,7 @@ class Options
    * @return true if the option was successfully set.
    */
   bool setOption(const std::string& key, bool val);
-  bool d_printLet;
+  bool d_printDag;
   /** 'let' is lexed as the SMT-LIB syntax for a dag term specified by a let */
   bool d_parseLet;
   bool d_stats;

--- a/user_manual.md
+++ b/user_manual.md
@@ -1937,7 +1937,7 @@ The Ethos command line interface can be invoked by `ethos <option>* <file>` wher
 
 - `--help`: displays a help message.
 - `--include=X`: includes the file specified by `X`.
-- `--no-print-let`: do not letify the output of terms in error messages and trace messages.
+- `--no-print-dag`: do not dagify the output of terms in error messages and trace messages.
 - `--no-rule-sym-table`: do not use a separate symbol table for proof rules and declared terms.
 - `--reference=X`: includes the file specified by `X` as a reference file.
 - `--show-config`: displays the build information for the given binary.


### PR DESCRIPTION
Fixes https://github.com/cvc5/ethos/issues/121.