### PR TITLE
Eliminate requires on parameters

### DIFF
--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -1174,7 +1174,6 @@ void ExprParser::parseAttributeList(
             case Attr::OPAQUE:
               // requires no value
               break;
-            case Attr::REQUIRES: val = parseExprPair(); break;
             case Attr::RESTRICT:
               // requires an expression that follows
               val = parseExpr();

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -526,29 +526,11 @@ Expr State::mkFunctionType(const std::vector<Expr>& args, const Expr& ret, bool 
     return Expr(mkExprInternal(Kind::FUNCTION_TYPE, atypes));
   }
   Expr curr = ret;
-  Kind rk = ret.getKind();
-  if (rk==Kind::EVAL_REQUIRES)
-  {
-    Expr currBase = ret;
-    do
-    {
-      currBase = currBase[2];
-      rk = currBase.getKind();
-    }while (rk==Kind::EVAL_REQUIRES);
-  }
   // no way to construct quote types, e.g. on return types
-  Assert (rk!=Kind::QUOTE_TYPE);
+  Assert (ret.getKind()!=Kind::QUOTE_TYPE);
   for (size_t i=0, nargs = args.size(); i<nargs; i++)
   {
     Expr a = args[(nargs-1)-i];
-    // process arguments
-    Kind ak = a.getKind();
-    while (ak == Kind::EVAL_REQUIRES)
-    {
-      curr = mkRequires(a[0], a[1], curr);
-      a = a[2];
-      ak = a.getKind();
-    }
     // append the function
     curr = Expr(
         mkExprInternal(Kind::FUNCTION_TYPE, {a.getValue(), curr.getValue()}));

--- a/tests/Arith-theory.eo
+++ b/tests/Arith-theory.eo
@@ -64,22 +64,22 @@
       Bool))) :chainable and)
 
 (declare-parameterized-const to_real
-  ((T Type :implicit) (t T :requires ((is_arith_type T) true)))
-  Real)
+  ((T Type :implicit) (t T))
+  (eo::requires (is_arith_type T) true Real))
 (declare-parameterized-const to_int
-  ((T Type :implicit) (t T :requires ((is_arith_type T) true)))
-  Int)
+  ((T Type :implicit) (t T))
+  (eo::requires (is_arith_type T) true Int))
 (declare-parameterized-const is_int
-  ((T Type :implicit) (t T :requires ((is_arith_type T) true)))
-  Bool)
+  ((T Type :implicit) (t T))
+  (eo::requires (is_arith_type T) true Bool))
 (declare-parameterized-const abs
-  ((T Type :implicit) (t T :requires ((is_arith_type T) true)))
-  T)
+  ((T Type :implicit) (t T))
+  (eo::requires (is_arith_type T) true T))
 
 ; power
 (declare-parameterized-const ^ ((T Type :implicit) (U Type :implicit)) 
   (-> T U (arith_typeunion T U)))
 
 ; currently unary negation cannot use overload
-(declare-parameterized-const u- ((T Type :implicit) (t T :requires ((is_arith_type T) true))) 
-  T)
+(declare-parameterized-const u- ((T Type :implicit) (t T))
+  (eo::requires (is_arith_type T) true T))

--- a/tests/bv-type-strict.eo
+++ b/tests/bv-type-strict.eo
@@ -20,7 +20,8 @@
     )
 )
 
-(declare-parameterized-const BitVec ((w Int :requires ((run_evaluate (> w 0)) true))) Type)
+(declare-parameterized-const BitVec ((w Int)) 
+  (eo::requires (run_evaluate (> w 0)) true Type))
 
 (declare-parameterized-const bvadd ((n Int :implicit)) 
   (-> (BitVec n) (BitVec n) (BitVec n)))

--- a/tests/nested-requires.eo
+++ b/tests/nested-requires.eo
@@ -1,7 +1,7 @@
 (declare-type Int ())
 (declare-consts <numeral> Int)
 (declare-parameterized-const C 
-  ((x Int) (y Int :requires ((eo::gt x y) true) :requires ((eo::gt x y) true)))
-  Type)
+  ((x Int) (y Int))
+  (eo::requires (eo::gt x y) true (eo::requires (eo::gt x y) true Type)))
 
 (declare-const test (C 4 3))

--- a/tests/quote-requires.eo
+++ b/tests/quote-requires.eo
@@ -1,7 +1,8 @@
 (declare-type Int ())
 (declare-consts <numeral> Int)
 
-(declare-parameterized-const BitVec ((n Int :requires ((eo::gt n 0) true))) Type)
+(declare-parameterized-const BitVec ((n Int))
+  (eo::requires (eo::gt n 0) true Type))
 
 (declare-const f (BitVec 3))
 

--- a/user_manual.md
+++ b/user_manual.md
@@ -254,23 +254,6 @@ For details, see [ambiguous functions](#amb-functions).
 
 > __Note:__ Internally, `(t T :implicit)` drops `t` from the list of arguments of the function type we are defining.
 
-### The :requires annotation
-
-Arguments to functions can also be annotated with the attribute `:requires (<term> <term>)` to denote a equality condition that is required for applications of the term to type check.
-
-```smt
-(declare-type Int ())
-(declare-parameterized-const BitVec ((w Int :requires ((eo::is_neg w) false))) Type)
-```
-The above declares the integer type `Int` and a bitvector type constructor `BitVec` that expects a _non-negative integer_ `w`.
-In detail, the first argument of `BitVec` is supposed to be an `Int` value and is named `w` via the `:var` attribute.
-The second annotation indicates that the term `(eo::is_neg w)` must evaluate to `false` at type checking type.
-Symbol `eo::is_neg` denotes a builtin function that returns `true` if its argument is a negative numeral, and returns false otherwise (for details, see [computation](#computation)).
-<!-- This needs discussion, what is the input type of `eo::is_neg`? How can `eo::is_neg` accept a value of a user-defined type `Int` given that it is builtin?  -->
-
-> __Note:__ Internally, a parameter `(t T :requires (s r))` is syntax sugar for the type term `(eo::requires s r T)` where `eo::requires` is an operator that evaluates to its third argument if and only if its first two arguments are _computationally_ equivalent (details on this operator are given in [computation](#computation)).
-Furthermore, the function type `(-> (eo::requires s r T) S)` is treated as `(-> T (eo::requires s r S))`. Ethos rewrites all types of the former form to the latter.
-
 <a name="opaque"></a>
 
 ### The :opaque annotation
@@ -1457,6 +1440,14 @@ A list of requirements can be given to a proof rule.
 
 This rule expects an arithmetic inequality.
 It requires that the left hand side of this inequality `x` is a negative numeral, which is checked via the requirement `:requires (((eo::is_neg x) true))`.
+The above requires annotation is equivalent to wrapping the conclusion in an `eo::requires` term (for details, see [computation](#computation)).
+In particular, the above is equivalent to:
+
+```smt
+(declare-rule leq-contra ((x Int))
+    :premise ((>= x 0))
+    :conclusion (eo::requires (eo::is_neg x) true false))
+```
 
 ### Premise lists
 


### PR DESCRIPTION
Furthermore eliminates the fairly unintuitive behavior of pushing requires from function arguments to function returns.