### PR TITLE
Change eo::is_eq, add eo::eq and eo::is_ok

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,10 +3,10 @@ This file contains a summary of important user-visible changes.
 ethos 0.1.2 prerelease
 ======================
 
-- Change the execution semantics when a program takes an unevalated term as an argument. In particular, we do not call user provided programs and oracles when at least argument could not be evaluated. This change was made to make errors more intuitive. Note this changes the semantics of programs that previously relied on being called on unevaluated terms.
+- Change the execution semantics when a program takes an unevalated term as an argument. In particular, we do not call user provided programs and oracles when at least one argument could not be evaluated. This change was made to make errors more intuitive. Note this changes the semantics of programs that previously relied on being called on unevaluated terms.
+- Change the semantics of a corner case of `eo::is_eq`. In particular, `eo::is_eq` now returns false if given two syntactically equivalent terms whose evaluation is stuck. This change also impacts the semantics of `eo::requires`, which evaluates to the third argument if and only if the first two arguments are syntactically equivalent *and* are fully evaluated.
 - User programs, user oracles, and builtin operators that are unapplied are now considered unevaluated. This makes the type checker more strict and disallows passing them as arguments to other programs, which previously led to undefined behavior.
 - Changes the interface of `declare-parameterized-const`. In particular, the parameters of a parameterized constants are no longer assumed to be implicit, and are explicit by default. The `:implicit` attribute can be used on all parameters to recover the previous behavior. Other attributes such as `:opaque` and `:requires` can now be used on parameters to this command.
-- Remove support for the explicit parameter annotation `eo::_`, which was used to provide annotations for implicit arguments to parameterized constants.
 - Changed the semantics of pairwise and chainable operators for a single argument, which now reduces to the neutral element of the combining operator instead of a parse error.
 - The operator `eo::typeof` now fails to evaluate if the type of the given term is not ground.
 
@@ -14,11 +14,13 @@ ethos 0.1.2 prerelease
 - The semantics for `eo::dt_constructors` is extended for instantiated parametric datatypes. For example calling `eo::dt_constructors` on `(List Int)` returns the list containing `cons` and `(as nil (List Int))`.
 - The semantics for `eo::dt_selectors` is extended for annotated constructors. For example calling `eo::dt_selectors` on `(as nil (List Int))` returns the empty list.
 
+- Adds builtin primitives `eo::eq` and `eo::is_ok`.
 - Added the option `--stats-all` to track the number of times side conditions are invoked.
 - The option `--print-let` has been renamed to `--print-dag` and is now enabled by default. The printer is changed to use `eo::define` instead of `let`.
 - Ethos now explicitly forbids `:var`, `:implicit`, and `:opaque` on return types.
 - The option `--binder-fresh`, which specified for fresh variables to be constructed when parsing binders, has been removed.
 - Programs and oracles now are explicitly required to have at least one argument.
+- Remove support for the explicit parameter annotation `eo::_`, which was used to provide annotations for implicit arguments to parameterized constants.
 
 ethos 0.1.1
 ===========

--- a/src/kind.cpp
+++ b/src/kind.cpp
@@ -51,6 +51,7 @@ std::ostream& operator<<(std::ostream& o, Kind k)
     case Kind::BINARY: o << "BINARY"; break;
     case Kind::STRING: o << "STRING"; break;
     // operations on literals
+    case Kind::EVAL_IS_OK: o << "EVAL_IS_OK"; break;
     case Kind::EVAL_IS_EQ: o << "EVAL_IS_EQ"; break;
     case Kind::EVAL_IF_THEN_ELSE: o << "EVAL_IF_THEN_ELSE"; break;
     case Kind::EVAL_REQUIRES: o << "EVAL_REQUIRES"; break;
@@ -65,6 +66,8 @@ std::ostream& operator<<(std::ostream& o, Kind k)
     case Kind::EVAL_IS_STR: o << "EVAL_IS_STR"; break;
     case Kind::EVAL_IS_BOOL: o << "EVAL_IS_BOOL"; break;
     case Kind::EVAL_IS_VAR: o << "EVAL_IS_VAR"; break;
