### PR TITLE
Add non-singleton versions of `assoc-nil` operators

### DIFF
--- a/src/attr.cpp
+++ b/src/attr.cpp
@@ -30,7 +30,9 @@ std::ostream& operator<<(std::ostream& o, Attr a)
     case Attr::RIGHT_ASSOC: o << "right-assoc"; break;
     case Attr::LEFT_ASSOC: o << "left-assoc"; break;
     case Attr::RIGHT_ASSOC_NIL: o << "right-assoc-nil"; break;
-    case Attr::LEFT_ASSOC_NIL: o << "let-assoc-nil"; break;
+    case Attr::LEFT_ASSOC_NIL: o << "left-assoc-nil"; break;
+    case Attr::RIGHT_ASSOC_NS_NIL: o << "right-assoc-non-singleton-nil"; break;
+    case Attr::LEFT_ASSOC_NS_NIL: o << "left-assoc-non-singleton-nil"; break;
     case Attr::CHAINABLE: o << "chainable"; break;
     case Attr::PAIRWISE: o << "pairwise"; break;
     case Attr::ARG_LIST: o << "arg-list"; break;
@@ -56,6 +58,21 @@ bool isNAryAttr(Attr a)
     case Attr::CHAINABLE:
     case Attr::PAIRWISE:
     case Attr::ARG_LIST: return true;
+    default:
+      break;
+  }
+  return false;
+}
+
+bool isListNilAttr(Attr a)
+{
+  switch (a)
+  {
+    case Attr::LEFT_ASSOC_NIL:
+    case Attr::RIGHT_ASSOC_NIL:
+    case Attr::RIGHT_ASSOC_NS_NIL:
+    case Attr::LEFT_ASSOC_NS_NIL:
+      return true;
     default:
       break;
   }

--- a/src/attr.cpp
+++ b/src/attr.cpp
@@ -71,10 +71,8 @@ bool isListNilAttr(Attr a)
     case Attr::LEFT_ASSOC_NIL:
     case Attr::RIGHT_ASSOC_NIL:
     case Attr::RIGHT_ASSOC_NS_NIL:
-    case Attr::LEFT_ASSOC_NS_NIL:
-      return true;
-    default:
-      break;
+    case Attr::LEFT_ASSOC_NS_NIL: return true;
+    default: break;
   }
   return false;
 }

--- a/src/attr.cpp
+++ b/src/attr.cpp
@@ -51,6 +51,8 @@ bool isNAryAttr(Attr a)
     case Attr::RIGHT_ASSOC:
     case Attr::LEFT_ASSOC_NIL:
     case Attr::RIGHT_ASSOC_NIL:
+    case Attr::RIGHT_ASSOC_NS_NIL:
+    case Attr::LEFT_ASSOC_NS_NIL:
     case Attr::CHAINABLE:
     case Attr::PAIRWISE:
     case Attr::ARG_LIST: return true;

--- a/src/attr.h
+++ b/src/attr.h
@@ -70,6 +70,10 @@ enum class Attr
  */
 bool isNAryAttr(Attr a);
 /**
+ * Returns true if the attribute is :(right|left)-assoc-(non-singleton)?-nil.
+ */
+bool isListNilAttr(Attr a);
+/**
  * Is the Attr specifying a constructor kind?
  */
 bool isConstructorKindAttr(Attr a);

--- a/src/attr.h
+++ b/src/attr.h
@@ -49,7 +49,7 @@ enum class Attr
   LEFT_ASSOC,
   RIGHT_ASSOC_NIL,
   LEFT_ASSOC_NIL,
-  RIGHT_ASSOC_NS_NIL, // non-singleton version
+  RIGHT_ASSOC_NS_NIL,  // non-singleton version
   LEFT_ASSOC_NS_NIL,
   CHAINABLE,
   PAIRWISE,

--- a/src/attr.h
+++ b/src/attr.h
@@ -49,6 +49,8 @@ enum class Attr
   LEFT_ASSOC,
   RIGHT_ASSOC_NIL,
   LEFT_ASSOC_NIL,
