### PR TITLE
Do not permit empty binary/hexadecimal constants

### DIFF
--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -239,13 +239,19 @@ Token Lexer::computeNextToken()
       {
         case 'b':
           pushToToken(ch);
-          // parse [01]*
-          parseCharList(CharacterClass::BIT);
+          // parse [01]+
+          if (!parseNonEmptyCharList(CharacterClass::BIT))
+          {
+            parseError("Error expected bit string");
+          }
           return Token::BINARY_LITERAL;
         case 'x':
           pushToToken(ch);
-          // parse [0-9a-fA-F]*
-          parseCharList(CharacterClass::HEXADECIMAL_DIGIT);
+          // parse [0-9a-fA-F]+
+          if (!parseNonEmptyCharList(CharacterClass::HEXADECIMAL_DIGIT))
+          {
+            parseError("Error expected hexadecimal string");
+          }
           return Token::HEX_LITERAL;
         default:
           // otherwise error


### PR DESCRIPTION
Initially I wanted to support the syntax `#b`, but this was never properly added and can be accomplished by `(eo::to_bin 0 0)`.

Currently we give an unintuitive error, this fixes this case.