### PR TITLE
Better support for explicit conclusions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,7 @@ ethos 0.1.2 prerelease
 - The option `--binder-fresh`, which specified for fresh variables to be constructed when parsing binders, has been removed.
 - Programs and oracles now are explicitly required to have at least one argument.
 - Remove support for the explicit parameter annotation `eo::_`, which was used to provide annotations for implicit arguments to parameterized constants.
+- Adds support for explicit conclusions to proof rules via `:conclusion-explicit`.
 
 ethos 0.1.1
 ===========

--- a/src/attr.cpp
+++ b/src/attr.cpp
@@ -21,8 +21,9 @@ std::ostream& operator<<(std::ostream& o, Attr a)
     case Attr::SORRY: o << "SORRY"; break;
     case Attr::LIST: o << "LIST"; break;
     case Attr::REQUIRES: o << "REQUIRES"; break;
-    case Attr::PREMISE_LIST: o << "PREMISE_LIST"; break;
-    case Attr::CONC_EXPLICIT: o << "CONC_EXPLICIT"; break;
+    case Attr::RULE_PREMISE_LIST: o << "RULE_PREMISE_LIST"; break;
+    case Attr::RULE_CONC_EXPLICIT: o << "RULE_CONC_EXPLICIT"; break;
+    case Attr::RULE_ASSUMPTION: o << "RULE_ASSUMPTION"; break;
     case Attr::PROGRAM: o << "PROGRAM"; break;
     case Attr::ORACLE: o << "ORACLE"; break;
     case Attr::BINDER: o << "BINDER"; break;

--- a/src/attr.cpp
+++ b/src/attr.cpp
@@ -22,6 +22,7 @@ std::ostream& operator<<(std::ostream& o, Attr a)
     case Attr::LIST: o << "LIST"; break;
     case Attr::REQUIRES: o << "REQUIRES"; break;
     case Attr::PREMISE_LIST: o << "PREMISE_LIST"; break;
+    case Attr::CONC_EXPLICIT: o << "CONC_EXPLICIT"; break;
     case Attr::PROGRAM: o << "PROGRAM"; break;
     case Attr::ORACLE: o << "ORACLE"; break;
     case Attr::BINDER: o << "BINDER"; break;

--- a/src/attr.h
+++ b/src/attr.h
@@ -41,6 +41,7 @@ enum class Attr
 
   // indicate how to construct proof rule steps
   PREMISE_LIST,
+  CONC_EXPLICIT, // note this may also have a cons for a premise list
 
   // indicate how to construct apps of function symbols
   RIGHT_ASSOC,

--- a/src/attr.h
+++ b/src/attr.h
@@ -41,7 +41,7 @@ enum class Attr
 
   // indicate how to construct proof rule steps
   PREMISE_LIST,
-  CONC_EXPLICIT, // note this may also have a cons for a premise list
+  CONC_EXPLICIT,  // note this may also have a cons for a premise list
 
   // indicate how to construct apps of function symbols
   RIGHT_ASSOC,

--- a/src/attr.h
+++ b/src/attr.h
@@ -40,8 +40,10 @@ enum class Attr
   RESTRICT,
 
   // indicate how to construct proof rule steps
-  PREMISE_LIST,
-  CONC_EXPLICIT,  // note this may also have a cons for a premise list
+  RULE_PREMISE_LIST,
+  RULE_CONC_EXPLICIT,   // note this may also have a cons for a premise list
+  RULE_ASSUMPTION,      // similarly, may also have a cons for a premise list
+  RULE_ASSUMPTION_CE,   // both :assumption and :conclusion-explicit
 
   // indicate how to construct apps of function symbols
   RIGHT_ASSOC,

--- a/src/cmd_parser.cpp
+++ b/src/cmd_parser.cpp
@@ -423,7 +423,7 @@ bool CmdParser::parseNextCommand()
       {
         conc = d_eparser.parseExpr();
       }
