### PR TITLE
Minor fixes

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -255,7 +255,6 @@ std::map<const ExprValue*, size_t> Expr::computeLetBinding(
     if (visited.find(cv) == visited.end())
     {
       visited.insert(cv);
-      llv.push_back(cur);
       for (size_t i = 0, nchildren = cur.getNumChildren(); i < nchildren; i++)
       {
         visit.push_back(cur[i]);
@@ -264,13 +263,14 @@ std::map<const ExprValue*, size_t> Expr::computeLetBinding(
     }
     if (lbind.find(cv) == lbind.end())
     {
+      llv.push_back(cur);
       lbind[cv] = idc;
       idc++;
     }
   }while(!visit.empty());
   for (size_t i=0, lsize = llv.size(); i<lsize; i++)
   {
-    const Expr& l = llv[lsize - 1 - i];
+    const Expr& l = llv[i];
     const ExprValue* lv = l.getValue();
     if (lbind.find(lv) != lbind.end())
     {

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -238,6 +238,7 @@ std::map<const ExprValue*, size_t> Expr::computeLetBinding(
 {
   size_t idc = 0;
   std::map<const ExprValue*, size_t> lbind;
+  std::map<const ExprValue*, size_t> lcount;
   std::unordered_set<const ExprValue*> visited;
   std::vector<Expr> visit;
   std::vector<Expr> llv;
@@ -246,9 +247,9 @@ std::map<const ExprValue*, size_t> Expr::computeLetBinding(
   do
   {
     cur = visit.back();
-    visit.pop_back();
     if (cur.getNumChildren() == 0)
     {
+      visit.pop_back();
       continue;
     }
     const ExprValue* cv = cur.getValue();
@@ -261,20 +262,26 @@ std::map<const ExprValue*, size_t> Expr::computeLetBinding(
       }
       continue;
     }
-    if (lbind.find(cv) == lbind.end())
+    visit.pop_back();
+    if (lcount.find(cv)==lcount.end())
     {
       llv.push_back(cur);
       lbind[cv] = idc;
       idc++;
     }
+    lcount[cv]++;
   }while(!visit.empty());
   for (size_t i=0, lsize = llv.size(); i<lsize; i++)
   {
     const Expr& l = llv[i];
     const ExprValue* lv = l.getValue();
-    if (lbind.find(lv) != lbind.end())
+    if (lcount[lv]>1)
     {
       ll.push_back(l);
+    }
+    else
+    {
+      lbind.erase(lv);
     }
   }
   return lbind;

--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -837,7 +837,7 @@ std::vector<std::pair<Expr, Expr>> ExprParser::parseAndBindLetList()
     t = parseExpr();
     d_lex.eatToken(Token::RPAREN);
     tt = typeCheck(t);
-    v = d_state.mkSymbol(Kind::VARIABLE, name, tt);
+    v = d_state.getBoundVar(name, tt);
     letList.emplace_back(v, t);
   }
   // now perform the bindings, which bind to the variable, not its definition

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -1598,7 +1598,6 @@ bool TypeChecker::computedParameterizedInternal(AppInfo* ai,
     {
       // if not in an application, we fail
       Warning() << "Failed to determine parameters for " << hd << std::endl;
-      AlwaysAssert(false);
       return false;
     }
     else


### PR DESCRIPTION
Makes a few minor fixes:
1. Terms constructed via `:let-binder` were not using canonical bound variables.
2. We were throwing an assertion failure in cases e.g. `(eo::nil bvor)`, which should instead be caught and reported as a user error,
3. We were not printing `eo::define` in the printer in the proper order. 