### PR TITLE
Fix eo::list_minclude

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,7 @@ ethos 0.2.3 prerelease
 - Fixes an issue where non-ground nil terminators would not be properly computed for list construction operators with types where the element type is different from the return type of the operator.
 - Fixes for evaluation of `:left-assoc-nil` and `:left-assoc-non-singleton-nil` operators.
 - Variables `(eo::var s T)` are now considered ordinary terms, which are hence allowed in patterns.
-
+- Fixes the implementation of `eo::list_minclude`, which had considered the arguments in opposite order.
 
 ethos 0.2.2
 ===========

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -1685,10 +1685,10 @@ Expr TypeChecker::evaluateListMPredInternal(Kind k,
   {
     return d_state.mkFalse();
   }
-  for (const std::pair<const ExprValue* const, uint32_t>& entry : count1)
+  for (const std::pair<const ExprValue* const, uint32_t>& entry : count2)
   {
-    if (isEq ? count2[entry.first] != entry.second
-             : count2[entry.first] < entry.second)
+    if (isEq ? count1[entry.first] != entry.second
+             : count1[entry.first] < entry.second)
     {
       return d_state.mkFalse();
     }

--- a/tests/eo-definitions-test.eo
+++ b/tests/eo-definitions-test.eo
@@ -85,10 +85,14 @@
 (declare-const test9 (eo::requires ($eo_list_setof or (or a a a)) (or a) Bool))
 (declare-const test10 (eo::requires ($eo_list_setof or false) false Bool))
 
-(declare-const test11 (eo::requires ($eo_list_minclude or (or a b) (or a a b)) true Bool))
-(declare-const test12 (eo::requires ($eo_list_minclude or (or a b) (or b a)) true Bool))
-(declare-const test13 (eo::requires ($eo_list_minclude or (or a b b) (or a b)) false Bool))
-(declare-const test14 (eo::requires ($eo_list_minclude or false (or a b)) true Bool))
+(declare-const test11 (eo::requires ($eo_list_minclude or (or a a b) (or a b)) true Bool))
+(declare-const test12 (eo::requires ($eo_list_minclude or (or b a) (or a b)) true Bool))
+(declare-const test13 (eo::requires ($eo_list_minclude or (or a b) (or a b b)) false Bool))
+(declare-const test14 (eo::requires ($eo_list_minclude or (or a b) false) true Bool))
+(declare-const test11 (eo::requires (eo::list_minclude or (or a a b) (or a b)) true Bool))
+(declare-const test12 (eo::requires (eo::list_minclude or (or b a) (or a b)) true Bool))
+(declare-const test13 (eo::requires (eo::list_minclude or (or a b) (or a b b)) false Bool))
+(declare-const test14 (eo::requires (eo::list_minclude or (or a b) false) true Bool))
 
 (declare-const test15 (eo::requires ($eo_list_meq or (or a b) (or a a b)) false Bool))
 (declare-const test16 (eo::requires ($eo_list_meq or (or a b c b) (or b a c b)) true Bool))

--- a/tests/eo-definitions-test.eo
+++ b/tests/eo-definitions-test.eo
@@ -89,10 +89,6 @@
 (declare-const test12 (eo::requires ($eo_list_minclude or (or b a) (or a b)) true Bool))
 (declare-const test13 (eo::requires ($eo_list_minclude or (or a b) (or a b b)) false Bool))
 (declare-const test14 (eo::requires ($eo_list_minclude or (or a b) false) true Bool))
-(declare-const test11 (eo::requires (eo::list_minclude or (or a a b) (or a b)) true Bool))
-(declare-const test12 (eo::requires (eo::list_minclude or (or b a) (or a b)) true Bool))
-(declare-const test13 (eo::requires (eo::list_minclude or (or a b) (or a b b)) false Bool))
-(declare-const test14 (eo::requires (eo::list_minclude or (or a b) false) true Bool))
 
 (declare-const test15 (eo::requires ($eo_list_meq or (or a b) (or a a b)) false Bool))
 (declare-const test16 (eo::requires ($eo_list_meq or (or a b c b) (or b a c b)) true Bool))

--- a/tests/eo-definitions.eo
+++ b/tests/eo-definitions.eo
@@ -351,14 +351,14 @@
 
 ; Note: a helper for $eo_list_minclude.
 (program $eo_list_minclude_rec
-  ((T Type) (x T) (y eo_List :list) (z eo_List))
+  ((T Type) (x T) (y eo_List) (z eo_List :list))
   :signature (eo_List eo_List) Bool
   (
-  (($eo_list_minclude_rec (eo_List_cons x y) z)  (eo::define ((res ($eo_list_erase eo_List_cons z x)))
-                                                   (eo::ite ($eo_eq res z)
-                                                     false   ; must have successfully removed occurrence of x from z
-                                                     ($eo_list_minclude_rec y res))))
-  (($eo_list_minclude_rec eo_List_nil z)          true)
+  (($eo_list_minclude_rec y (eo_List_cons x z))  (eo::define ((res ($eo_list_erase eo_List_cons y x)))
+                                                   (eo::ite ($eo_eq res y)
+                                                     false   ; must have successfully removed occurrence of x from y
+                                                     ($eo_list_minclude_rec res z))))
+  (($eo_list_minclude_rec y eo_List_nil)          true)
   )
 )
 

--- a/tests/eo-list-ops.eo
+++ b/tests/eo-list-ops.eo
@@ -64,10 +64,10 @@
 (declare-const test9 (eo::requires (eo::list_setof or (or a a a)) (or a) Bool))
 (declare-const test10 (eo::requires (eo::list_setof or false) false Bool))
 
-(declare-const test11 (eo::requires (eo::list_minclude or (or a b) (or a a b)) true Bool))
-(declare-const test12 (eo::requires (eo::list_minclude or (or a b) (or b a)) true Bool))
-(declare-const test13 (eo::requires (eo::list_minclude or (or a b b) (or a b)) false Bool))
-(declare-const test14 (eo::requires (eo::list_minclude or false (or a b)) true Bool))
+(declare-const test11 (eo::requires (eo::list_minclude or (or a a b) (or a b)) true Bool))
+(declare-const test12 (eo::requires (eo::list_minclude or (or b a) (or a b)) true Bool))
+(declare-const test13 (eo::requires (eo::list_minclude or (or a b) (or a b b)) false Bool))
+(declare-const test14 (eo::requires (eo::list_minclude or (or a b) false) true Bool))
 
 (declare-const test15 (eo::requires (eo::list_meq or (or a b) (or a a b)) false Bool))
 (declare-const test16 (eo::requires (eo::list_meq or (or a b c b) (or b a c b)) true Bool))

--- a/tests/list-ops-new.eo
+++ b/tests/list-ops-new.eo
@@ -24,10 +24,10 @@
 (declare-const test9 (eo::requires (eo::list_setof or (or a a a)) (or a) Bool))
 (declare-const test10 (eo::requires (eo::list_setof or false) false Bool))
 
-(declare-const test11 (eo::requires (eo::list_minclude or (or a b) (or a a b)) true Bool))
-(declare-const test12 (eo::requires (eo::list_minclude or (or a b) (or b a)) true Bool))
-(declare-const test13 (eo::requires (eo::list_minclude or (or a b b) (or a b)) false Bool))
-(declare-const test14 (eo::requires (eo::list_minclude or false (or a b)) true Bool))
+(declare-const test11 (eo::requires (eo::list_minclude or (or a a b) (or a b)) true Bool))
+(declare-const test12 (eo::requires (eo::list_minclude or (or b a) (or a b)) true Bool))
+(declare-const test13 (eo::requires (eo::list_minclude or (or a b) (or a b b)) false Bool))
+(declare-const test14 (eo::requires (eo::list_minclude or (or a b) false) true Bool))
 
 (declare-const test15 (eo::requires (eo::list_meq or (or a b) (or a a b)) false Bool))
 (declare-const test16 (eo::requires (eo::list_meq or (or a b c b) (or b a c b)) true Bool))

--- a/user_manual.md
+++ b/user_manual.md
@@ -1090,10 +1090,10 @@ The terms on both sides of the given evaluation are written in their form prior 
 (eo::list_setof or (or a a a))            == (or a)
 (eo::list_setof or false)                 == false
 
-(eo::list_minclude or (or a b) (or a a b))  == true
-(eo::list_minclude or (or a b) (or b a))    == true
-(eo::list_minclude or (or a b b) (or a b))  == false
-(eo::list_minclude or false (or a b))       == true
+(eo::list_minclude or (or a a b) (or a b))  == true
+(eo::list_minclude or (or b a) (or a b))    == true
+(eo::list_minclude or (or a b) (or a b b))  == false
+(eo::list_minclude or (or a b) false)       == true
 
 (eo::list_meq or (or a b) (or a a b))       == false
 (eo::list_meq or (or a b c b) (or b a c b)) == true


### PR DESCRIPTION
There was an inconsistency: 
`eo::list_minclude f x1 x2` was assumed to mean "x1 includes all elements of x2" in the Ethos user manual, cvc5's CPC signature.
`eo::list_minclude f x1 x2` was assumed to mean "x2 includes all elements of x1" in the Ethos implementation, as well as Ethos examples in the user manual.

This takes the former.