-      else if (keyword=="conclusion-explicit")
+      else if (keyword == "conclusion-explicit")
       {
         // :conclusion-given is equivalent to :conclusion eo::conclusion
         conc = d_eparser.parseExpr();
@@ -856,7 +856,7 @@ bool CmdParser::parseNextCommand()
       bool isPop = (tok==Token::STEP_POP);
       if (isPop)
       {
-        if (d_state.getAssumptionLevel()==0)
+        if (d_state.getAssumptionLevel() == 0)
         {
           d_lex.parseError("Cannot pop at level zero");
         }
@@ -904,7 +904,8 @@ bool CmdParser::parseNextCommand()
         args = d_eparser.parseExprList();
       }
       std::vector<Expr> children;
-      if (!d_state.getProofRuleArguments(children, rule, proven, premises, args, isPop))
+      if (!d_state.getProofRuleArguments(
+              children, rule, proven, premises, args, isPop))
       {
         d_lex.parseError("Failed to get arguments for proof rule");
       }

--- a/src/cmd_parser.h
+++ b/src/cmd_parser.h
@@ -36,6 +36,14 @@ class CmdParser
  protected:
   /** Next command token */
   Token nextCommandToken();
+  /** Get the proof rule arguments for an application of a proof rule.
+   */
+  void getProofRuleArguments(std::vector<Expr>& children,
+                             Expr& rule,
+                             Expr& proven,
+                             const std::vector<Expr>& premises,
+                             const std::vector<Expr>& args,
+                             bool isPop);
   /** The lexer */
   Lexer& d_lex;
   /** The state */

--- a/src/cmd_parser.h
+++ b/src/cmd_parser.h
@@ -36,14 +36,6 @@ class CmdParser
  protected:
   /** Next command token */
   Token nextCommandToken();
-  /** Get the proof rule arguments for an application of a proof rule.
-   */
-  void getProofRuleArguments(std::vector<Expr>& children,
-                             Expr& rule,
-                             Expr& proven,
-                             const std::vector<Expr>& premises,
-                             const std::vector<Expr>& args,
-                             bool isPop);
   /** The lexer */
   Lexer& d_lex;
   /** The state */

--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -1371,7 +1371,7 @@ Expr ExprParser::findFreeVar(const Expr& e, const std::vector<Expr>& bvs)
     if (std::find(bvs.begin(), bvs.end(), v)==bvs.end())
     {
       // ignore distinguished variables
-      if (v==d_state.mkConclusion() || v==d_state.mkSelf())
+      if (v==d_state.mkSelf())
       {
         continue;
       }

--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -1371,7 +1371,7 @@ Expr ExprParser::findFreeVar(const Expr& e, const std::vector<Expr>& bvs)
     if (std::find(bvs.begin(), bvs.end(), v)==bvs.end())
     {
       // ignore distinguished variables
-      if (v==d_state.mkSelf())
+      if (v == d_state.mkSelf())
       {
         continue;
       }

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1285,19 +1285,19 @@ Expr State::getProofRule(const std::string& name) const
 }
 
 bool State::getProofRuleArguments(std::vector<Expr>& children,
-                             Expr& rule,
-                             Expr& proven,
-                             std::vector<Expr>& premises,
-                             std::vector<Expr>& args,
-                             bool isPop)
+                                  Expr& rule,
+                                  Expr& proven,
+                                  std::vector<Expr>& premises,
+                                  std::vector<Expr>& args,
+                                  bool isPop)
 {
   children.emplace_back(rule.getValue());
   // arguments first
   children.insert(children.end(), args.begin(), args.end());
   AppInfo* ainfo = getAppInfo(rule.getValue());
-  if (ainfo!=nullptr)
+  if (ainfo != nullptr)
   {
-    if (ainfo->d_attrCons==Attr::CONC_EXPLICIT)
+    if (ainfo->d_attrCons == Attr::CONC_EXPLICIT)
     {
       if (proven.isNull())
       {
@@ -1309,7 +1309,8 @@ bool State::getProofRuleArguments(std::vector<Expr>& children,
     Expr plCons = ainfo->d_attrConsTerm;
     if (!plCons.isNull())
     {
-      Assert (ainfo->d_attrCons==Attr::CONC_EXPLICIT || ainfo->d_attrCons==Attr::PREMISE_LIST);
+      Assert(ainfo->d_attrCons == Attr::CONC_EXPLICIT
+             || ainfo->d_attrCons == Attr::PREMISE_LIST);
       std::vector<Expr> achildren;
       achildren.push_back(plCons);
       for (Expr& e : premises)

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1309,6 +1309,7 @@ bool State::getProofRuleArguments(std::vector<Expr>& children,
     Expr plCons = ainfo->d_attrConsTerm;
     if (!plCons.isNull())
     {
+      Assert (ainfo->d_attrCons==Attr::CONC_EXPLICIT || ainfo->d_attrCons==Attr::PREMISE_LIST);
       std::vector<Expr> achildren;
       achildren.push_back(plCons);
       for (Expr& e : premises)
@@ -1341,10 +1342,14 @@ bool State::getProofRuleArguments(std::vector<Expr>& children,
         ap = mkExpr(Kind::APPLY, achildren);
       }
       Expr pfap = mkProofType(ap);
-      // TODO: collect operator???
-      // dummy, const term of the given proof type
+      // dummy, "collected" term of the given proof type
       Expr n = mkSymbol(Kind::CONST, "tmp", pfap);
       children.push_back(n);
+    }
+    else
+    {
+      // otherwise ordinary premises
+      children.insert(children.end(), premises.begin(), premises.end());
     }
   }
   else

--- a/src/state.h
+++ b/src/state.h
@@ -166,7 +166,19 @@ class State
   Expr getBoundVar(const std::string& name, const Expr& type);
   /** Get the proof rule with the given name or nullptr if it does not exist */
   Expr getProofRule(const std::string& name) const;
-  /** Get actual premises */
+  /**
+   * Get proof rule arguments, which determines the argument list to a proof
+   * rule in a step or step-pop. This takes into account whether the rule was
+   * marked :premise-list, :conclusion-explicit, or :assumption (for step-pop
+   * commands).
+   * @param children The vector of children to populate.
+   * @param rule The proof rule being applied.
+   * @param proven The conclusion of the proof rule, if provided.
+   * @param premises The provided premises of the proof rule.
+   * @param args The provided arguments of the proof rule.
+   * @param isPop Whether we were a step-pop.
+   * @return true if we successfully populated the arguments to the proof rule.
+   */
   bool getProofRuleArguments(std::vector<Expr>& children,
                              Expr& rule,
                              Expr& proven,

--- a/src/state.h
+++ b/src/state.h
@@ -122,8 +122,6 @@ class State
   Expr mkRequires(const Expr& a1, const Expr& a2, const Expr& ret);
   /** */
   Expr mkSelf() const;
-  /** Make the conclusion variable */
-  Expr mkConclusion() const;
   /** Make pair */
   Expr mkPair(const Expr& t1, const Expr& t2);
   /** */
@@ -169,9 +167,12 @@ class State
   /** Get the proof rule with the given name or nullptr if it does not exist */
   Expr getProofRule(const std::string& name) const;
   /** Get actual premises */
-  bool getActualPremises(const ExprValue* ev,
-                         std::vector<Expr>& given,
-                         std::vector<Expr>& actual);
+  bool getProofRuleArguments(std::vector<Expr>& children,
+                             Expr& rule,
+                             Expr& proven,
+                             std::vector<Expr>& premises,
+                             std::vector<Expr>& args,
+                             bool isPop);
   /** Get the program */
   Expr getProgram(const ExprValue* ev);
   /** Get the oracle command */
@@ -217,7 +218,6 @@ class State
   Expr d_false;
   Expr d_self;
   Expr d_any;
-  Expr d_conclusion;
   Expr d_fail;
   Expr d_listType;
   Expr d_listNil;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -153,6 +153,7 @@ set(ethos_test_file_list
     double-list.eo
     list-param-immediate.eo
     conclusion-explicit-cases.eo
+    rule-all-cases.eo
 )
 
 if(ENABLE_ORACLES)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -152,6 +152,7 @@ set(ethos_test_file_list
     is-eq-tests.eo
     double-list.eo
     list-param-immediate.eo
+    conclusion-explicit-cases.eo
 )
 
 if(ENABLE_ORACLES)

--- a/tests/conclusion-explicit-cases.eo
+++ b/tests/conclusion-explicit-cases.eo
@@ -1,0 +1,26 @@
+(declare-const or (-> Bool Bool Bool) :right-assoc-nil true)
+(declare-const and (-> Bool Bool Bool) :right-assoc-nil false)
+(declare-const not (-> Bool Bool))
+
+(declare-rule split ((F Bool))
+  :conclusion-explicit (or F (not F))
+)
+
+(step @p0 (or true (not true)) :rule split)
+
+
+(declare-rule or-intro ((F Bool) (G Bool))
+  :premises (F)
+  :args (G)
+  :conclusion-explicit (or G F)
+)
+
+(declare-rule or-intro-ex2 ((F Bool) (G Bool))
+  :premise-list F and
+  :conclusion-explicit (or F G)
+)
+
+(assume @p1 true)
+(step @p2 (or true true) :rule or-intro :premises (@p1) :args (true))
+
+(step @p3 (or (and true true) true) :rule or-intro-ex2 :premises (@p1 @p1))

--- a/tests/conclusion-spec.eo
+++ b/tests/conclusion-spec.eo
@@ -9,9 +9,9 @@
   )
 )
 
-(declare-rule split ()
-  :requires (((is_split eo::conclusion) true))
-  :conclusion-given
+(declare-rule split ((C Bool))
+  :requires (((is_split C) true))
+  :conclusion-explicit C
 )
 
 (step @p0 (or true (not true)) :rule split)

--- a/tests/rule-all-cases.eo
+++ b/tests/rule-all-cases.eo
@@ -1,0 +1,14 @@
+(declare-const or (-> Bool Bool Bool) :right-assoc-nil true)
+(declare-const and (-> Bool Bool Bool) :right-assoc-nil false)
+(declare-const => (-> Bool Bool Bool))
+(declare-const not (-> Bool Bool))
+
+(declare-rule assume-explicit-list ((A Bool) (F Bool))
+  :assumption A
+  :premise-list F and
+  :conclusion-explicit (=> A F)
+)
+
+
+(assume-push @p0 true)
+(step-pop @p1 (=> true (and true true)) :rule assume-explicit-list :premises (@p0 @p0))

--- a/tests/segfault-98.eo
+++ b/tests/segfault-98.eo
@@ -5,9 +5,9 @@
   )
 )
 
-(declare-rule bind ((ctx Bool) (old_ctx Bool) (T Type) (l T) (r T) (l1 T) (r1 T))
+(declare-rule bind ((ctx Bool) (old_ctx Bool) (T Type) (l T) (r T) (l1 T) (r1 T) (C Bool))
   :assumption ctx
-  :conclusion-given
+  :conclusion-explicit C
 )
 
 (declare-const @cl (-> Bool Bool Bool) :right-assoc-nil false)

--- a/user_manual.md
+++ b/user_manual.md
@@ -1304,12 +1304,13 @@ The selectors of a constructor (which are never ambiguous) are returned independ
 The generic syntax for a `declare-rule` command accepted by `ethos` is:
 
 ```smt
-(declare-rule <symbol> :ethos (<typed-param>*) <assumption>? <premises>? <arguments>? <reqs>? :conclusion <term> <attr>*)
+(declare-rule <symbol> :ethos (<typed-param>*) <assumption>? <premises>? <arguments>? <reqs>? <conclusion> <attr>*)
 where
 <assumption>   ::= :assumption <term>
 <premises>     ::= :premises (<term>*) | :premise-list <term> <term>
 <arguments>    ::= :args (<term>*)
 <reqs>         ::= :requires ((<term> <term>)*)
+<conclusion>   ::= :conclusion <term> | :conclusion-explicit <term>
 ```
 
 A proof rule begins by defining a list of free parameters, followed by 4 optional fields and a conclusion term.
@@ -1402,6 +1403,26 @@ The conclusion of the rule returns `F` itself.
 Note that the type of functions provided as the second argument of `:premise-list` should be operators that are marked to take an arbitrary number of arguments, that is those marked e.g. with `:right-assoc-nil` or `:chainable`.
 
 <a name="proofs"></a>
+
+### Explicit Conclusions
+
+Rules can be specified to pattern match on the provided conclusion as input.
+This is useful if the proof rule is written in the style where an arbitrary conclusion can be provided by user, and is checked to see if it is a valid possible conclusion of the rule.
+For example:
+
+```smt
+(declare-const or (-> Bool Bool Bool) :right-assoc-nil true)
+(declare-const not (-> Bool Bool))
+
+(declare-rule split ((F Bool))
+  :conclusion-explicit (or F (not F))
+)
+(step @p0 (or true (not true)) :rule split)
+```
+
+In the above rule definition, a proof rule `split` is given which expects a conclusion of the form `(or F (not F))` to be provided.
+A step invoking this rule is only valid if the provided conclusion of that step matches this pattern.
+Any step not providing a conclusion as the second argument to the step command will result in a proof checking failure.
 
 ## Writing Proofs
 
@@ -1992,7 +2013,7 @@ When streaming input to Ethos, we assume the input is being given for a proof fi
     (declare-consts <lit-category> <type>) |
     (declare-parameterized-const <symbol> (<typed-param>*) <type> <attr>*) |
     (declare-oracle-fun <symbol> (<type>+) <type> <symbol>) |
-    (declare-rule <symbol> (<typed-param>*) <assumption>? <premises>? <arguments>? <reqs>? :conclusion <term> <attr>*) |
+    (declare-rule <symbol> (<typed-param>*) <assumption>? <premises>? <arguments>? <reqs>? <conclusion> <attr>*) |
     (declare-type <symbol> (<type>*)) |
     (define <symbol> (<typed-param>*) <term> <attr>*) |
     (define-type <symbol> (<type>*) <type>) |
@@ -2045,6 +2066,7 @@ When streaming input to Ethos, we assume the input is being given for a proof fi
 <simple-premises> ::= :premises (<term>*)
 <arguments>       ::= :args (<term>*)
 <reqs>            ::= :requires ((<term> <term>)*)
+<conclusion>      ::= :conclusion <term> | :conclusion-explicit <term>
 
 ```
 


### PR DESCRIPTION
This also makes our checking for assumptions / step-pop matching more pedantic.

For example, this proof checked previously by treating an ordinary argument as an assumption, this now does not due to an explicit check that proof rules with `:assumption` are the only ones that take assumptions.
```
(declare-rule temp ((A Bool))
  :assumption A
  :conclusion true
)
(step @p2 true :rule temp :args (true))