### PR TITLE
Forbid evaluation in types, apart from return types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ ethos 0.2.1 pre-release
 - Removes support for `eo::match`, which was equivalent to invoking an auxiliary function. These auxiliary functions now should be defined explicitly.
 - Adds builtin list operators `eo::list_diff` (difference) and `eo::list_inter` (intersection)
 - Removes support for oracles and the command `declare-oracle-fun`. Custom extensions are now recommended to be added via the plugin feature, which provides an interface for custom evaluation (Plugin::hasEvaluation).
+- Evaluation is now forbidden in types of parameters and in the argument types of programs.
 
 
 ethos 0.2.0

--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -464,7 +464,7 @@ Expr ExprParser::parseExpr()
   return ret;
 }
 
-Expr ExprParser::parseType(bool allowQuoteArg)
+Expr ExprParser::parseType(bool allowQuoteArg, bool allowEval)
 {
   if (allowQuoteArg)
   {
@@ -498,13 +498,24 @@ Expr ExprParser::parseType(bool allowQuoteArg)
   // ensure it is a type
   typeCheck(e, d_state.mkType());
   // should not contain stuck term
-  if (e.isGround() && e.isEvaluatable())
+  if (e.isEvaluatable())
   {
-    std::stringstream msg;
-    msg << "Parsed type has an unevalated term:" << std::endl;
-    msg << "Type: " << e << std::endl;
-    d_lex.parseError(msg.str());
+    if (e.isGround())
+    {
+      std::stringstream msg;
+      msg << "Parsed type has an unevalated term:" << std::endl;
+      msg << "Type: " << e << std::endl;
+      d_lex.parseError(msg.str());
+    }
+    else if (!allowEval)
+    {
+      std::stringstream msg;
+      msg << "Parsed type cannot contain evaluation in this context:" << std::endl;
+      msg << "Type: " << e << std::endl;
+      d_lex.parseError(msg.str());
+    }
   }
+  
   return e;
 }
 
@@ -540,7 +551,8 @@ std::vector<Expr> ExprParser::parseTypeList(bool allowQuoteArg)
   while (tok != Token::RPAREN)
   {
     d_lex.reinsertToken(tok);
-    Expr t = parseType(allowQuoteArg);
+    // never allow evaluation
+    Expr t = parseType(allowQuoteArg, false);
     terms.push_back(t);
     tok = d_lex.nextToken();
   }
@@ -614,7 +626,8 @@ std::vector<Expr> ExprParser::parseAndBindSortedVarList(
   while (d_lex.eatTokenChoice(Token::LPAREN, Token::RPAREN))
   {
     name = parseSymbol();
-    t = parseType();
+    // do not allow quote or evaluation
+    t = parseType(false, false);
     Expr v;
     bool isImplicit = false;
     if (k == Kind::NONE)

--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -510,12 +510,13 @@ Expr ExprParser::parseType(bool allowQuoteArg, bool allowEval)
     else if (!allowEval)
     {
       std::stringstream msg;
-      msg << "Parsed type cannot contain evaluation in this context:" << std::endl;
+      msg << "Parsed type cannot contain evaluation in this context:"
+          << std::endl;
       msg << "Type: " << e << std::endl;
       d_lex.parseError(msg.str());
     }
   }
-  
+
   return e;
 }
 

--- a/src/expr_parser.h
+++ b/src/expr_parser.h
@@ -27,14 +27,15 @@ class ExprParser
   ExprParser(Lexer& lex, State& state, bool isSignature);
   virtual ~ExprParser() {}
 
-  /** Parses an SMT-LIB term <term> */
+  /** Parses a term <term> */
   Expr parseExpr();
   /**
-   * Parses an SMT-LIB type <type>
-   * @param allowQuoteArg If true, we also permit (eo::arg <term>).
+   * Parses a type <type>. We reject types that are ground and evaluatable.
+   * @param allowQuoteArg If true, we also permit (eo::quote <term>).
+   * @param allowEval If true, we permit the term to be evaluatable.
    */
-  Expr parseType(bool allowQuoteArg=false);
-  /** Parses an SMT-LIB formula <formula> */
+  Expr parseType(bool allowQuoteArg=false, bool allowEval=true);
+  /** Parses a formula <formula> (term of Boolean type). */
   Expr parseFormula();
   /** Parses an SMT-LIB term pair */
   Expr parseExprPair();
@@ -43,10 +44,11 @@ class ExprParser
   /** Parses parentheses-enclosed term list (<term>*) */
   std::vector<Expr> parseExprList();
   /**
-   * Parses parentheses-enclosed term list (<type>*)
-   * @param allowQuoteArg If true, we also permit (eo::arg t).
+   * Parses parentheses-enclosed term list (<type>*).
+   * Note that we never allow evaluation in types in this list.
+   * @param allowQuoteArg If true, we also permit (eo::quote t).
    */
-  std::vector<Expr> parseTypeList(bool allowQuoteArg=false);
+  std::vector<Expr> parseTypeList(bool allowQuoteArg = false);
   /** Parses parentheses-enclosed term list ((<term> <term>)*) */
   std::vector<Expr> parseExprPairList();
   /**
@@ -55,6 +57,7 @@ class ExprParser
    * All variables marked
    * :implicit that were parsed and not added to the return value of this
    * method.
+   * Note that we never allow quote or evaluation in types in this list.
    *
    * @param k The category of the parameter list:
    * - CONST if this is a parameter list of declare-paramaterized-const.

--- a/src/expr_parser.h
+++ b/src/expr_parser.h
@@ -34,7 +34,7 @@ class ExprParser
    * @param allowQuoteArg If true, we also permit (eo::quote <term>).
    * @param allowEval If true, we permit the term to be evaluatable.
    */
-  Expr parseType(bool allowQuoteArg=false, bool allowEval=true);
+  Expr parseType(bool allowQuoteArg = false, bool allowEval = true);
   /** Parses a formula <formula> (term of Boolean type). */
   Expr parseFormula();
   /** Parses an SMT-LIB term pair */


### PR DESCRIPTION
This forbids examples such as the following:
```
(declare-parameterized-const foo1 
  ((T Type) (U Type) (F Bool) (c (eo::ite F T U))) 
  Type)

(program foo2 ((T Type) (U Type) (F Bool) (t T))
  :signature ((eo::ite F T U)) Type
  (
  ((foo2 t) Type)
  )
)
