### PR TITLE
ci: Fix installation of GMP formula from path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,8 @@ jobs:
 
     - name: Install Packages (macOS)
       if: runner.os == 'macOS'
+      env:
+        HOMEBREW_DEVELOPER: 1 # Required by Brew >= 4.6.4. See https://github.com/Homebrew/brew/pull/20414
       run: |
         # Install GMP 6.3.0 bottle for macOS 12.0 (monterey)
         # Ensure compatibility with older versions of macOS


### PR DESCRIPTION
This is a preventive fix before Homebrew is updated in CI.