+    // equality
+    case Kind::EVAL_EQ: o << "EVAL_EQ";break;
     // lists
     case Kind::EVAL_NIL: o << "EVAL_NIL";break;
     case Kind::EVAL_CONS: o << "EVAL_CONS"; break;
@@ -134,6 +137,7 @@ std::string kindToTerm(Kind k)
         ss << "eo::";
         switch (k)
         {
+        case Kind::EVAL_IS_OK: ss << "is_ok"; break;
         case Kind::EVAL_IS_EQ: ss << "is_eq"; break;
         case Kind::EVAL_IF_THEN_ELSE: ss << "ite"; break;
         case Kind::EVAL_REQUIRES: ss << "requires"; break;
@@ -148,6 +152,8 @@ std::string kindToTerm(Kind k)
         case Kind::EVAL_IS_STR: ss << "is_str"; break;
         case Kind::EVAL_IS_BOOL: ss << "is_bool"; break;
         case Kind::EVAL_IS_VAR: ss << "is_var"; break;
+        // equality
+        case Kind::EVAL_EQ: ss << "eq"; break;
         // lists
         case Kind::EVAL_NIL: ss << "nil"; break;
         case Kind::EVAL_CONS: ss << "cons"; break;
@@ -227,6 +233,7 @@ bool isLiteralOp(Kind k)
 {
   switch(k)
   {
+    case Kind::EVAL_IS_OK:
     case Kind::EVAL_IS_EQ:
     case Kind::EVAL_IF_THEN_ELSE:
     case Kind::EVAL_REQUIRES:
@@ -241,6 +248,8 @@ bool isLiteralOp(Kind k)
     case Kind::EVAL_IS_STR:
     case Kind::EVAL_IS_BOOL:
     case Kind::EVAL_IS_VAR:
+    // equality
+    case Kind::EVAL_EQ:
     // lists
     case Kind::EVAL_NIL:
     case Kind::EVAL_CONS:

--- a/src/kind.cpp
+++ b/src/kind.cpp
@@ -67,7 +67,7 @@ std::ostream& operator<<(std::ostream& o, Kind k)
     case Kind::EVAL_IS_BOOL: o << "EVAL_IS_BOOL"; break;
     case Kind::EVAL_IS_VAR: o << "EVAL_IS_VAR"; break;
     // equality
-    case Kind::EVAL_EQ: o << "EVAL_EQ";break;
+    case Kind::EVAL_EQ: o << "EVAL_EQ"; break;
     // lists
     case Kind::EVAL_NIL: o << "EVAL_NIL";break;
     case Kind::EVAL_CONS: o << "EVAL_CONS"; break;
@@ -137,58 +137,58 @@ std::string kindToTerm(Kind k)
         ss << "eo::";
         switch (k)
         {
-        case Kind::EVAL_IS_OK: ss << "is_ok"; break;
-        case Kind::EVAL_IS_EQ: ss << "is_eq"; break;
-        case Kind::EVAL_IF_THEN_ELSE: ss << "ite"; break;
-        case Kind::EVAL_REQUIRES: ss << "requires"; break;
-        case Kind::EVAL_HASH: ss << "hash"; break;
-        case Kind::EVAL_VAR: ss << "var"; break;
-        case Kind::EVAL_TYPE_OF: ss << "typeof"; break;
-        case Kind::EVAL_NAME_OF: ss << "nameof"; break;
-        case Kind::EVAL_COMPARE: ss << "cmp"; break;
-        case Kind::EVAL_IS_Z: ss << "is_z"; break;
-        case Kind::EVAL_IS_Q: ss << "is_q"; break;
-        case Kind::EVAL_IS_BIN: ss << "is_bin"; break;
-        case Kind::EVAL_IS_STR: ss << "is_str"; break;
-        case Kind::EVAL_IS_BOOL: ss << "is_bool"; break;
-        case Kind::EVAL_IS_VAR: ss << "is_var"; break;
-        // equality
-        case Kind::EVAL_EQ: ss << "eq"; break;
-        // lists
-        case Kind::EVAL_NIL: ss << "nil"; break;
-        case Kind::EVAL_CONS: ss << "cons"; break;
-        case Kind::EVAL_LIST_LENGTH: ss << "list_len"; break;
-        case Kind::EVAL_LIST_CONCAT: ss << "list_concat"; break;
-        case Kind::EVAL_LIST_NTH: ss << "list_nth"; break;
-        case Kind::EVAL_LIST_FIND: ss << "list_find"; break;
-        // boolean
-        case Kind::EVAL_NOT: ss << "not"; break;
-        case Kind::EVAL_AND: ss << "and"; break;
-        case Kind::EVAL_OR: ss << "or"; break;
-        case Kind::EVAL_XOR: ss << "xor"; break;
-        // arithmetic
-        case Kind::EVAL_ADD: ss << "add";break;
-        case Kind::EVAL_NEG: ss << "neg";break;
-        case Kind::EVAL_MUL: ss << "mul";break;
-        case Kind::EVAL_INT_DIV: ss << "zdiv";break;
-        case Kind::EVAL_INT_MOD: ss << "zmod";break;
-        case Kind::EVAL_RAT_DIV: ss << "qdiv";break;
-        case Kind::EVAL_IS_NEG: ss << "is_neg";break;
-        case Kind::EVAL_GT: ss << "gt";break;
-        // strings
-        case Kind::EVAL_LENGTH: ss << "len"; break;
-        case Kind::EVAL_CONCAT: ss << "concat"; break;
-        case Kind::EVAL_EXTRACT: ss << "extract"; break;
-        case Kind::EVAL_FIND: ss << "find"; break;
-        // conversions
-        case Kind::EVAL_TO_INT: ss << "to_z";break;
-        case Kind::EVAL_TO_RAT: ss << "to_q";break;
-        case Kind::EVAL_TO_BIN: ss << "to_bin";break;
-        case Kind::EVAL_TO_STRING: ss << "to_str";break;
-        // datatypes
-        case Kind::EVAL_DT_CONSTRUCTORS: ss << "dt_constructors"; break;
-        case Kind::EVAL_DT_SELECTORS: ss << "dt_selectors"; break;
-        default:ss << "[" << k << "]";break;
+          case Kind::EVAL_IS_OK: ss << "is_ok"; break;
+          case Kind::EVAL_IS_EQ: ss << "is_eq"; break;
+          case Kind::EVAL_IF_THEN_ELSE: ss << "ite"; break;
+          case Kind::EVAL_REQUIRES: ss << "requires"; break;
+          case Kind::EVAL_HASH: ss << "hash"; break;
+          case Kind::EVAL_VAR: ss << "var"; break;
+          case Kind::EVAL_TYPE_OF: ss << "typeof"; break;
+          case Kind::EVAL_NAME_OF: ss << "nameof"; break;
+          case Kind::EVAL_COMPARE: ss << "cmp"; break;
+          case Kind::EVAL_IS_Z: ss << "is_z"; break;
+          case Kind::EVAL_IS_Q: ss << "is_q"; break;
+          case Kind::EVAL_IS_BIN: ss << "is_bin"; break;
+          case Kind::EVAL_IS_STR: ss << "is_str"; break;
+          case Kind::EVAL_IS_BOOL: ss << "is_bool"; break;
+          case Kind::EVAL_IS_VAR: ss << "is_var"; break;
+          // equality
+          case Kind::EVAL_EQ: ss << "eq"; break;
+          // lists
+          case Kind::EVAL_NIL: ss << "nil"; break;
+          case Kind::EVAL_CONS: ss << "cons"; break;
+          case Kind::EVAL_LIST_LENGTH: ss << "list_len"; break;
+          case Kind::EVAL_LIST_CONCAT: ss << "list_concat"; break;
+          case Kind::EVAL_LIST_NTH: ss << "list_nth"; break;
+          case Kind::EVAL_LIST_FIND: ss << "list_find"; break;
+          // boolean
+          case Kind::EVAL_NOT: ss << "not"; break;
+          case Kind::EVAL_AND: ss << "and"; break;
+          case Kind::EVAL_OR: ss << "or"; break;
+          case Kind::EVAL_XOR: ss << "xor"; break;
+          // arithmetic
+          case Kind::EVAL_ADD: ss << "add"; break;
+          case Kind::EVAL_NEG: ss << "neg"; break;
+          case Kind::EVAL_MUL: ss << "mul"; break;
+          case Kind::EVAL_INT_DIV: ss << "zdiv"; break;
+          case Kind::EVAL_INT_MOD: ss << "zmod"; break;
+          case Kind::EVAL_RAT_DIV: ss << "qdiv"; break;
+          case Kind::EVAL_IS_NEG: ss << "is_neg"; break;
+          case Kind::EVAL_GT: ss << "gt"; break;
+          // strings
+          case Kind::EVAL_LENGTH: ss << "len"; break;
+          case Kind::EVAL_CONCAT: ss << "concat"; break;
+          case Kind::EVAL_EXTRACT: ss << "extract"; break;
+          case Kind::EVAL_FIND: ss << "find"; break;
+          // conversions
+          case Kind::EVAL_TO_INT: ss << "to_z"; break;
+          case Kind::EVAL_TO_RAT: ss << "to_q"; break;
+          case Kind::EVAL_TO_BIN: ss << "to_bin"; break;
+          case Kind::EVAL_TO_STRING: ss << "to_str"; break;
+          // datatypes
+          case Kind::EVAL_DT_CONSTRUCTORS: ss << "dt_constructors"; break;
+          case Kind::EVAL_DT_SELECTORS: ss << "dt_selectors"; break;
+          default: ss << "[" << k << "]"; break;
         }
       }
       else

--- a/src/kind.h
+++ b/src/kind.h
@@ -62,6 +62,7 @@ enum class Kind
 
   // operations on literals
   // core
+  EVAL_IS_OK,
   EVAL_IS_EQ,
   EVAL_IF_THEN_ELSE,
   EVAL_REQUIRES,
@@ -70,12 +71,15 @@ enum class Kind
   EVAL_TYPE_OF,
   EVAL_NAME_OF,
   EVAL_COMPARE,
+  // testers
   EVAL_IS_Z,
   EVAL_IS_Q,
   EVAL_IS_BIN,
   EVAL_IS_STR,
   EVAL_IS_BOOL,
   EVAL_IS_VAR,
+  // equality
+  EVAL_EQ,
   // lists
   EVAL_NIL,
   EVAL_CONS,

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1280,6 +1280,13 @@ Expr State::getVar(const std::string& name) const
 
 Expr State::getBoundVar(const std::string& name, const Expr& type)
 {
+  if (!type.isGround())
+  {
+    // If the type is non-ground, we cannot evaluate it yet. Moreover this is
+    // not cached here, instead it is cached as part of mkExpr.
+    Expr ename = mkLiteral(Kind::STRING, name);
+    return mkExpr(Kind::EVAL_VAR, {ename, type});
+  }
   std::pair<std::string, const ExprValue*> key(name, type.getValue());
   std::map<std::pair<std::string, const ExprValue*>, Expr>::iterator it = d_boundVars.find(key);
   if (it!=d_boundVars.end())

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1029,6 +1029,11 @@ Expr State::mkFalse()
   return d_false;
 }
 
+Expr State::mkBool(bool val)
+{
+  return val ? d_true : d_false;
+}
+
 Expr State::mkLiteral(Kind k, const std::string& s)
 {
   // convert string to literal

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -99,7 +99,9 @@ State::State(Options& opts, Stats& stats)
   bindBuiltin("->", Kind::FUNCTION_TYPE);
   bindBuiltin("_", Kind::APPLY);
 
+  bindBuiltinEval("is_ok", Kind::EVAL_IS_OK);
   bindBuiltinEval("is_eq", Kind::EVAL_IS_EQ);
+  bindBuiltinEval("eq", Kind::EVAL_EQ);
   bindBuiltinEval("ite", Kind::EVAL_IF_THEN_ELSE);
   bindBuiltinEval("requires", Kind::EVAL_REQUIRES);
   bindBuiltinEval("hash", Kind::EVAL_HASH);

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1029,10 +1029,7 @@ Expr State::mkFalse()
   return d_false;
 }
 
-Expr State::mkBool(bool val)
-{
-  return val ? d_true : d_false;
-}
+Expr State::mkBool(bool val) { return val ? d_true : d_false; }
 
 Expr State::mkLiteral(Kind k, const std::string& s)
 {

--- a/src/state.h
+++ b/src/state.h
@@ -136,6 +136,8 @@ class State
   Expr mkTrue();
   /** make false */
   Expr mkFalse();
+  /** make Boolean value */
+  Expr mkBool(bool val);
   /**
    * Create a literal from a string.
    * @param s The string representation of the literal, may represent an

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -1143,7 +1143,7 @@ Expr TypeChecker::evaluateLiteralOpInternal(
     case Kind::EVAL_EQ:
     {
       // syntactic equality, only evaluated if the terms are values
-      if (args[0]->isEvaluatable() && args[1]->isEvaluatable())
+      if (!args[0]->isEvaluatable() && !args[1]->isEvaluatable())
       {
         return d_state.mkBool(args[0] == args[1]);
       }

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -1087,8 +1087,10 @@ Expr TypeChecker::evaluateLiteralOpInternal(
     break;
     case Kind::EVAL_REQUIRES:
     {
-      // eagerly 
-      if (args[0]->isGround() && !args[0]->isEvaluatable() && args[1]->isGround() && !args[1]->isEvaluatable() && args[0]==args[1])
+      // eagerly
+      if (args[0]->isGround() && !args[0]->isEvaluatable()
+          && args[1]->isGround() && !args[1]->isEvaluatable()
+          && args[0] == args[1])
       {
         return Expr(args[2]);
       }
@@ -1115,18 +1117,19 @@ Expr TypeChecker::evaluateLiteralOpInternal(
   {
     case Kind::EVAL_IS_OK:
     {
-      Assert (args.size()==1);
+      Assert(args.size() == 1);
       // returns true or false based on whether the argument is stuck
       return d_state.mkBool(!args[0]->isEvaluatable());
     }
     break;
     case Kind::EVAL_IS_EQ:
     {
-      Assert (args.size()==2);
+      Assert(args.size() == 2);
       // true if both arguments are not stuck and are equal, false otherwise
       // Note that (eo::is_eq t s) is equivalent to
       // (eo::ite (eo::and (eo::is_ok t) (eo::is_ok s)) (eo::eq s t) false)
-      return d_state.mkBool(!args[0]->isEvaluatable() && !args[1]->isEvaluatable() && args[0]==args[1]);
+      return d_state.mkBool(!args[0]->isEvaluatable()
+                            && !args[1]->isEvaluatable() && args[0] == args[1]);
     }
     break;
     case Kind::EVAL_EQ:
@@ -1134,14 +1137,14 @@ Expr TypeChecker::evaluateLiteralOpInternal(
       // syntactic equality, only evaluated if the terms are values
       if (args[0]->isEvaluatable() && args[1]->isEvaluatable())
       {
-        return d_state.mkBool(args[0]==args[1]);
+        return d_state.mkBool(args[0] == args[1]);
       }
       return d_null;
     }
     break;
     case Kind::EVAL_HASH:
     {
-      Assert (args.size()==1);
+      Assert(args.size() == 1);
       size_t h = d_state.getHash(args[0]);
       Literal lh(Integer(static_cast<unsigned int>(h)));
       return Expr(d_state.mkLiteralInternal(lh));
@@ -1151,7 +1154,7 @@ Expr TypeChecker::evaluateLiteralOpInternal(
     {
       size_t h1 = d_state.getHash(args[0]);
       size_t h2 = d_state.getHash(args[1]);
-      Literal lb(h1>h2);
+      Literal lb(h1 > h2);
       return Expr(d_state.mkLiteralInternal(lb));
     }
     break;
@@ -1162,7 +1165,7 @@ Expr TypeChecker::evaluateLiteralOpInternal(
     case Kind::EVAL_IS_BOOL:
     case Kind::EVAL_IS_VAR:
     {
-      Assert (args.size()==1);
+      Assert(args.size() == 1);
       Kind kk;
       switch (k)
       {
@@ -1187,7 +1190,7 @@ Expr TypeChecker::evaluateLiteralOpInternal(
       if (et.isGround())
       {
         // don't permit ground evaluatable types
-        Assert (!et.isEvaluatable());
+        Assert(!et.isEvaluatable());
         return et;
       }
       return d_null;
@@ -1196,7 +1199,7 @@ Expr TypeChecker::evaluateLiteralOpInternal(
     case Kind::EVAL_NAME_OF:
     {
       Kind k = args[0]->getKind();
-      if (k==Kind::CONST || k==Kind::VARIABLE)
+      if (k == Kind::CONST || k == Kind::VARIABLE)
       {
         Literal sym(String(Expr(args[0]).getSymbol()));
         return Expr(d_state.mkLiteralInternal(sym));
@@ -1206,7 +1209,7 @@ Expr TypeChecker::evaluateLiteralOpInternal(
     case Kind::EVAL_VAR:
     {
       // if arguments are ground and the first argument is a string
-      if (args[0]->getKind()==Kind::STRING)
+      if (args[0]->getKind() == Kind::STRING)
       {
         Expr type(args[1]);
         Expr tt = getType(type);

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -1183,10 +1183,6 @@ Expr TypeChecker::evaluateLiteralOpInternal(
     case Kind::EVAL_IS_VAR:
     {
       Assert(args.size() == 1);
-      if (args[0]->isEvaluatable())
-      {
-        return d_null;
-      }
       Kind kk;
       switch (k)
       {

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -1601,6 +1601,7 @@ ExprValue* TypeChecker::getLiteralOpType(Kind k,
       // type is the first child
       return childTypes[0];
     case Kind::EVAL_IS_EQ:
+    case Kind::EVAL_EQ:
     case Kind::EVAL_IS_NEG:
     case Kind::EVAL_COMPARE:
     case Kind::EVAL_IS_Z:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -148,6 +148,7 @@ set(ethos_test_file_list
     const-array.eo
     type-var-exists.eo
     array-ext-implicit-type-infer.eo
+    is-eq-tests.eo
 )
 
 if(ENABLE_ORACLES)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -146,6 +146,7 @@ set(ethos_test_file_list
     quote-requires.eo
     set-empty-amb.eo
     const-array.eo
+    type-var-exists.eo
 )
 
 if(ENABLE_ORACLES)

--- a/tests/is-eq-tests.eo
+++ b/tests/is-eq-tests.eo
@@ -1,0 +1,23 @@
+(declare-type Int ())
+(declare-consts <numeral> Int)
+
+(declare-type String ())
+(declare-consts <string> String)
+
+(define addOne ((T Type :implicit) (x T)) (eo::add x 1))
+
+(define testReflEq ((T Type :implicit) (x T)) (eo::is_eq x x))
+
+
+(declare-type Set (Type))
+
+(declare-const foo (Set (eo::requires (testReflEq (addOne 0)) true Bool)))
+; should fail
+;(declare-const foo2 (Set (eo::requires (testReflEq (addOne "ABC")) true Bool)))
+
+
+(declare-const foo3 (Set (eo::requires (eo::eq "ABC" "ABC") true Bool)))
+(declare-const foo4 (Set (eo::requires (eo::is_ok "ABC") true Bool)))
+; should fail
+;(declare-const foo5 (Set (eo::requires (eo::is_ok (addOne "ABC")) true Bool)))
+

--- a/tests/type-var-exists.eo
+++ b/tests/type-var-exists.eo
@@ -1,0 +1,13 @@
+
+
+(declare-type Int ())
+
+(declare-const exists (-> eo::List Bool Bool) :binder eo::List::cons)
+(declare-parameterized-const = ((A Type :implicit)) (-> A A Bool))
+
+(declare-rule exists-refl ((T Type))
+  :args (T)
+  :conclusion (exists ((x T)) (= x x)))
+
+  
+(step @p0 (exists ((x Int)) (= x x)) :rule exists-refl :args (Int))

--- a/user_manual.md
+++ b/user_manual.md
@@ -669,7 +669,7 @@ In other words, apart from `eo::ite`, all evaluation proceeds bottom-up,
 where their arguments are evaluated before the builtin operator is evaluated.
 
 In the following, we say a term is _ground_ if it contains no parameters as subterms.
-We say a term is a _value_ if it is ground and has no occurrences of builtin operators that failed to evaluate.
+We say a term is a _value_ if it is ground and has no occurrences of builtin operators or programs that failed to evaluate.
 We say an _arithmetic value_ is a numeral, decimal or rational value.
 We say a _bitwise value_ is a binary or hexadecimal value.
 A 32-bit numeral value is a numeral value between `0` and `2^32-1`.

--- a/user_manual.md
+++ b/user_manual.md
@@ -690,6 +690,7 @@ Note, however, that the evaluation of these operators is handled by more efficie
 
 - `(eo::eq t1 t2)`
   - If `t1` and `t2` are ground values, this returns `true` if `t1` is (syntactically) equal to `t2` and false otherwise. Otherwise, if either `t1` or `t2` is non-ground, it does not evaluate.
+
 - `(eo::is_eq t1 t2)`
   - Equivalent to `(eo::ite (eo::and (eo::is_ok t) (eo::is_ok s)) (eo::eq s t) false)`.
 

--- a/user_manual.md
+++ b/user_manual.md
@@ -664,16 +664,16 @@ For example, `eo::add` returns the result of adding two integers or rationals, b
 Similarly, `eo::concat` returns the result of concatenating two string literals, but can also concatenate binary constants.
 We remark on the semantics in the following.
 
+Apart from `eo::ite`, the evaluation of all operators assume that their arguments are fully reduced.
+In other words, apart from `eo::ite`, all evaluation proceeds bottom-up,
+where their arguments are evaluated before the builtin operator is evaluated.
+
 In the following, we say a term is _ground_ if it contains no parameters as subterms.
-We say a term is a _value_ if it is ground and has no occurrences of unevaluated builtin operators.
+We say a term is a _value_ if it is ground and has no occurrences of builtin operators that failed to evaluate.
 We say an _arithmetic value_ is a numeral, decimal or rational value.
 We say a _bitwise value_ is a binary or hexadecimal value.
 A 32-bit numeral value is a numeral value between `0` and `2^32-1`.
 Binary values are considered to be in little endian form.
-
-Apart from `eo::ite`, all cases of evaluation assume that the arguments are fully reduced.
-In other words, apart from `eo::ite`, all evaluation proceeds bottom-up,
-where the arguments of builtin operators are evaluated before the builtin operator is evaluated.
 
 Some of the following operators can be defined in terms of the other operators.
 For these operators, we provide the equivalent formulation.

--- a/user_manual.md
+++ b/user_manual.md
@@ -695,16 +695,16 @@ Note, however, that the evaluation of these operators is handled by more efficie
   - Equivalent to `(eo::ite (eo::and (eo::is_ok t) (eo::is_ok s)) (eo::eq s t) false)`.
 
 - `(eo::requires t1 t2 t3)`
-  - Returns `t3` if `(eo::is_eq t1 t2)` evaluates to `true`, and is not evaluated otherwise. If the case that this operator evaluates, it may be the case that `t3` is non-ground.
+  - Returns `t3` if `(eo::is_eq t1 t2)` evaluates to `true`, and is not evaluated otherwise. In the case this operator evaluates, it may be the case that `t3` is non-ground.
 
 - `(eo::hash t1)`
-  - If `t1` is a ground term, this returns a numeral that is unique to `t1`.
+  - If `t1` is a value, this returns a numeral that is unique to `t1`.
 - `(eo::typeof t1)`
-  - If `t1` is a ground term, this returns the type of `t1` if its type is ground.
+  - If `t1` is a value, this returns the type of `t1` if its type is ground.
 - `(eo::nameof t1)`
   - If `t1` is a ground constant or variable, this returns the name of `t1`, i.e. the string corresponding to the symbol it was declared with.
 - `(eo::var t1 t2)`
-  - If `t1` is a string value and `t2` is ground type, this returns the variable whose name is `t1` and whose type is `t2`.
+  - If `t1` is a string value and `t2` is a ground type, this returns the variable whose name is `t1` and whose type is `t2`.
 - `(eo::cmp t1 t2)`
   - Equivalent to `(eo::is_neg (eo::add (eo::neg (eo::hash t1)) (eo::hash t2)))`. Note that this method corresponds to an arbitrary total order on terms.
 - `(eo::is_z t)`


### PR DESCRIPTION
This changes the semantics of `eo::is_eq` such that it returns "false" for two terms that are both stuck.  This also impacts the semantics of `eo::requires`, whose semantics depends on `eo::is_eq`.

It introduces `eo::eq` and `eo::is_ok`, which are the more primitive operators that `eo::is_eq` can be described in terms of.