### PR TITLE
Simplify handling of parameteric nil terminators

### DIFF
--- a/src/state.cpp
+++ b/src/state.cpp
@@ -728,8 +728,7 @@ Expr State::mkExpr(Kind k, const std::vector<Expr>& children)
       // (prior to resolution) was PARAMETERIZED. So, for example, applying
       // `bvor` to `a` of type `(BitVec 4)` results in
       //   consTerm := #b0000.
-      Expr consTerm;
-      d_tc.computedParameterizedInternal(ai, children, consTerm);
+      Expr consTerm = d_tc.computeConstructorTermInternal(ai, children);
       Trace("state-debug") << "...updated " << consTerm << std::endl;
       vchildren[0] = hd;
       // if it has a constructor attribute

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -727,12 +727,10 @@ Expr State::mkExpr(Kind k, const std::vector<Expr>& children)
       // in hdTerm, where notice hdTerm is of kind PARAMETERIZED if consTerm
       // (prior to resolution) was PARAMETERIZED. So, for example, applying
       // `bvor` to `a` of type `(BitVec 4)` results in
-      //   hdTerm := (PARAMETERIZED (4) bvor),
       //   consTerm := #b0000.
-      Expr hdTerm;
       Expr consTerm;
-      d_tc.computedParameterizedInternal(ai, children, hdTerm, consTerm);
-      Trace("state-debug") << "...updated " << hdTerm << " / " << consTerm << std::endl;
+      d_tc.computedParameterizedInternal(ai, children, consTerm);
+      Trace("state-debug") << "...updated " << consTerm << std::endl;
       vchildren[0] = hd;
       // if it has a constructor attribute
       switch (ai->d_attrCons)

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -1698,26 +1698,8 @@ bool TypeChecker::computedParameterizedInternal(AppInfo* ai,
     }
     args.emplace_back(cv);
   }
-  // the head is now disambiguated
-  Trace("type_checker_debug") << "Infered parameterized op" << std::endl;
-  Ctx ctx;
-  if (args.size()==ct[0].getNumChildren())
-  {
-    for (size_t i=0, nparams = args.size(); i<nparams; i++)
-    {
-      ctx[ct[0][i].getValue()] = args[i].getValue();
-    }
-  }
-  else
-  {
-    // error
-    Warning() << "Unexpected number of parameters for " << hd[1]
-              << ", expected " << ct.getNumChildren() << " parameters, got "
-              << args.size() << std::endl;
-    return false;
-  }
-  Trace("type_checker") << "Context for constructor term: " << ctx << std::endl;
-  nil = evaluate(ct[1].getValue(), ctx);
+  Trace("type_checker") << "Context for constructor term: " << tctx << std::endl;
+  nil = evaluate(ct[1].getValue(), tctx);
   return true;
 }
 

--- a/src/type_checker.h
+++ b/src/type_checker.h
@@ -113,7 +113,6 @@ class TypeChecker
   /** Returns the (possibly disambiguated) operator in children and its nil terminator */
   bool computedParameterizedInternal(AppInfo* ai,
                                      const std::vector<Expr>& children,
-                                     Expr& hd,
                                      Expr& nil);
   /** The state */
   State& d_state;

--- a/src/type_checker.h
+++ b/src/type_checker.h
@@ -110,10 +110,6 @@ class TypeChecker
   /** Get the nil terminator */
   Expr computeConstructorTermInternal(AppInfo* ai,
                                       const std::vector<Expr>& children);
-  /** Returns the (possibly disambiguated) operator in children and its nil terminator */
-  bool computedParameterizedInternal(AppInfo* ai,
-                                     const std::vector<Expr>& children,
-                                     Expr& nil);
   /** The state */
   State& d_state;
   /** Plugin of the state */


### PR DESCRIPTION
This simplification is independent of the recent changes. This is simply a cleanup of the code based on the view that heads of n-ary apps do not need to be annotated.