### PR TITLE
Minor change to proof rule semantics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ ethos 0.2.1 pre-release
 
 - Adds builtin list operators `eo::list_diff` (difference) and `eo::list_inter` (intersection).
 - Removes support for oracles and the command `declare-oracle-fun`. Custom extensions are now recommended to be added via the plugin feature, which provides an interface for custom evaluation (Plugin::hasEvaluation).
+- We now reject proof rules whose conclusions contain free parameters *only* occurring in the types of arguments. Furthermore, free parameters in the types of arguments to proof rules are not bound when applying the proof rule.
 
 ethos 0.2.0
 ===========

--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -783,11 +783,12 @@ std::vector<Expr> ExprParser::parseAndBindSortedVarList(
     else
     {
       v = d_state.mkSymbol(Kind::PARAM, name, t);
-      // if this parameter is used to define the type of a constant or proof
-      // rule, then if it has non-ground type, its type will be taken into
-      // account for matching and evaluation. We wrap it in (eo::param ...)
-      // here.
-      if ((k == Kind::CONST || k == Kind::PROOF_RULE) && !t.isGround())
+      // if this parameter is used to define the type of a constant, then if 
+      // it has non-ground type, its type will be taken into account for
+      // matching and evaluation. We wrap it in (eo::param ...) here.
+      // Older versions of ethos had also done this for PROOF_RULE, but
+      // we now view proof rules more as programs not constants.
+      if (k == Kind::CONST && !t.isGround())
       {
         v = d_state.mkExpr(Kind::ANNOT_PARAM, {v, t});
       }

--- a/tests/array-ext-implicit-type-infer.eo
+++ b/tests/array-ext-implicit-type-infer.eo
@@ -10,8 +10,11 @@
 (declare-parameterized-const select ((U Type :implicit) (T Type :implicit))
    (-> (Array U T) U T))
 
+; In ethos 0.2.0, this rule would work even if the T argument was removed.
+; The semantics for proof rules was simplified to not bind free parameters
+; in the *types* of arguments.
 (declare-rule array_ext ((T Type) (U Type) (a (Array T U)) (b (Array T U)))
-  :args (a b)
+  :args (T a b)
   :conclusion (or (= a b) (exists ((x T)) (not (= (select a x) (select b x)))))
 )
 
@@ -21,4 +24,4 @@
 (declare-const a1 (Array Int Int))
 (declare-const a2 (Array Int Int))
 
-(step @p0 (or (= a1 a2) (exists ((x Int)) (not (= (select a1 x) (select a2 x))))) :rule array_ext :args (a1 a2))
+(step @p0 (or (= a1 a2) (exists ((x Int)) (not (= (select a1 x) (select a2 x))))) :rule array_ext :args (Int a1 a2))


### PR DESCRIPTION
The commit https://github.com/cvc5/ethos/commit/de1a0ece902f553147d902264e1b27f90d895345 updated the type checker for applications of constants to also consider their type.

The above change also was applied to *proof rules*, as one can view proof rules as constants.

However, for simplicity, we can also see proof rules as programs, in which case it is simpler and more intuitive for proof rules to not automatically bind the parameters in types.

One regression had been added demonstrating this feature, we fix it and give an explanation.