### PR TITLE
Do not return non-ground types with eo::typeof

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ ethos 0.1.2 prerelease
 - The semantics for `eo::dt_constructors` is extended for instantiated parametric datatypes. For example calling `eo::dt_constructors` on `(List Int)` returns the list containing `cons` and `(as nil (List Int))`.
 - The semantics for `eo::dt_selectors` is extended for annotated constructors. For example calling `eo::dt_selectors` on `(as nil (List Int))` returns the empty list.
 - The option `--print-let` has been renamed to `--print-dag` and is now enabled by default. The printer is changed to use `eo::define` instead of `let`.
+- The operator `eo::typeof` now is unevaluated if the type of the given term is not ground.
 
 ethos 0.1.1
 ===========

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@ ethos 0.1.2 prerelease
 - The semantics for `eo::dt_constructors` is extended for instantiated parametric datatypes. For example calling `eo::dt_constructors` on `(List Int)` returns the list containing `cons` and `(as nil (List Int))`.
 - The semantics for `eo::dt_selectors` is extended for annotated constructors. For example calling `eo::dt_selectors` on `(as nil (List Int))` returns the empty list.
 - The option `--print-let` has been renamed to `--print-dag` and is now enabled by default. The printer is changed to use `eo::define` instead of `let`.
-- The operator `eo::typeof` now is unevaluated if the type of the given term is not ground.
+- The operator `eo::typeof` now fails to evaluate if the type of the given term is not ground.
 
 ethos 0.1.1
 ===========

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -1185,7 +1185,13 @@ Expr TypeChecker::evaluateLiteralOpInternal(
       if (isGround(args))
       {
         Expr e(args[0]);
-        return getType(e);
+        Expr et = getType(e);
+        if (et.isGround())
+        {
+          // don't permit ground evaluatable types
+          Assert (!et.isEvaluatable());
+          return et;
+        }
       }
       return d_null;
     }

--- a/user_manual.md
+++ b/user_manual.md
@@ -654,7 +654,7 @@ Note, however, that the evaluation of these operators is handled by more efficie
 - `(eo::hash t1)`
   - If `t1` is a ground term, this returns a numeral that is unique to `t1`.
 - `(eo::typeof t1)`
-  - If `t1` is a ground term, this returns the type of `t1`.
+  - If `t1` is a ground term, this returns the type of `t1` if its type is ground.
 - `(eo::nameof t1)`
   - If `t1` is a ground constant or variable, this returns the name of `t1`, i.e. the string corresponding to the symbol it was declared with.
 - `(eo::var t1 t2)`


### PR DESCRIPTION
`eo::typeof` is an exceptional case in that it can return a term with free parameters. It is the only such operator that may do so.  This behavior is fairly unintuitive and moreover allows non-first-class terms e.g. `Quote` to appear in terms.

We instead make it so that `eo::typeof` does not evaluate if the type is non-ground.