### PR TITLE
Add an optimization to list ops, fix corner case of list_nth

### DIFF
--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -1712,8 +1712,9 @@ Expr TypeChecker::evaluateListSetOfInternal(ExprValue* op,
   {
     return Expr(args[1]);
   }
-  // Similar to erase, for performance, we resize to the size of the vector at the place it was last modified,
-  // and take the changeIndex^th tail of args[1].
+  // Similar to erase, for performance, we resize to the size of the vector at
+  // the place it was last modified, and take the changeIndex^th tail of
+  // args[1].
   result.resize(changeSize);
   ExprValue* ret = getNAryNthTail(args[1], isLeft, changeIndex);
   return prependNAryChildren(op, ret, result, isLeft);

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -1067,15 +1067,14 @@ Expr TypeChecker::evaluateLiteralOp(Kind k,
 }
 
 /**
- * Get nary children, gets a list of children from op-application e
- * up to maxChildren (0 means no limit), stores them in children.
+ * Get nary children, gets a list of children from op-application e,
+ * stores them in children.
  */
 ExprValue* getNAryChildren(ExprValue* e,
                            ExprValue* op,
                            ExprValue* checkNil,
                            std::vector<ExprValue*>& children,
-                           bool isLeft,
-                           size_t maxChildren=0)
+                           bool isLeft)
 {
   ExprValue* orig = e;
   while (e->getKind()==Kind::APPLY)
@@ -1089,10 +1088,6 @@ ExprValue* getNAryChildren(ExprValue* e,
     children.push_back(isLeft ? (*e)[1] : (*cop)[1]);
     // traverse to tail
     e = isLeft ? (*cop)[1] : (*e)[1];
-    if (children.size()==maxChildren)
-    {
-      return e;
-    }
   }
   // must be equal to the nil term, if provided
   if (checkNil!=nullptr && e!=checkNil)
@@ -1569,17 +1564,13 @@ Expr TypeChecker::evaluateLiteralOpInternal(
         return d_null;
       }
       size_t i = index.toUnsignedInt();
-      // extract up to i+1 children
-      ExprValue* rem = getNAryChildren(args[1], op, nil, hargs, isLeft, i + 1);
-      if (hargs.size()==i+1)
+      // extract all children, to ensure a list
+      ExprValue* a = getNAryChildren(args[1], op, nil, hargs, isLeft);
+      if (a==nullptr && i>=hargs.size())
       {
-        if (!isNAryList(rem, op, nil, isLeft))
-        {
-          return d_null;
-        }
-        return Expr(hargs.back());
+        return d_null;
       }
-      return d_null;
+      return Expr(hargs[i]);
     }
       break;
     case Kind::EVAL_LIST_FIND:

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -1081,7 +1081,7 @@ ExprValue* getNAryChildren(ExprValue* e,
   while (e->getKind()==Kind::APPLY)
   {
     ExprValue* cop = (*e)[0];
-    if (cop->getKind()!=Kind::APPLY || (*cop)[0] != op)
+    if (cop->getKind() != Kind::APPLY || (*cop)[0] != op)
     {
       break;
     }
@@ -1103,15 +1103,12 @@ ExprValue* getNAryChildren(ExprValue* e,
   return e;
 }
 
-bool isNAryList(ExprValue* e,
-                ExprValue* op,
-                ExprValue* checkNil,
-                bool isLeft)
+bool isNAryList(ExprValue* e, ExprValue* op, ExprValue* checkNil, bool isLeft)
 {
-  while (e->getKind()==Kind::APPLY)
+  while (e->getKind() == Kind::APPLY)
   {
     ExprValue* cop = (*e)[0];
-    if (cop->getKind()!=Kind::APPLY || (*cop)[0] != op)
+    if (cop->getKind() != Kind::APPLY || (*cop)[0] != op)
     {
       return false;
     }
@@ -1119,20 +1116,18 @@ bool isNAryList(ExprValue* e,
     e = isLeft ? (*cop)[1] : (*e)[1];
   }
   // must be equal to the nil term
-  if (e!=checkNil)
+  if (e != checkNil)
   {
     return false;
   }
   return true;
 }
 
-ExprValue* getNAryNth(ExprValue* e,
-                      bool isLeft,
-                      size_t n)
+ExprValue* getNAryNth(ExprValue* e, bool isLeft, size_t n)
 {
-  for (size_t i=0; i<n; i++)
+  for (size_t i = 0; i < n; i++)
   {
-    Assert (e->getKind()==Kind::APPLY && (*e)[0]->getKind()==Kind::APPLY);
+    Assert(e->getKind() == Kind::APPLY && (*e)[0]->getKind() == Kind::APPLY);
     // traverse to tail
     e = isLeft ? (*(*e)[0])[1] : (*e)[1];
   }
@@ -1568,7 +1563,7 @@ Expr TypeChecker::evaluateLiteralOpInternal(
       }
       size_t i = index.toUnsignedInt();
       // extract up to i+1 children
-      ExprValue * rem = getNAryChildren(args[1], op, nil, hargs, isLeft, i+1);
+      ExprValue* rem = getNAryChildren(args[1], op, nil, hargs, isLeft, i + 1);
       if (hargs.size()==i+1)
       {
         if (!isNAryList(rem, op, nil, isLeft))
@@ -1649,11 +1644,11 @@ Expr TypeChecker::evaluateListEraseInternal(Kind k,
   bool isAll = (k == Kind::EVAL_LIST_ERASE_ALL);
   size_t changeIndex = 0;
   size_t changeSize = 0;
-  for (size_t i=0, nargs=hargs.size(); i<nargs; i++)
+  for (size_t i = 0, nargs = hargs.size(); i < nargs; i++)
   {
     if (hargs[i] == args[2])
     {
-      changeIndex = i+1;
+      changeIndex = i + 1;
       if (!isAll)
       {
         break;
@@ -1663,7 +1658,7 @@ Expr TypeChecker::evaluateListEraseInternal(Kind k,
     }
     result.emplace_back(hargs[i]);
   }
-  if (changeIndex==0)
+  if (changeIndex == 0)
   {
     return Expr(args[1]);
   }
@@ -1689,20 +1684,20 @@ Expr TypeChecker::evaluateListSetOfInternal(ExprValue* op,
   std::vector<ExprValue*> result;
   size_t changeIndex = 0;
   size_t changeSize = 0;
-  for (size_t i=0, nargs=hargs.size(); i<nargs; i++)
+  for (size_t i = 0, nargs = hargs.size(); i < nargs; i++)
   {
-    ExprValue * elem = hargs[i];
+    ExprValue* elem = hargs[i];
     if (seen.insert(elem).second)
     {
       result.emplace_back(elem);
     }
     else
     {
-      changeIndex = i+1;
+      changeIndex = i + 1;
       changeSize = result.size();
     }
   }
-  if (changeIndex==0)
+  if (changeIndex == 0)
   {
     return Expr(args[1]);
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -155,6 +155,7 @@ set(ethos_test_file_list
     double-list.eo
     list-param-immediate.eo
     nground-nil-ex.eo
+    list-nth-non-list.eo
 )
 
 if(ENABLE_ORACLES)

--- a/tests/list-nth-non-list.eo
+++ b/tests/list-nth-non-list.eo
@@ -1,0 +1,6 @@
+
+(declare-const or (-> Bool Bool Bool) :right-assoc-nil false)
+(declare-const a Bool)
+
+; (eo::cons or a a) constructs a non or-list, eo::list_nth should fail to evaluate
+(declare-const test (eo::requires (eo::is_ok (eo::list_nth or (eo::cons or a a) 0)) false Bool))


### PR DESCRIPTION
Based on the forthcoming spec, `list_nth` should not evaluate if the argument is not an f-list (even if it is a list up to the index n). The code was over-optimized to evaluate successfully in this case.

This also adds an important optimization to erase/erase_all/setof to avoid unecessary expression construction, which in my initial tests makes e.g. chain resolution 15% faster.