### PR TITLE
Simplify behavior of eo::to_str

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ ethos 0.2.3 prerelease
 - Updates to the external plugin interface.
 - The identifier `Type` is no longer treated as a keyword in proofs and reference files.
 - The command `declare-sort` is now allowed in proof files.
+- The builtin `eo::to_str` no longer prints rationals, decimals, or bitvectors. It now only evaluates on strings and numeral code points.
 
 ethos 0.2.2
 ===========
@@ -91,4 +92,3 @@ https://github.com/cvc5/ethos
 ## Documentation
 
 https://github.com/cvc5/ethos/blob/main/user_manual.md
-

--- a/src/literal.cpp
+++ b/src/literal.cpp
@@ -436,7 +436,6 @@ Literal Literal::evaluate(Kind k, const std::vector<const Literal*>& args)
     case Kind::EVAL_TO_STRING:
       switch (ka)
       {
-        case Kind::DECIMAL:return Literal(String(args[0]->d_rat.toStringDecimal()));
         case Kind::NUMERAL:
         {
           // if integer is 0...num_codes-1, we convert to the string whose code
@@ -450,10 +449,8 @@ Literal Literal::evaluate(Kind k, const std::vector<const Literal*>& args)
               return Literal(String(vec));
             }
           }
+          break;
         }
-        case Kind::RATIONAL:return Literal(String(args[0]->toString()));
-        case Kind::HEXADECIMAL:return Literal(String("#x" + args[0]->toString()));
-        case Kind::BINARY:return Literal(String("#b" + args[0]->toString()));
         case Kind::STRING: return *args[0];break;
         default: break;
       }

--- a/tests/to_string.eo
+++ b/tests/to_string.eo
@@ -1,13 +1,10 @@
-; The lines with decimals and hexadecimals are commented out since
-; we can't do options in regression tests, these pass with:
-; `--no-normalize-dec --no-normalize-hex`
+; This file checks the remaining eo::to_str behavior on numerals and strings,
+; and that other literal kinds remain unevaluated.
 
 (declare-const Real Type)
 (declare-consts <rational> Real)
-;(declare-consts <decimal> Real)
 (declare-const BitVec Type)
 (declare-consts <binary> BitVec)
-;(declare-consts <hexadecimal> BitVec)
 (declare-const String Type)
 (declare-consts <string> String)
 
@@ -18,14 +15,14 @@
   :requires (((eo::to_str x) s))
   :conclusion (ok x))
 
-;(step @p0 (ok 1.1) :rule test_to_str :args (1.1 "1.1"))
-(step @p1 (ok 2/12) :rule test_to_str :args (2/12 "1/6"))
-(step @p2 (ok #b001) :rule test_to_str :args (#b001 "#b001"))
-;(step @p3 (ok #xab) :rule test_to_str :args (#xAB "#xab"))
-(step @p4 (ok "abc") :rule test_to_str :args ("abc" "abc"))
+(step @p1 (ok 65) :rule test_to_str :args (65 "A"))
+(step @p2 (ok "abc") :rule test_to_str :args ("abc" "abc"))
 
-
-;(step @p0 (ok 1.123456789) :rule test_to_str :args (1.123456789 "1.123456789"))
-;(step @p0 (ok 12345.0) :rule test_to_str :args (12345.0 "12345.0"))
-;(step @p00 (ok 12345.1) :rule test_to_str :args (12345.1 "12345.1"))
-;(step @p0 (ok 123456789.0) :rule test_to_str :args (123456789.0 "123456789.0"))
+(declare-const test_q
+  (eo::requires (eo::is_ok (eo::to_str 2/12)) false Bool))
+(declare-const test_bin
+  (eo::requires (eo::is_ok (eo::to_str #b001)) false Bool))
+(declare-const test_invalid_neg
+  (eo::requires (eo::is_ok (eo::to_str -1)) false Bool))
+(declare-const test_invalid_large
+  (eo::requires (eo::is_ok (eo::to_str 200000)) false Bool))

--- a/user_manual.md
+++ b/user_manual.md
@@ -861,9 +861,6 @@ Note, however, that the evaluation of these operators is handled by more efficie
 - `(eo::to_str t1)`
   - If `t1` is a string value, return `t1`.
   - If `t1` is a numeral value specifying a code point from Unicode planes `0-2` (i.e. a numeral between `0` and `196607`), return the string of length one whose character has code point `t1`.
-  - If `t1` is a rational or binary value, return the string value corresponding to the result of printing `t1`. 
-  - If `t1` is a hexadecimal value, return the string value corresponding to the result of printing `t1`. This will use lowercase letters for digits greater than `9`.
-  - If `t1` is a decimal value, return the string value corresponding to the result of printing `t1` as a rational.
 
 Ethos eagerly evaluates ground applications of computational operators.
 In other words, the term `(eo::add 1 1)` is syntactically equivalent in all contexts to `2`.
@@ -937,8 +934,8 @@ Ethos supports extensions of `eo::and, eo::or, eo::xor, eo::add, eo::mul, eo::co
 (eo::to_str 123)            == "{"
 (eo::to_str -1)             == (eo::to_str -1) ; since not a valid code point
 (eo::to_str 200000)         == (eo::to_str 200000) ; since not a valid code point
-(eo::to_str 1/2)            == "1/2"
-(eo::to_str #b101)          == "#b101"
+(eo::to_str 1/2)            == (eo::to_str 1/2)
+(eo::to_str #b101)          == (eo::to_str #b101)
 ```
 
 ### Core Computation Examples


### PR DESCRIPTION
Co-authored by ChatGPT 5.4.

It is not worthwhile to formally model this behavior. I am removing it for simplicity to ensure the formal model of Eunoia is complete.