+  RIGHT_ASSOC_NS_NIL, // non-singleton version
+  LEFT_ASSOC_NS_NIL,
   CHAINABLE,
   PAIRWISE,
   ARG_LIST,

--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -1047,6 +1047,8 @@ void ExprParser::parseAttributeList(
             break;
           case Attr::RIGHT_ASSOC_NIL:
           case Attr::LEFT_ASSOC_NIL:
+          case Attr::RIGHT_ASSOC_NS_NIL:
+          case Attr::LEFT_ASSOC_NS_NIL:
           case Attr::CHAINABLE:
           case Attr::PAIRWISE:
           case Attr::BINDER:

--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -71,6 +71,8 @@ ExprParser::ExprParser(Lexer& lex, State& state, bool isSignature)
   d_strToAttr[":right-assoc"] = Attr::RIGHT_ASSOC;
   d_strToAttr[":left-assoc-nil"] = Attr::LEFT_ASSOC_NIL;
   d_strToAttr[":right-assoc-nil"] = Attr::RIGHT_ASSOC_NIL;
+  d_strToAttr[":left-assoc-non-singleton-nil"] = Attr::LEFT_ASSOC_NS_NIL;
+  d_strToAttr[":right-assoc-non-singleton-nil"] = Attr::RIGHT_ASSOC_NS_NIL;
   d_strToAttr[":chainable"] = Attr::CHAINABLE;
   d_strToAttr[":pairwise"] = Attr::PAIRWISE;
   d_strToAttr[":binder"] = Attr::BINDER;

--- a/src/kind.cpp
+++ b/src/kind.cpp
@@ -81,6 +81,7 @@ std::ostream& operator<<(std::ostream& o, Kind k)
     case Kind::EVAL_LIST_MEQ: o << "EVAL_LIST_MEQ"; break;
     case Kind::EVAL_LIST_DIFF: o << "EVAL_LIST_DIFF"; break;
     case Kind::EVAL_LIST_INTER: o << "EVAL_LIST_INTER"; break;
+    case Kind::EVAL_LIST_SINGLETON_ELIM: o << "EVAL_LIST_SINGLETON_ELIM"; break;
     // boolean
     case Kind::EVAL_NOT: o << "EVAL_NOT"; break;
     case Kind::EVAL_AND: o << "EVAL_AND"; break;
@@ -174,6 +175,7 @@ std::string kindToTerm(Kind k)
           case Kind::EVAL_LIST_MEQ: ss << "list_meq"; break;
           case Kind::EVAL_LIST_DIFF: ss << "list_diff"; break;
           case Kind::EVAL_LIST_INTER: ss << "list_inter"; break;
+          case Kind::EVAL_LIST_SINGLETON_ELIM: ss << "list_singleton_elim"; break;
           // boolean
           case Kind::EVAL_NOT: ss << "not"; break;
           case Kind::EVAL_AND: ss << "and"; break;
@@ -278,6 +280,7 @@ bool isLiteralOp(Kind k)
     case Kind::EVAL_LIST_MEQ:
     case Kind::EVAL_LIST_DIFF:
     case Kind::EVAL_LIST_INTER:
+    case Kind::EVAL_LIST_SINGLETON_ELIM:
     // boolean
     case Kind::EVAL_NOT:
     case Kind::EVAL_AND:
@@ -342,7 +345,8 @@ bool isListLiteralOp(Kind k)
     case Kind::EVAL_LIST_MINCLUDE:
     case Kind::EVAL_LIST_MEQ:
     case Kind::EVAL_LIST_DIFF:
-    case Kind::EVAL_LIST_INTER: return true;
+    case Kind::EVAL_LIST_INTER:
+    case Kind::EVAL_LIST_SINGLETON_ELIM: return true;
     default:
       break;
   }

