### PR TITLE
Update type system with annotated parameters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ ethos 0.1.2 prerelease
 - Change the execution semantics when a program takes an unevalated term as an argument. In particular, we do not call user provided programs and oracles when at least argument could not be evaluated. This change was made to make errors more intuitive. Note this changes the semantics of programs that previously relied on being called on unevaluated terms.
 - User programs, user oracles, and builtin operators that are unapplied are now considered unevaluated. This makes the type checker more strict and disallows passing them as arguments to other programs, which previously led to undefined behavior.
 - Changes the interface of `declare-parameterized-const`. In particular, the parameters of a parameterized constants are no longer assumed to be implicit, and are explicit by default. The `:implicit` attribute can be used on all parameters to recover the previous behavior. Other attributes such as `:opaque` and `:requires` can now be used on parameters to this command.
+- In type checking, the free parameters in the types of parameters are now also bound when that parameter is instantiated.
 - Remove support for the explicit parameter annotation `eo::_`, which was used to provide annotations for implicit arguments to parameterized constants.
 - Changed the semantics of pairwise and chainable operators for a single argument, which now reduces to the neutral element of the combining operator instead of a parse error.
 - The operator `eo::typeof` now fails to evaluate if the type of the given term is not ground.

--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -795,8 +795,10 @@ std::vector<Expr> ExprParser::parseAndBindSortedVarList(
     else
     {
       v = d_state.mkSymbol(Kind::PARAM, name, t);
-      // if this parameter is used to define the type of a constant, then if it has non-ground type, its type will be taken into account for matching and evaluation. We wrap it in (eo::param ...) here.
-      if (k==Kind::CONST && !t.isGround())
+      // if this parameter is used to define the type of a constant, then if it
+      // has non-ground type, its type will be taken into account for matching
+      // and evaluation. We wrap it in (eo::param ...) here.
+      if (k == Kind::CONST && !t.isGround())
       {
         v = d_state.mkExpr(Kind::ANNOT_PARAM, {v, t});
       }

--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -795,9 +795,10 @@ std::vector<Expr> ExprParser::parseAndBindSortedVarList(
     else
     {
       v = d_state.mkSymbol(Kind::PARAM, name, t);
-      // if this parameter is used to define the type of a constant or proof rule, then if it
-      // has non-ground type, its type will be taken into account for matching
-      // and evaluation. We wrap it in (eo::param ...) here.
+      // if this parameter is used to define the type of a constant or proof
+      // rule, then if it has non-ground type, its type will be taken into
+      // account for matching and evaluation. We wrap it in (eo::param ...)
+      // here.
       if ((k == Kind::CONST || k == Kind::PROOF_RULE) && !t.isGround())
       {
         v = d_state.mkExpr(Kind::ANNOT_PARAM, {v, t});

--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -795,6 +795,11 @@ std::vector<Expr> ExprParser::parseAndBindSortedVarList(
     else
     {
       v = d_state.mkSymbol(Kind::PARAM, name, t);
+      // if this parameter is used to define the type of a constant, then if it has non-ground type, its type will be taken into account for matching and evaluation. We wrap it in (eo::param ...) here.
+      if (k==Kind::CONST && !t.isGround())
+      {
+        v = d_state.mkExpr(Kind::ANNOT_PARAM, {v, t});
+      }
       bind(name, v);
       // parse attribute list
       AttrMap& attrs = amap[v.getValue()];

--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -795,10 +795,10 @@ std::vector<Expr> ExprParser::parseAndBindSortedVarList(
     else
     {
       v = d_state.mkSymbol(Kind::PARAM, name, t);
-      // if this parameter is used to define the type of a constant, then if it
+      // if this parameter is used to define the type of a constant or proof rule, then if it
       // has non-ground type, its type will be taken into account for matching
       // and evaluation. We wrap it in (eo::param ...) here.
-      if (k == Kind::CONST && !t.isGround())
+      if ((k == Kind::CONST || k == Kind::PROOF_RULE) && !t.isGround())
       {
         v = d_state.mkExpr(Kind::ANNOT_PARAM, {v, t});
       }

--- a/src/kind.cpp
+++ b/src/kind.cpp
@@ -229,6 +229,7 @@ bool isLiteralOp(Kind k)
 {
   switch(k)
   {
+    case Kind::ANNOT_PARAM:
     case Kind::EVAL_IS_EQ:
     case Kind::EVAL_IF_THEN_ELSE:
     case Kind::EVAL_REQUIRES:

--- a/src/kind.cpp
+++ b/src/kind.cpp
@@ -42,6 +42,7 @@ std::ostream& operator<<(std::ostream& o, Kind k)
     case Kind::AS_RETURN: o << "AS_RETURN"; break;
     case Kind::PARAMETERIZED: o << "PARAMETERIZED"; break;
     case Kind::APPLY_OPAQUE: o << "APPLY_OPAQUE"; break;
+    case Kind::ANNOT_PARAM: o << "ANNOT_PARAM"; break;
     // literals
     case Kind::BOOLEAN: o << "BOOLEAN"; break;
     case Kind::NUMERAL: o << "NUMERAL"; break;
@@ -122,6 +123,7 @@ std::string kindToTerm(Kind k)
     // terms
     case Kind::APPLY: ss << "_"; break;
     case Kind::APPLY_OPAQUE: ss << "_"; break;
+    case Kind::ANNOT_PARAM: ss << "eo::param"; break;
     case Kind::LAMBDA: ss << "lambda"; break;
     case Kind::PROGRAM: ss << "program"; break;
     case Kind::AS: ss << "eo::as"; break;

--- a/src/kind.h
+++ b/src/kind.h
@@ -40,7 +40,8 @@ enum class Kind
   AS_RETURN,  // SMT-LIB (as t T), where T is the return type of t
   PARAMETERIZED,
   APPLY_OPAQUE,
-  ANNOT_PARAM,  // a parameter with non-ground type that appears in type checking
+  ANNOT_PARAM,  // a parameter with non-ground type that appears in type
+                // checking
 
   // symbols
   PARAM,

--- a/src/kind.h
+++ b/src/kind.h
@@ -40,6 +40,7 @@ enum class Kind
   AS_RETURN,  // SMT-LIB (as t T), where T is the return type of t
   PARAMETERIZED,
   APPLY_OPAQUE,
+  ANNOT_PARAM,  // a parameter with non-ground type that appears in type checking
 
   // symbols
   PARAM,

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1430,7 +1430,8 @@ bool State::isProofRuleSorry(const ExprValue* e) const
 
 AppInfo* State::getAppInfo(const ExprValue* e)
 {
-  Assert (e->getKind()!=Kind::ANNOT_PARAM);
+  // we may be an ANNOT_PARAM here, which will never have relevant properties
+  // in the context where it is being used as the head of an application
   std::map<const ExprValue *, AppInfo>::iterator it = d_appData.find(e);
   if (it!=d_appData.end())
   {
@@ -1441,7 +1442,7 @@ AppInfo* State::getAppInfo(const ExprValue* e)
 
 const AppInfo* State::getAppInfo(const ExprValue* e) const
 {
-  Assert (e->getKind()!=Kind::ANNOT_PARAM);
+  // similar to above, we may be ANNOT_PARAM.
   std::map<const ExprValue *, AppInfo>::const_iterator it = d_appData.find(e);
   if (it!=d_appData.end())
   {

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1259,6 +1259,9 @@ const ExprValue* State::getBaseOperator(const ExprValue * v) const
 
 Attr State::getConstructorKind(const ExprValue* v) const
 {
+  // If we ask for the constructor kind of an annotated parameter,
+  // it is stored on the parameter it annotates. This makes a difference
+  // for parameters with non-ground type that are marked :list.
   if (v->getKind()==Kind::ANNOT_PARAM)
   {
     return getConstructorKind(v->d_children[0]);
@@ -1525,6 +1528,7 @@ void State::defineProgram(const Expr& v, const Expr& prog)
 
 bool State::markConstructorKind(const Expr& v, Attr a, const Expr& cons)
 {
+  // If marking an annotated parameter, we mark the parameter it annotates.
   if (v.getKind()==Kind::ANNOT_PARAM)
   {
     return markConstructorKind(v[0], a, cons);

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1262,7 +1262,7 @@ Attr State::getConstructorKind(const ExprValue* v) const
   // If we ask for the constructor kind of an annotated parameter,
   // it is stored on the parameter it annotates. This makes a difference
   // for parameters with non-ground type that are marked :list.
-  if (v->getKind()==Kind::ANNOT_PARAM)
+  if (v->getKind() == Kind::ANNOT_PARAM)
   {
     return getConstructorKind(v->d_children[0]);
   }
@@ -1529,7 +1529,7 @@ void State::defineProgram(const Expr& v, const Expr& prog)
 bool State::markConstructorKind(const Expr& v, Attr a, const Expr& cons)
 {
   // If marking an annotated parameter, we mark the parameter it annotates.
-  if (v.getKind()==Kind::ANNOT_PARAM)
+  if (v.getKind() == Kind::ANNOT_PARAM)
   {
     return markConstructorKind(v[0], a, cons);
   }

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1259,6 +1259,10 @@ const ExprValue* State::getBaseOperator(const ExprValue * v) const
 
 Attr State::getConstructorKind(const ExprValue* v) const
 {
+  if (v->getKind()==Kind::ANNOT_PARAM)
+  {
+    return getConstructorKind(v->d_children[0]);
+  }
   const AppInfo* ai = getAppInfo(v);
   if (ai!=nullptr)
   {
@@ -1426,7 +1430,7 @@ bool State::isProofRuleSorry(const ExprValue* e) const
 
 AppInfo* State::getAppInfo(const ExprValue* e)
 {
-  Assert (e->getKind()!=Kind::PARAMETERIZED);
+  Assert (e->getKind()!=Kind::ANNOT_PARAM);
   std::map<const ExprValue *, AppInfo>::iterator it = d_appData.find(e);
   if (it!=d_appData.end())
   {
@@ -1437,7 +1441,7 @@ AppInfo* State::getAppInfo(const ExprValue* e)
 
 const AppInfo* State::getAppInfo(const ExprValue* e) const
 {
-  Assert (e->getKind()!=Kind::PARAMETERIZED);
+  Assert (e->getKind()!=Kind::ANNOT_PARAM);
   std::map<const ExprValue *, AppInfo>::const_iterator it = d_appData.find(e);
   if (it!=d_appData.end())
   {
@@ -1520,6 +1524,10 @@ void State::defineProgram(const Expr& v, const Expr& prog)
 
 bool State::markConstructorKind(const Expr& v, Attr a, const Expr& cons)
 {
+  if (v.getKind()==Kind::ANNOT_PARAM)
+  {
+    return markConstructorKind(v[0], a, cons);
+  }
   Expr acons = cons;
   if (a==Attr::ORACLE)
   {

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -1133,9 +1133,7 @@ Expr TypeChecker::evaluateLiteralOpInternal(
       // is ensured by the fact that the context we are in is the result
       // of a context that was extended by matching the second argument
       // to the type of the (instantiated) first argument.
-      // if the second argument is ground, then as an optimization,
-      // we can simply return the second argument. TODO: remove?
-      if (args[0]->isGround() || args[1]->isGround())
+      if (args[0]->isGround())
       {
         // by construction, args[0] should have type args[1]
         return Expr(args[0]);

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -546,12 +546,14 @@ bool TypeChecker::match(ExprValue* a,
           ExprValue* t = d_state.lookupType(curr.second);
           if (t == nullptr)
           {
-            std::cout << "Failed to get type of " << Expr(t) << std::endl;
             return false;
           }
           stack.emplace_back(curr.first->d_children[1], t);
         }
-        return false;
+        else
+        {
+          return false;
+        }
       }
       else
       {
@@ -799,6 +801,16 @@ Expr TypeChecker::evaluate(ExprValue* e, Ctx& ctx)
                   canEvaluate = false;
                 }
               }
+            }
+          }
+            break;
+          case Kind::ANNOT_PARAM:
+          {
+            // if the type is ground, we can "evaluate" to the first argument
+            if (cchildren[1]->isGround())
+            {
+              // by construction, cchildren[0] should have type cchildren[1]
+              evaluated = Expr(cchildren[0]);
             }
           }
             break;

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -805,16 +805,6 @@ Expr TypeChecker::evaluate(ExprValue* e, Ctx& ctx)
             }
           }
             break;
-          case Kind::ANNOT_PARAM:
-          {
-            // if the type is ground, we can "evaluate" to the first argument
-            if (cchildren[0]->isGround() || cchildren[1]->isGround())
-            {
-              // by construction, cchildren[0] should have type cchildren[1]
-              evaluated = Expr(cchildren[0]);
-            }
-          }
-            break;
           default:
             if (isLiteralOp(ck))
             {
@@ -1132,6 +1122,18 @@ Expr TypeChecker::evaluateLiteralOpInternal(
       return d_null;
     }
     break;
+    case Kind::ANNOT_PARAM:
+    {
+      // if the first argument is ground, then we know by construction
+      // if the second argument is ground, then as an optimization,
+      // we can simply return the second argument.
+      if (args[0]->isGround() || args[1]->isGround())
+      {
+        // by construction, args[0] should have type args[1]
+        return Expr(args[0]);
+      }
+    }
+      break;
     case Kind::EVAL_REQUIRES:
     {
       if (args[0]==args[1])

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -1129,8 +1129,12 @@ Expr TypeChecker::evaluateLiteralOpInternal(
     case Kind::ANNOT_PARAM:
     {
       // if the first argument is ground, then we know by construction
+      // that its type is equal to the second argument. This invariant
+      // is ensured by the fact that the context we are in is the result
+      // of a context that was extended by matching the second argument
+      // to the type of the (instantiated) first argument.
       // if the second argument is ground, then as an optimization,
-      // we can simply return the second argument.
+      // we can simply return the second argument. TODO: remove?
       if (args[0]->isGround() || args[1]->isGround())
       {
         // by construction, args[0] should have type args[1]

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -539,12 +539,12 @@ bool TypeChecker::match(ExprValue* a,
       if (curr.first->getNumChildren() != curr.second->getNumChildren()
           || curr.first->getKind() != curr.second->getKind())
       {
-        if (curr.first->getKind()==Kind::ANNOT_PARAM)
+        if (curr.first->getKind() == Kind::ANNOT_PARAM)
         {
           stack.emplace_back(curr.first->d_children[0], curr.second);
           // independently check its type
           ExprValue* t = d_state.lookupType(curr.second);
-          if (t==nullptr)
+          if (t == nullptr)
           {
             return false;
           }
@@ -557,7 +557,8 @@ bool TypeChecker::match(ExprValue* a,
         // recurse on children
         for (size_t i = 0, n = curr.first->getNumChildren(); i < n; ++i)
         {
-          stack.emplace_back(curr.first->d_children[i], curr.second->d_children[i]);
+          stack.emplace_back(curr.first->d_children[i],
+                             curr.second->d_children[i]);
         }
       }
     }

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -1135,8 +1135,11 @@ Expr TypeChecker::evaluateLiteralOpInternal(
       // to the type of the (instantiated) first argument.
       if (args[0]->isGround())
       {
-        // by construction, args[0] should have type args[1]
-        return Expr(args[0]);
+        // by construction, args[0] should have type args[1], this is
+        // an assertion that is not checked in production.
+        Expr ret(args[0]);
+        Assert (getType(ret).getValue()==args[1]);
+        return Expr(ret);
       }
     }
       break;

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -139,6 +139,7 @@ bool TypeChecker::checkArity(Kind k, size_t nargs, std::ostream* out)
   // check arities
   switch(k)
   {
+    case Kind::ANNOT_PARAM:
     case Kind::EVAL_IS_EQ:
     case Kind::EVAL_VAR:
     case Kind::EVAL_INT_DIV:
@@ -463,7 +464,6 @@ Expr TypeChecker::getTypeAppInternal(std::vector<ExprValue*>& children,
         }
         (*out) << std::endl;
         (*out) << "  Context " << ctx << std::endl;
-        AlwaysAssert(false);
       }
       return d_null;
     }
@@ -808,7 +808,7 @@ Expr TypeChecker::evaluate(ExprValue* e, Ctx& ctx)
           case Kind::ANNOT_PARAM:
           {
             // if the type is ground, we can "evaluate" to the first argument
-            if (cchildren[1]->isGround())
+            if (cchildren[0]->isGround() || cchildren[1]->isGround())
             {
               // by construction, cchildren[0] should have type cchildren[1]
               evaluated = Expr(cchildren[0]);

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -546,6 +546,7 @@ bool TypeChecker::match(ExprValue* a,
           ExprValue* t = d_state.lookupType(curr.second);
           if (t == nullptr)
           {
+            std::cout << "Failed to get type of " << Expr(t) << std::endl;
             return false;
           }
           stack.emplace_back(curr.first->d_children[1], t);

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -494,11 +494,20 @@ bool TypeChecker::match(ExprValue* a,
   {
     curr = stack.back();
     stack.pop_back();
-    if (curr.first == curr.second)
+    // if we are ground
+    if (curr.first->isGround())
     {
-      // holds trivially
-      continue;
+      if (curr.first == curr.second)
+      {
+        // holds trivially
+        continue;
+      }
+      // otherwise fails
+      return false;
     }
+    // note that if curr.first == curr.second, and both are non-ground,
+    // then we still require recursing, which will bind identity substitutions
+    // on each of their parameters.
     it = visited.find(curr);
     if (it != visited.end())
     {

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -463,6 +463,7 @@ Expr TypeChecker::getTypeAppInternal(std::vector<ExprValue*>& children,
         }
         (*out) << std::endl;
         (*out) << "  Context " << ctx << std::endl;
+        AlwaysAssert(false);
       }
       return d_null;
     }

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -549,10 +549,11 @@ bool TypeChecker::match(ExprValue* a,
       if (curr.first->getNumChildren() != curr.second->getNumChildren()
           || curr.first->getKind() != curr.second->getKind())
       {
-        // Special case: if we are an annotated parameter, then matching takes into account
-        // its *type*. In particular, the type of the term we are matching is matched
-        // against the annotated type. This has the effect that free parameters in the
-        // type of parameters are also bound, if the parameter is annotated.
+        // Special case: if we are an annotated parameter, then matching takes
+        // into account its *type*. In particular, the type of the term we are
+        // matching is matched against the annotated type. This has the effect
+        // that free parameters in the type of parameters are also bound, if the
+        // parameter is annotated.
         if (curr.first->getKind() == Kind::ANNOT_PARAM)
         {
           stack.emplace_back(curr.first->d_children[0], curr.second);
@@ -1147,11 +1148,11 @@ Expr TypeChecker::evaluateLiteralOpInternal(
         // by construction, args[0] should have type args[1], this is
         // an assertion that is not checked in production.
         Expr ret(args[0]);
-        Assert (getType(ret).getValue()==args[1]);
+        Assert(getType(ret).getValue() == args[1]);
         return Expr(ret);
       }
     }
-      break;
+    break;
     case Kind::EVAL_REQUIRES:
     {
       if (args[0]==args[1])

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -540,6 +540,10 @@ bool TypeChecker::match(ExprValue* a,
       if (curr.first->getNumChildren() != curr.second->getNumChildren()
           || curr.first->getKind() != curr.second->getKind())
       {
+        // Special case: if we are an annotated parameter, then matching takes into account
+        // its *type*. In particular, the type of the term we are matching is matched
+        // against the annotated type. This has the effect that free parameters in the
+        // type of parameters are also bound, if the parameter is annotated.
         if (curr.first->getKind() == Kind::ANNOT_PARAM)
         {
           stack.emplace_back(curr.first->d_children[0], curr.second);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -147,6 +147,7 @@ set(ethos_test_file_list
     set-empty-amb.eo
     const-array.eo
     type-var-exists.eo
+    array-ext-implicit-type-infer.eo
 )
 
 if(ENABLE_ORACLES)

--- a/tests/array-ext-implicit-type-infer.eo
+++ b/tests/array-ext-implicit-type-infer.eo
@@ -1,0 +1,24 @@
+
+(declare-const or (-> Bool Bool Bool))
+(declare-const not (-> Bool Bool))
+(declare-parameterized-const = ((T Type :implicit)) (-> T T Bool))
+(declare-const exists (-> eo::List Bool Bool) :binder eo::List::cons)
+
+
+(declare-type Array (Type Type))
+
+(declare-parameterized-const select ((U Type :implicit) (T Type :implicit))
+   (-> (Array U T) U T))
+
+(declare-rule array_ext ((T Type) (U Type) (a (Array T U)) (b (Array T U)))
+  :args (a b)
+  :conclusion (or (= a b) (exists ((x T)) (not (= (select a x) (select b x)))))
+)
+
+
+(declare-type Int ())
+
+(declare-const a1 (Array Int Int))
+(declare-const a2 (Array Int Int))
+
+(step @p0 (or (= a1 a2) (exists ((x Int)) (not (= (select a1 x) (select a2 x))))) :rule array_ext :args (a1 a2))

--- a/tests/datatypes-split-rule-param-uinst.eo
+++ b/tests/datatypes-split-rule-param-uinst.eo
@@ -35,8 +35,8 @@
 (step @p0 (or (is cons x) (is nil x)) :rule dt-split :args (x))
 
 
-(program $mk_dt_inst ((D Type) (x D) (T Type) (t T) (S Type) (s S) (xs eo::List :list) (U Type))
-  (eo::List D T) U
+(program $mk_dt_inst ((D Type) (x D) (T Type) (t T) (S Type) (s S) (xs eo::List :list))
+  (eo::List D T) D
   (
     (($mk_dt_inst eo::List::nil x t)          t)
     (($mk_dt_inst (eo::List::cons s xs) x t)  ($mk_dt_inst xs x (t (s x))))

--- a/tests/datatypes-split-rule-param-uinst.eo
+++ b/tests/datatypes-split-rule-param-uinst.eo
@@ -35,8 +35,8 @@
 (step @p0 (or (is cons x) (is nil x)) :rule dt-split :args (x))
 
 
-(program $mk_dt_inst ((D Type) (x D) (T Type) (t T) (S Type) (s S) (xs eo::List :list))
-  (eo::List D T) Bool
+(program $mk_dt_inst ((D Type) (x D) (T Type) (t T) (S Type) (s S) (xs eo::List :list) (U Type))
+  (eo::List D T) U
   (
     (($mk_dt_inst eo::List::nil x t)          t)
     (($mk_dt_inst (eo::List::cons s xs) x t)  ($mk_dt_inst xs x (t (s x))))

--- a/tests/datatypes-split-rule-param.eo
+++ b/tests/datatypes-split-rule-param.eo
@@ -4,7 +4,7 @@
 ;(define as ((T Type :implicit) (x T) (S Type)) (as x S))
 
 (declare-type Int ())
-(declare-datatypes ((Lst 1)) ((par (X)((cons (head X) (tail (Lst X))) (nil)))))
+(declare-datatypes ((Lst 1)) ((par (X) ((cons (head X) (tail (Lst X))) (nil)))))
 
 
 (declare-parameterized-const is ((C Type :implicit) (D Type :implicit)) (-> C D Bool))
@@ -29,8 +29,8 @@
 (step @p0 (or (is cons x) (is (as nil (Lst Int)) x)) :rule dt-split :args (x))
 
 
-(program $mk_dt_inst ((D Type) (x D) (T Type) (t T) (S Type) (s S) (xs eo::List :list))
-  (eo::List D T) Bool
+(program $mk_dt_inst ((D Type) (x D) (T Type) (t T) (S Type) (s S) (xs eo::List :list) (U Type))
+  (eo::List D T) D
   (
     (($mk_dt_inst eo::List::nil x t)          t)
     (($mk_dt_inst (eo::List::cons s xs) x t)  ($mk_dt_inst xs x (t (s x))))

--- a/tests/datatypes-split-rule-param.eo
+++ b/tests/datatypes-split-rule-param.eo
@@ -29,7 +29,7 @@
 (step @p0 (or (is cons x) (is (as nil (Lst Int)) x)) :rule dt-split :args (x))
 
 
-(program $mk_dt_inst ((D Type) (x D) (T Type) (t T) (S Type) (s S) (xs eo::List :list) (U Type))
+(program $mk_dt_inst ((D Type) (x D) (T Type) (t T) (S Type) (s S) (xs eo::List :list))
   (eo::List D T) D
   (
     (($mk_dt_inst eo::List::nil x t)          t)

--- a/tests/emptylist.eo
+++ b/tests/emptylist.eo
@@ -6,14 +6,14 @@
 
 
 (program mk_nary_cong_lhs ((U Type) (f (-> U U U)) (t1 U) (t2 U) (s1 U) (s2 U)  (tail Bool :list))
-    ((-> U U) Bool) Bool
+    ((-> U U U) Bool) Bool
     (
         ((mk_nary_cong_lhs f (and (= s1 s2) tail)) (f s1 (mk_nary_cong_lhs f tail)))
         ((mk_nary_cong_lhs f true)                 (eo::nil f))
     )
 )
 (program mk_nary_cong_rhs ((U Type) (f (-> U U U)) (t1 U) (t2 U) (s1 U) (s2 U)  (tail Bool :list))
-    ((-> U U) Bool) Bool
+    ((-> U U U) Bool) Bool
     (
         ((mk_nary_cong_rhs f (and (= s1 s2) tail)) (f s2 (mk_nary_cong_rhs f tail)))
         ((mk_nary_cong_rhs f true)                 (eo::nil f))

--- a/tests/emptylist.eo
+++ b/tests/emptylist.eo
@@ -5,14 +5,14 @@
 (declare-const and (-> Bool Bool Bool) :right-assoc-nil true)
 
 
-(program mk_nary_cong_lhs ((U Type) (f (-> U U)) (t1 U) (t2 U) (s1 U) (s2 U)  (tail Bool :list))
+(program mk_nary_cong_lhs ((U Type) (f (-> U U U)) (t1 U) (t2 U) (s1 U) (s2 U)  (tail Bool :list))
     ((-> U U) Bool) Bool
     (
         ((mk_nary_cong_lhs f (and (= s1 s2) tail)) (f s1 (mk_nary_cong_lhs f tail)))
         ((mk_nary_cong_lhs f true)                 (eo::nil f))
     )
 )
-(program mk_nary_cong_rhs ((U Type) (f (-> U U)) (t1 U) (t2 U) (s1 U) (s2 U)  (tail Bool :list))
+(program mk_nary_cong_rhs ((U Type) (f (-> U U U)) (t1 U) (t2 U) (s1 U) (s2 U)  (tail Bool :list))
     ((-> U U) Bool) Bool
     (
         ((mk_nary_cong_rhs f (and (= s1 s2) tail)) (f s2 (mk_nary_cong_rhs f tail)))
@@ -20,7 +20,7 @@
     )
 )
 
-(declare-rule nary_cong ((U Type) (E Bool) (f (-> U U)) (nil U))
+(declare-rule nary_cong ((U Type) (E Bool) (f (-> U U U)) (nil U))
     :premise-list E and
     :args (f)
     :conclusion (= (mk_nary_cong_lhs f E) (mk_nary_cong_rhs f E))

--- a/tests/nground-nil-v3.eo
+++ b/tests/nground-nil-v3.eo
@@ -23,7 +23,7 @@
 
 (declare-parameterized-const is-tail-of ((T Type :implicit) (U Type :implicit)) (-> T U Bool))
 
-(declare-rule find_tail ((T Type) (f (-> T T T)) (t T) (s T :list))
+(declare-rule find_tail ((T Type) (U Type) (f U) (t T) (s T :list))
   :args ((f t s))
   :conclusion (is-tail-of ($get_tail f (f t s)) (f t s)))
 

--- a/tests/premise-list-nary-cong-2.eo
+++ b/tests/premise-list-nary-cong-2.eo
@@ -2,15 +2,15 @@
 (declare-parameterized-const = ((T Type :implicit)) (-> T T Bool))
 (declare-const and (-> Bool Bool Bool) :right-assoc-nil true)
 
-(program add_nary_arg ((U Type) (f (-> U U)) (s1 U) (s2 U) (t1 U) (t2 U) (nil U :list))
-    ((-> U U) U U Bool) Bool
+(program add_nary_arg ((U Type) (f (-> U U U)) (s1 U) (s2 U) (t1 U) (t2 U) (nil U :list))
+    ((-> U U U) U U Bool) Bool
     (
       ((add_nary_arg f s1 s2 (= t1 t2)) (= (f s1 t1) (f s2 t2)))
     )
 )
 
 (program mk_nary_cong_eq ((U Type) (f (-> U U U)) (t1 U :list) (t2 U :list) (s1 U) (s2 U) (tail Bool :list))
-    ((-> U U) Bool) Bool
+    ((-> U U U) Bool) Bool
     (
         ((mk_nary_cong_eq f true)                 (= true true))
         ((mk_nary_cong_eq f (and (= s1 s2) tail)) (add_nary_arg f s1 s2 (mk_nary_cong_eq f tail)))

--- a/tests/premise-list-nary-cong-2.eo
+++ b/tests/premise-list-nary-cong-2.eo
@@ -9,7 +9,7 @@
     )
 )
 
-(program mk_nary_cong_eq ((U Type) (f (-> U U)) (t1 U :list) (t2 U :list) (s1 U) (s2 U) (tail Bool :list))
+(program mk_nary_cong_eq ((U Type) (f (-> U U U)) (t1 U :list) (t2 U :list) (s1 U) (s2 U) (tail Bool :list))
     ((-> U U) Bool) Bool
     (
         ((mk_nary_cong_eq f true)                 (= true true))
@@ -17,7 +17,7 @@
     )
 )
 
-(declare-rule nary_cong ((U Type) (E Bool) (f (-> U U)))
+(declare-rule nary_cong ((U Type) (E Bool) (f (-> U U U)))
     :premise-list E and
     :args (f)
     :conclusion (mk_nary_cong_eq f E)

--- a/tests/premise-list-nary-cong.eo
+++ b/tests/premise-list-nary-cong.eo
@@ -10,7 +10,7 @@
     )
 )
 
-(program mk_nary_cong_eq ((U Type) (f (-> U U)) (t1 U :list) (t2 U :list) (s1 U) (s2 U) (tail Bool :list))
+(program mk_nary_cong_eq ((U Type) (f (-> U U U)) (t1 U :list) (t2 U :list) (s1 U) (s2 U) (tail Bool :list))
     ((-> U U) Bool) Bool
     (
         ((mk_nary_cong_eq f true)                 (= true true))
@@ -18,7 +18,7 @@
     )
 )
 
-(declare-rule nary_cong ((U Type) (E Bool) (f (-> U U)))
+(declare-rule nary_cong ((U Type) (E Bool) (f (-> U U U)))
     :premise-list E and
     :args (f)
     :conclusion (mk_nary_cong_eq f E)

--- a/tests/premise-list-nary-cong.eo
+++ b/tests/premise-list-nary-cong.eo
@@ -3,15 +3,15 @@
 (declare-const and (-> Bool Bool Bool) :right-assoc-nil true)
 
 
-(program add_nary_arg ((U Type) (f (-> U U)) (s1 U) (s2 U) (t1 U) (t2 U) (nil U :list))
-    ((-> U U) U U Bool) Bool
+(program add_nary_arg ((U Type) (f (-> U U U)) (s1 U) (s2 U) (t1 U) (t2 U) (nil U :list))
+    ((-> U U U) U U Bool) Bool
     (
       ((add_nary_arg f s1 s2 (= t1 t2)) (= (f s1 t1) (f s2 t2)))
     )
 )
 
 (program mk_nary_cong_eq ((U Type) (f (-> U U U)) (t1 U :list) (t2 U :list) (s1 U) (s2 U) (tail Bool :list))
-    ((-> U U) Bool) Bool
+    ((-> U U U) Bool) Bool
     (
         ((mk_nary_cong_eq f true)                 (= true true))
         ((mk_nary_cong_eq f (and (= s1 s2) tail)) (add_nary_arg f s1 s2 (mk_nary_cong_eq f tail)))

--- a/tests/use-match.eo
+++ b/tests/use-match.eo
@@ -1,5 +1,5 @@
-(program maybe_nil ((T Type) (t T))
-    (T T) T
+(program maybe_nil ((T Type) (U Type) (t T))
+    (T U) T
     (
       ((maybe_nil t t)       t)
       ((maybe_nil t "") t)


### PR DESCRIPTION
This changes type checking such that the free parameters of the types of parameters are also bound when that parameter is instantiated.

The motivation for this change:
- It makes the relationship between quote arrow and ordinary arrow more intuitive, i.e. quoting an argument does not impact its behavior.
- Ensures the types of parameters are taken into account instead of ignored.
- Allows for more powerful proof rules, e.g. the array extensionality rule added in a regression on this PR.

To implement this, we introduce a new distinguished operator `eo::param` or "annotated parameter" that "wraps" a parameter with its type. The match algorithm now treats this operator as a special case, matching the second argument with the type of the term that is matched.  This operator is used internally but is not available in the parser.

Fixes several regressions where the more pedantic check catches an error.