### PR TITLE
Guard use of builtin operators in argument positions

### DIFF
--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -280,6 +280,12 @@ Expr ExprParser::parseExpr()
       {
         std::string name = tokenStrToSymbol(tok);
         ret = getVar(name);
+        if (ret.getKind()==Kind::BUILTIN_CONST)
+        {
+          std::stringstream ss;
+          ss << "Cannot use \"" << name << "\" as a first-class term.";
+          d_lex.parseError(ss.str());
+        }
       }
       break;
       case Token::INTEGER_LITERAL:

--- a/src/kind.cpp
+++ b/src/kind.cpp
@@ -29,6 +29,7 @@ std::ostream& operator<<(std::ostream& o, Kind k)
     case Kind::LAMBDA: o << "LAMBDA"; break;
     case Kind::PARAM: o << "PARAM"; break;
     case Kind::CONST: o << "CONST"; break;
+    case Kind::BUILTIN_CONST: o << "BUILTIN_CONST"; break;
     case Kind::PROGRAM_CONST: o << "PROGRAM_CONST"; break;
     case Kind::PROOF_RULE: o << "PROOF_RULE"; break;
     case Kind::VARIABLE: o << "VARIABLE"; break;

--- a/src/kind.h
+++ b/src/kind.h
@@ -42,6 +42,7 @@ enum class Kind
   // symbols
   PARAM,
   CONST,
+  BUILTIN_CONST,    // used for e.g. _, ->, eo::*, as, etc. which are temporary during parsing only
   PROGRAM_CONST,
   PROOF_RULE,
   VARIABLE,

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1453,6 +1453,9 @@ void State::bindBuiltin(const std::string& name, Kind k, Attr ac, const Expr& t)
     ai.d_kind = k;
     ai.d_attrCons = ac;
   }
+  // mark it evaluatable, which prevents e.g. eo::add as being passed as an
+  // argument to other operators or side conditions.
+  c.getValue()->d_flags = static_cast<uint8_t>(ExprValue::Flag::IS_FLAGS_COMPUTED) | static_cast<uint8_t>(ExprValue::Flag::IS_EVAL);
 }
 
 void State::bindBuiltinEval(const std::string& name, Kind k, Attr ac)

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1444,7 +1444,7 @@ void State::bindBuiltin(const std::string& name, Kind k, Attr ac)
 
 void State::bindBuiltin(const std::string& name, Kind k, Attr ac, const Expr& t)
 {
-  Expr c = mkSymbol(Kind::CONST, name, t);
+  Expr c = mkSymbol(Kind::BUILTIN_CONST, name, t);
   bind(name, c);
   if (ac!=Attr::NONE || k!=Kind::NONE)
   {
@@ -1453,9 +1453,6 @@ void State::bindBuiltin(const std::string& name, Kind k, Attr ac, const Expr& t)
     ai.d_kind = k;
     ai.d_attrCons = ac;
   }
-  // mark it evaluatable, which prevents e.g. eo::add as being passed as an
-  // argument to other operators or side conditions.
-  c.getValue()->d_flags = static_cast<uint8_t>(ExprValue::Flag::IS_FLAGS_COMPUTED) | static_cast<uint8_t>(ExprValue::Flag::IS_EVAL);
 }
 
 void State::bindBuiltinEval(const std::string& name, Kind k, Attr ac)


### PR DESCRIPTION
This prevents us from using e.g. `->`, `_`, `as`, `eo::*` as arguments to other functions.

This was not properly guarded since these symbols are bound in the symbol table, and not lexed as heads of applications for simplicity.