--- a/src/kind.cpp
+++ b/src/kind.cpp
@@ -175,7 +175,9 @@ std::string kindToTerm(Kind k)
           case Kind::EVAL_LIST_MEQ: ss << "list_meq"; break;
           case Kind::EVAL_LIST_DIFF: ss << "list_diff"; break;
           case Kind::EVAL_LIST_INTER: ss << "list_inter"; break;
-          case Kind::EVAL_LIST_SINGLETON_ELIM: ss << "list_singleton_elim"; break;
+          case Kind::EVAL_LIST_SINGLETON_ELIM:
+            ss << "list_singleton_elim";
+            break;
           // boolean
           case Kind::EVAL_NOT: ss << "not"; break;
           case Kind::EVAL_AND: ss << "and"; break;

--- a/src/kind.h
+++ b/src/kind.h
@@ -95,6 +95,7 @@ enum class Kind
   EVAL_LIST_MEQ,
   EVAL_LIST_DIFF,
   EVAL_LIST_INTER,
+  EVAL_LIST_SINGLETON_ELIM,
   // boolean
   EVAL_NOT,
   EVAL_AND,

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -129,6 +129,7 @@ State::State(Options& opts, Stats& stats)
   bindBuiltinEval("list_meq", Kind::EVAL_LIST_MEQ);
   bindBuiltinEval("list_diff", Kind::EVAL_LIST_DIFF);
   bindBuiltinEval("list_inter", Kind::EVAL_LIST_INTER);
+  bindBuiltinEval("list_singleton_elim", Kind::EVAL_LIST_SINGLETON_ELIM);
   // boolean
   bindBuiltinEval("not", Kind::EVAL_NOT);
   bindBuiltinEval("and", Kind::EVAL_AND);
