### PR TITLE
Allow qualified identifiers as heads of applications

### DIFF
--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -175,9 +175,11 @@ Expr ExprParser::parseExpr()
             // we allow the syntax ((_ to begin a term
             pstack.emplace_back(ParseCtx::NEXT_ARG);
             tok = d_lex.nextToken();
-            if (tokenStrToSymbol(tok)!="_" && tokenStrToSymbol(tok)!="as")
+            if (tokenStrToSymbol(tok) != "_" && tokenStrToSymbol(tok) != "as")
             {
-              d_lex.parseError("Expected qualified identifier or indexed symbol as head of apply");
+              d_lex.parseError(
+                  "Expected qualified identifier or indexed symbol as head of "
+                  "apply");
             }
           }
           case Token::SYMBOL:

--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -175,9 +175,9 @@ Expr ExprParser::parseExpr()
             // we allow the syntax ((_ to begin a term
             pstack.emplace_back(ParseCtx::NEXT_ARG);
             tok = d_lex.nextToken();
-            if (tokenStrToSymbol(tok)!="_")
+            if (tokenStrToSymbol(tok)!="_" && tokenStrToSymbol(tok)!="as")
             {
-              d_lex.parseError("Expected indexed symbol as head of apply");
+              d_lex.parseError("Expected qualified identifier or indexed symbol as head of apply");
             }
           }
           case Token::SYMBOL:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -145,6 +145,7 @@ set(ethos_test_file_list
     quote-opaque.eo
     quote-requires.eo
     set-empty-amb.eo
+    const-array.eo
 )
 
 if(ENABLE_ORACLES)

--- a/tests/const-array.eo
+++ b/tests/const-array.eo
@@ -1,0 +1,11 @@
+
+(declare-type Int ())
+(declare-consts <numeral> Int)
+
+(declare-type Array (Type Type))
+
+; The store all array constant.
+(declare-parameterized-const const ((T Type :implicit) (U Type :implicit)) (-> U (Array T U)))
+
+
+(define foo () ((as const (Array Int Int)) 0) :type (Array Int Int))


### PR DESCRIPTION
We initially did not plan to have general support for `as`; support for parsing it as a head of an application was missing, which is fixed by this PR. A regression is added.