### PR TITLE
Minor updates in preparation for ethos compilation plugins

### DIFF
--- a/src/cmd_parser.cpp
+++ b/src/cmd_parser.cpp
@@ -260,14 +260,14 @@ bool CmdParser::parseNextCommand()
         {
           d_lex.parseError("Can only use opaque argument on functions without attributes.");
         }
-        // Reconstruct with opaque arguments, do not flatten function type.
-        t = d_state.mkFunctionType(opaqueArgs, t);
         ck = Attr::OPAQUE;
         // we store the number of opaque arguments as the constructor
         std::stringstream onum;
         onum << opaqueArgs.size();
         Assert(cons.isNull());
         cons = d_state.mkLiteral(Kind::NUMERAL, onum.str());
+        opaqueArgs.push_back(t);
+        t = d_state.mkExpr(Kind::FUNCTION_TYPE, opaqueArgs);
       }
       Expr v = d_state.mkSymbol(sk, name, t);
       // if the type has a property, we mark it on the variable of this type
@@ -822,10 +822,6 @@ bool CmdParser::parseNextCommand()
       {
         // parse the body
         std::vector<Expr> pchildren = d_eparser.parseExprPairList();
-        if (pchildren.empty())
-        {
-          d_lex.parseError("Expected non-empty list of cases");
-        }
         // ensure program cases are
         // (A) applications of the program
         // (B) have arguments that are not evaluatable
@@ -930,7 +926,8 @@ bool CmdParser::parseNextCommand()
         // because allocation of std::stringstream is expensive and this
         // block of code only executes at most once.
         std::stringstream sserr;
-        sserr << "A step of rule " << ruleName << " failed to check." << std::endl;
+        sserr << "A step of rule " << ruleName << " failed to check."
+              << std::endl;
         bool recheck = d_state.notifyStep(
             name, rule, proven, premises, args, isPop, concTerm, &sserr);
         // should fail again

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -508,6 +508,11 @@ Expr& Expr::operator=(const Expr& e)
 bool Expr::operator==(const Expr& e) const { return d_value == e.d_value; }
 bool Expr::operator!=(const Expr& e) const { return d_value != e.d_value; }
 Kind Expr::getKind() const { return d_value->getKind(); }
+Expr Expr::getType() const
+{
+  Expr t(d_value);
+  return ExprValue::d_state->getTypeChecker().getType(t);
+}
 bool Expr::operator<(const Expr& e) const { return d_value < e.d_value; }
 
 bool Expr::hasVariable(const Expr& e,

--- a/src/expr.h
+++ b/src/expr.h
@@ -149,6 +149,8 @@ class Expr
   bool isNull() const;
   /** get the kind of this expression */
   Kind getKind() const;
+  /** get the type of this expression */
+  Expr getType() const;
   /** Has variable */
   bool isEvaluatable() const;
   /** Has variable */

--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -111,7 +111,7 @@ ExprParser::ExprParser(Lexer& lex, State& state, bool isSignature)
   d_strToAttr[":syntax"] = Attr::SYNTAX;
   d_strToAttr[":restrict"] = Attr::RESTRICT;
   d_strToAttr[":sorry"] = Attr::SORRY;
-  
+
   d_strToLiteralKind["<boolean>"] = Kind::BOOLEAN;
   d_strToLiteralKind["<numeral>"] = Kind::NUMERAL;
   d_strToLiteralKind["<decimal>"] = Kind::DECIMAL;
@@ -890,11 +890,6 @@ void ExprParser::parseConstructorDefinitionList(
       Expr sel = d_state.mkSymbol(Kind::CONST, id, stype);
       toBind.emplace_back(id,sel);
       sels.push_back(sel);
-      std::stringstream ss;
-      ss << "update-" << id;
-      Expr utype = d_state.mkFunctionType({dt, t}, dt);
-      Expr updater = d_state.mkSymbol(Kind::CONST, ss.str(), utype);
-      toBind.emplace_back(ss.str(), updater);
       d_lex.eatToken(Token::RPAREN);
     }
     bool isAmb = false;
@@ -918,12 +913,6 @@ void ExprParser::parseConstructorDefinitionList(
     Expr cons = d_state.mkSymbol(Kind::CONST, name, ctype);
     toBind.emplace_back(name, cons);
     conslist.push_back(cons);
-    // make the discriminator
-    std::stringstream ss;
-    ss << "is-" << name;
-    Expr dtype = d_state.mkFunctionType({dt}, boolType);
-    Expr tester = d_state.mkSymbol(Kind::CONST, ss.str(), dtype);
-    toBind.emplace_back(ss.str(), tester);
     dtcons[cons.getValue()] = sels;
     if (isAmb)
     {
@@ -1103,7 +1092,7 @@ void ExprParser::parseAttributeList(
             val = parseExprPair();
           }
             break;
-          default:break;
+            default: break;
         }
       }
         break;

--- a/src/literal.cpp
+++ b/src/literal.cpp
@@ -92,10 +92,6 @@ std::string Literal::toString() const
     case Kind::BOOLEAN: return d_bool ? "true" : "false";
     case Kind::DECIMAL: return d_rat.toStringDecimal();
     case Kind::RATIONAL:
-      if (d_rat.isIntegral())
-      {
-        return d_rat.toString() + "/1";
-      }
       return d_rat.toString();
     case Kind::NUMERAL: return d_int.toString();
     case Kind::HEXADECIMAL: return d_bv.toString(16);

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1187,7 +1187,8 @@ Expr State::mkApplyAttr(AppInfo* ai,
       }
       else
       {
-        // construct curried APPLY_OPAQUE application.
+        // Note we do not curry APPLY_OPAQUE applications, as they are simpler
+        // to reason about in flattened form.
         std::vector<ExprValue*> ochildren(vchildren.begin(),
                                           vchildren.begin() + 1 + nargs);
         Expr op = Expr(mkExprInternal(Kind::APPLY_OPAQUE, ochildren));

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1188,12 +1188,9 @@ Expr State::mkApplyAttr(AppInfo* ai,
       else
       {
         // construct curried APPLY_OPAQUE application.
-        ExprValue* curr = vchildren[0];
-        for (size_t i = 1; i < nargs + 1; i++)
-        {
-          curr = mkExprInternal(Kind::APPLY_OPAQUE, {curr, vchildren[i]});
-        }
-        Expr op = Expr(curr);
+        std::vector<ExprValue*> ochildren(vchildren.begin(),
+                                          vchildren.begin() + 1 + nargs);
+        Expr op = Expr(mkExprInternal(Kind::APPLY_OPAQUE, ochildren));
         Trace("opaque") << "Construct opaque operator " << op << std::endl;
         if (nargs + 1 == vchildren.size())
         {

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1189,6 +1189,7 @@ Expr State::mkApplyAttr(AppInfo* ai,
       {
         // Note we do not curry APPLY_OPAQUE applications, as they are simpler
         // to reason about in flattened form.
+        Assert (nargs < vchildren.size());
         std::vector<ExprValue*> ochildren(vchildren.begin(),
                                           vchildren.begin() + 1 + nargs);
         Expr op = Expr(mkExprInternal(Kind::APPLY_OPAQUE, ochildren));

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -899,7 +899,6 @@ Expr TypeChecker::evaluateProgramInternal(
     RuleStat* ps = &d_sts.d_pstats[hd];
     ps->d_count++;
   }
-  Assert(!prog.isNull());
   if (!prog.isNull())
   {
     Trace("type_checker") << "INTERPRET program " << children << std::endl;
@@ -935,6 +934,10 @@ Expr TypeChecker::evaluateProgramInternal(
       }
     }
     Trace("type_checker") << "...failed to match." << std::endl;
+  }
+  else
+  {
+    Warning() << "No program defined for " << Expr(children[0]) << std::endl;
   }
   // just return nullptr, which should be interpreted as a failed evaluation
   return d_null;

--- a/src/util/rational.cpp
+++ b/src/util/rational.cpp
@@ -44,7 +44,10 @@ Rational Rational::fromDecimal(const std::string& dec) {
 
 bool Rational::isIntegral() const { return mpz_cmp_ui(d_value.get_den_mpz_t(), 1) == 0; }
 
-std::string Rational::toString(int base) const { return d_value.get_str(base); }
+std::string Rational::toString(int base) const
+{
+  return d_value.get_str(base) + (isIntegral() ? "/1" : "");
+}
 std::string Rational::toStringDecimal() const
 {
   // NOTE: we simply print as a rational for now, due to limitations in

--- a/user_manual.md
+++ b/user_manual.md
@@ -1697,7 +1697,7 @@ Furthermore, if `si` contains any computational operators (i.e. those with `eo::
 
 > __Note:__ Programs are *not* invoked when applied to other programs in this version of Ethos. For example, the application of a program `f : (Int -> Int) -> Int` to another user defined program `g : Int -> Int` will be unevaluated, i.e. `(f g)`. Similarly, programs are not invoked when applied to builtin operators `eo::` and oracle functions. In contrast, `f` is invoked when `g` is an ordinary term e.g. one defined by `declare-const`.
 
-> __Note:__ Programs with no specified cases always get stuck.
+> __Note:__ Programs with an empty list of cases always fail to evaluate.
 
 ### Example: Finding a child in an `or` term
 

--- a/user_manual.md
+++ b/user_manual.md
@@ -1673,7 +1673,7 @@ In particular, in Ethos, a program is an ordered list of rewrite rules.
 The syntax for this command is as follows.
 
 ```smt
-(program <symbol> (<typed-param>*) :signature (<type>+) <type> ((<term> <term>)+))
+(program <symbol> (<typed-param>*) :signature (<type>+) <type> ((<term> <term>)*))
 ```
 
 This command declares a program named `<symbol>`.
@@ -1696,6 +1696,8 @@ Furthermore, if `si` contains any computational operators (i.e. those with `eo::
 > __Note:__ Programs are *not* invoked on terms that fail to evaluate. For example, if a function `f : Int -> Int` is applied to `(eo::add "A" "B")`, we return `(f (eo::add "A" "B"))`.
 
 > __Note:__ Programs are *not* invoked when applied to other programs in this version of Ethos. For example, the application of a program `f : (Int -> Int) -> Int` to another user defined program `g : Int -> Int` will be unevaluated, i.e. `(f g)`. Similarly, programs are not invoked when applied to builtin operators `eo::` and oracle functions. In contrast, `f` is invoked when `g` is an ordinary term e.g. one defined by `declare-const`.
+
+> __Note:__ Programs with no specified cases always get stuck.
 
 ### Example: Finding a child in an `or` term
 
@@ -2120,7 +2122,7 @@ When streaming input to Ethos, we assume the input is being given for a proof fi
     (declare-rule <symbol> (<typed-param>*) <assumption>? <premises>? <arguments>? <reqs>? :conclusion <term> <attr>*) |
     (define <symbol> (<typed-param>*) <term> <attr>*) |
     (include <string>) |
-    (program <symbol> (<typed-param>*) :signature (<type>+) <type> ((<term> <term>)+)) |
+    (program <symbol> (<typed-param>*) :signature (<type>+) <type> ((<term> <term>)*)) |
     (reference <string> <symbol>?) |
     (step <symbol> <term>? :rule <symbol> <simple-premises>? <arguments>?) |
     (step-pop <symbol> <term>? :rule <symbol> <simple-premises>? <arguments>?) |


### PR DESCRIPTION
This contains several minor changes from the ethos compilers branch.

In particular:
- opaque applications are no longer curried (reverting a recent change). This simplifies the Ethos compiler to SMT and Lean significantly.
- We now permit programs with empty list of cases. This is to support auto-generated programs that intentionally have no cases (e.g. the desugared $eo_dt_constructors when no user datatypes are defined).
- We no longer silently declare testers and updaters for datatypes, which was undocumented and unused.
- Improvements to printing rationals. This fixes our printing of integral decimals which were incorrectly printing as numerals.