@@ -1024,8 +1025,7 @@ Expr State::mkApplyAttr(AppInfo* ai,
         {
           cc[prevIndex] = curr;
           cc[nextIndex] = vchildren[isLeft ? i : nchild - i];
-          // if the "head" child is marked as list, we construct
-          // Kind::EVAL_LIST_CONCAT
+          // if the "head" child is marked as list, we construct concatenation
           if (isNil && getConstructorKind(cc[nextIndex]) == Attr::LIST)
           {
             curr = mkExprInternal(Kind::EVAL_LIST_CONCAT, cc);
@@ -1039,6 +1039,8 @@ Expr State::mkApplyAttr(AppInfo* ai,
         if (isNsNil)
         {
           // add singleton elimination
+          std::vector<ExprValue*> ccse{hd, curr};
+          curr = mkExprInternal(Kind::EVAL_LIST_SINGLETON_ELIM, ccse);
         }
         Trace("type_checker")
             << "...return for " << Expr(vchildren[0]) << std::endl;

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1040,8 +1040,10 @@ Expr State::mkApplyAttr(AppInfo* ai,
         {
           // If we are a "non-singleton" kind, we add singleton elimination.
           // Note that this case is applied possibly on ground arguments,
-          // in contrast to the case of EVAL_LIST_CONCAT above. Hence, we must
-          // call mkExpr in case we evaluate this application immediately.
+          // in contrast to the case of EVAL_LIST_CONCAT above which requires a
+          // :list annotation, which can only be applied to parameters. Hence,
+          // we must call mkExpr in case we evaluate this application
+          // immediately.
           std::vector<Expr> ccse;
           ccse.emplace_back(hd);
           ccse.emplace_back(curr);

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -970,6 +970,8 @@ Expr State::mkApplyAttr(AppInfo* ai,
     case Attr::RIGHT_ASSOC:
     case Attr::LEFT_ASSOC_NIL:
     case Attr::RIGHT_ASSOC_NIL:
+    case Attr::RIGHT_ASSOC_NS_NIL:
+    case Attr::LEFT_ASSOC_NS_NIL:
     {
       // This means that we don't construct bogus terms when e.g.
       // right-assoc-nil operators are used in side condition bodies.
@@ -978,8 +980,11 @@ Expr State::mkApplyAttr(AppInfo* ai,
       if (nchild >= 2)
       {
         bool isLeft = (ai->d_attrCons == Attr::LEFT_ASSOC
-                       || ai->d_attrCons == Attr::LEFT_ASSOC_NIL);
-        bool isNil = (ai->d_attrCons == Attr::RIGHT_ASSOC_NIL
+                       || ai->d_attrCons == Attr::LEFT_ASSOC_NIL
+                       || ai->d_attrCons == Attr::LEFT_ASSOC_NS_NIL);
+        bool isNsNil = (ai->d_attrCons == Attr::RIGHT_ASSOC_NS_NIL
+                      || ai->d_attrCons == Attr::LEFT_ASSOC_NS_NIL);
+        bool isNil = (isNsNil || ai->d_attrCons == Attr::RIGHT_ASSOC_NIL
                       || ai->d_attrCons == Attr::LEFT_ASSOC_NIL);
         size_t i = 1;
         ExprValue* curr = vchildren[isLeft ? i : nchild - i];

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -984,7 +984,7 @@ Expr State::mkApplyAttr(AppInfo* ai,
                        || ai->d_attrCons == Attr::LEFT_ASSOC_NIL
                        || ai->d_attrCons == Attr::LEFT_ASSOC_NS_NIL);
         bool isNsNil = (ai->d_attrCons == Attr::RIGHT_ASSOC_NS_NIL
-                      || ai->d_attrCons == Attr::LEFT_ASSOC_NS_NIL);
+                        || ai->d_attrCons == Attr::LEFT_ASSOC_NS_NIL);
         bool isNil = (isNsNil || ai->d_attrCons == Attr::RIGHT_ASSOC_NIL
                       || ai->d_attrCons == Attr::LEFT_ASSOC_NIL);
         size_t i = 1;

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1038,7 +1038,7 @@ Expr State::mkApplyAttr(AppInfo* ai,
         }
         if (isNsNil)
         {
-          // add singleton elimination
+          // if we a "non-singleton" kind, we add singleton elimination
           std::vector<ExprValue*> ccse{hd, curr};
           curr = mkExprInternal(Kind::EVAL_LIST_SINGLETON_ELIM, ccse);
         }

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1036,6 +1036,10 @@ Expr State::mkApplyAttr(AppInfo* ai,
           }
           i++;
         }
+        if (isNsNil)
+        {
+          // add singleton elimination
+        }
         Trace("type_checker")
             << "...return for " << Expr(vchildren[0]) << std::endl;
         return Expr(curr);

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1038,9 +1038,14 @@ Expr State::mkApplyAttr(AppInfo* ai,
         }
         if (isNsNil)
         {
-          // if we a "non-singleton" kind, we add singleton elimination
-          std::vector<ExprValue*> ccse{hd, curr};
-          curr = mkExprInternal(Kind::EVAL_LIST_SINGLETON_ELIM, ccse);
+          // If we are a "non-singleton" kind, we add singleton elimination.
+          // Note that this case is applied possibly on ground arguments,
+          // in contrast to the case of EVAL_LIST_CONCAT above. Hence, we must
+          // call mkExpr in case we evaluate this application immediately.
+          std::vector<Expr> ccse;
+          ccse.emplace_back(hd);
+          ccse.emplace_back(curr);
+          return mkExpr(Kind::EVAL_LIST_SINGLETON_ELIM, ccse);
         }
         Trace("type_checker")
             << "...return for " << Expr(vchildren[0]) << std::endl;
@@ -1406,7 +1411,7 @@ bool State::getProofRuleArguments(std::vector<Expr>& children,
         // the nil terminator if applied to empty list
         AppInfo* aic = getAppInfo(plCons.getValue());
         Attr ck = aic->d_attrCons;
-        if (ck==Attr::RIGHT_ASSOC_NIL || ck==Attr::LEFT_ASSOC_NIL)
+        if (isListNilAttr(ck))
         {
           ap = aic->d_attrConsTerm;
         }

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -163,7 +163,8 @@ bool TypeChecker::checkArity(Kind k, size_t nargs, std::ostream* out)
     case Kind::EVAL_GT:
     case Kind::EVAL_LIST_LENGTH:
     case Kind::EVAL_LIST_REV:
-    case Kind::EVAL_LIST_SETOF: ret = (nargs == 2); break;
+    case Kind::EVAL_LIST_SETOF:
+    case Kind::EVAL_LIST_SINGLETON_ELIM: ret = (nargs == 2); break;
     case Kind::EVAL_NIL:
       ret = (nargs==2);
       break;
@@ -1569,6 +1570,15 @@ Expr TypeChecker::evaluateLiteralOpInternal(
     case Kind::EVAL_LIST_DIFF:
     case Kind::EVAL_LIST_INTER:
       return evaluateListDiffInterInternal(k, op, nil, isLeft, args);
+    case Kind::EVAL_LIST_SINGLETON_ELIM: 
+    {
+      std::vector<ExprValue*> hargs;
+      if (getNAryChildren(args[1], op, nil, hargs, isLeft) == nullptr)
+      {
+        return d_null;
+      }
+      return Expr(hargs.size()==1 ? hargs[0] : args[1]);
+    }
     default:
       break;
   }
@@ -1820,7 +1830,8 @@ Expr TypeChecker::getLiteralOpType(Kind k,
     case Kind::EVAL_LIST_REV:
     case Kind::EVAL_LIST_SETOF:
     case Kind::EVAL_LIST_DIFF:
-    case Kind::EVAL_LIST_INTER: return Expr(childTypes[1]);
+    case Kind::EVAL_LIST_INTER:
+    case Kind::EVAL_LIST_SINGLETON_ELIM: return Expr(childTypes[1]);
     case Kind::EVAL_CONCAT:
     case Kind::EVAL_EXTRACT:
       // type is the first child

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -1433,7 +1433,7 @@ Expr TypeChecker::evaluateLiteralOpInternal(
     // not an associative operator
     return d_null;
   }
-  bool isLeft = (ck==Attr::LEFT_ASSOC_NIL || ck==Attr::LEFT_ASSOC_NS_NIL);
+  bool isLeft = (ck == Attr::LEFT_ASSOC_NIL || ck == Attr::LEFT_ASSOC_NS_NIL);
   Trace("type_checker_debug") << "EVALUATE-LIT (list) " << k << " " << isLeft << " " << args << std::endl;
   // infer the nil expression, which depends on the type of args[1]
   std::vector<Expr> eargs;
@@ -1570,7 +1570,7 @@ Expr TypeChecker::evaluateLiteralOpInternal(
     case Kind::EVAL_LIST_DIFF:
     case Kind::EVAL_LIST_INTER:
       return evaluateListDiffInterInternal(k, op, nil, isLeft, args);
-    case Kind::EVAL_LIST_SINGLETON_ELIM: 
+    case Kind::EVAL_LIST_SINGLETON_ELIM:
     {
       std::vector<ExprValue*> hargs;
       if (getNAryChildren(args[1], op, nil, hargs, isLeft) == nullptr)
@@ -1578,9 +1578,10 @@ Expr TypeChecker::evaluateLiteralOpInternal(
         Trace("type_checker") << "...head not in list form" << std::endl;
         return d_null;
       }
-        Trace("type_checker") << "...has " << hargs.size() << " arguments" << std::endl;
+      Trace("type_checker")
+          << "...has " << hargs.size() << " arguments" << std::endl;
       // if a list of size 1, it is that argument, otherwise unchanged
-      return Expr(hargs.size()==1 ? hargs[0] : args[1]);
+      return Expr(hargs.size() == 1 ? hargs[0] : args[1]);
     }
     default:
       break;

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -1428,7 +1428,7 @@ Expr TypeChecker::evaluateLiteralOpInternal(
     return d_null;
   }
   Attr ck = ac->d_attrCons;
-  if (ck!=Attr::RIGHT_ASSOC_NIL && ck!=Attr::LEFT_ASSOC_NIL)
+  if (!isListNilAttr(ck))
   {
     // not an associative operator
     return d_null;
@@ -1575,8 +1575,11 @@ Expr TypeChecker::evaluateLiteralOpInternal(
       std::vector<ExprValue*> hargs;
       if (getNAryChildren(args[1], op, nil, hargs, isLeft) == nullptr)
       {
+        Trace("type_checker") << "...head not in list form" << std::endl;
         return d_null;
       }
+        Trace("type_checker") << "...has " << hargs.size() << " arguments" << std::endl;
+      // if a list of size 1, it is that argument, otherwise unchanged
       return Expr(hargs.size()==1 ? hargs[0] : args[1]);
     }
     default:

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -1433,7 +1433,7 @@ Expr TypeChecker::evaluateLiteralOpInternal(
     // not an associative operator
     return d_null;
   }
-  bool isLeft = (ck==Attr::LEFT_ASSOC_NIL);
+  bool isLeft = (ck==Attr::LEFT_ASSOC_NIL || ck==Attr::LEFT_ASSOC_NS_NIL);
   Trace("type_checker_debug") << "EVALUATE-LIT (list) " << k << " " << isLeft << " " << args << std::endl;
   // infer the nil expression, which depends on the type of args[1]
   std::vector<Expr> eargs;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -163,6 +163,7 @@ set(ethos_test_file_list
     curry-nary.eo
     arg-list-cong.eo
     arg-list-distinct-elim.eo
+    list-non-singleton.eo
 )
 
 macro(ethos_test file)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -164,6 +164,7 @@ set(ethos_test_file_list
     arg-list-cong.eo
     arg-list-distinct-elim.eo
     list-non-singleton.eo
+    list-non-singleton-left.eo
 )
 
 macro(ethos_test file)

--- a/tests/list-non-singleton-left.eo
+++ b/tests/list-non-singleton-left.eo
@@ -1,0 +1,14 @@
+(declare-parameterized-const = ((T Type :implicit)) (-> T T Bool))
+(declare-const or (-> Bool Bool Bool) :left-assoc-non-singleton-nil false)
+(declare-const and (-> Bool Bool Bool) :left-assoc-non-singleton-nil true)
+(declare-const not (-> Bool Bool))
+
+(declare-rule bool-or-de-morgan ((xs1 Bool :list) (y1 Bool) (z1 Bool))
+  :args (xs1 y1 z1)
+  :conclusion (= (not (or xs1 y1 z1)) (and (not (or xs1 y1)) (not z1)))
+)
+
+(declare-const a Bool)
+(declare-const b Bool)
+
+(step @p0 (= (not (or a b)) (and (not a) (not b))) :rule bool-or-de-morgan :args (false a b))

--- a/tests/list-non-singleton.eo
+++ b/tests/list-non-singleton.eo
@@ -1,0 +1,14 @@
+(declare-parameterized-const = ((T Type :implicit)) (-> T T Bool))
+(declare-const or (-> Bool Bool Bool) :right-assoc-non-singleton-nil false)
+(declare-const and (-> Bool Bool Bool) :right-assoc-non-singleton-nil true)
+(declare-const not (-> Bool Bool))
+
+(declare-rule bool-or-de-morgan ((x1 Bool) (y1 Bool) (zs1 Bool :list))
+  :args (x1 y1 zs1)
+  :conclusion (= (not (or x1 y1 zs1)) (and (not x1) (not (or y1 zs1))))
+)
+
+(declare-const a Bool)
+(declare-const b Bool)
+
+(step @p0 (= (not (or a b)) (and (not a) (not b))) :rule bool-or-de-morgan :args (a b false))


### PR DESCRIPTION
This is to support Eunoia as a formalization of RARE in Alethe.

This adds variants of operator annotations which automatically collapse singleton lists, e.g. `(or a false)` becomes `a`.