### PR TITLE
Fix handling of bound variables with non-ground type

### DIFF
--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1283,7 +1283,7 @@ Expr State::getBoundVar(const std::string& name, const Expr& type)
   if (!type.isGround())
   {
     // If the type is non-ground, we cannot evaluate it yet. Moreover this is
-    // not cached
+    // not cached here, instead it is cached as part of mkExpr.
     Expr ename = mkLiteral(Kind::STRING, name);
     return mkExpr(Kind::EVAL_VAR, {ename, type});
   }

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1280,6 +1280,13 @@ Expr State::getVar(const std::string& name) const
 
 Expr State::getBoundVar(const std::string& name, const Expr& type)
 {
+  if (!type.isGround())
+  {
+    // If the type is non-ground, we cannot evaluate it yet. Moreover this is
+    // not cached
+    Expr ename = mkLiteral(Kind::STRING, name);
+    return mkExpr(Kind::EVAL_VAR, {ename, type});
+  }
   std::pair<std::string, const ExprValue*> key(name, type.getValue());
   std::map<std::pair<std::string, const ExprValue*>, Expr>::iterator it = d_boundVars.find(key);
   if (it!=d_boundVars.end())

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -146,6 +146,7 @@ set(ethos_test_file_list
     quote-requires.eo
     set-empty-amb.eo
     const-array.eo
+    type-var-exists.eo
 )
 
 if(ENABLE_ORACLES)

--- a/tests/type-var-exists.eo
+++ b/tests/type-var-exists.eo
@@ -1,0 +1,13 @@
+
+
+(declare-type Int ())
+
+(declare-const exists (-> eo::List Bool Bool) :binder eo::List::cons)
+(declare-parameterized-const = ((A Type :implicit)) (-> A A Bool))
+
+(declare-rule exists-refl ((T Type))
+  :args (T)
+  :conclusion (exists ((x T)) (= x x)))
+
+  
+(step @p0 (exists ((x Int)) (= x x)) :rule exists-refl :args (Int))


### PR DESCRIPTION
This corrects an issue in how binders were parsed: in certain contexts, we could construct a variable whose type is non-ground.  However, based on the understood desugaring of binders which uses `(eo::var <name> <type>)`, this application should wait to evaluate until `<type>` becomes ground.

A regression is added that fails before but now succeeds.