### PR TITLE
Add shared plugin meta-reduction support

### DIFF
--- a/plugins/meta_reduce_plugin.cpp
+++ b/plugins/meta_reduce_plugin.cpp
@@ -1,0 +1,302 @@
+/******************************************************************************
+ * This file is part of the ethos project.
+ *
+ * Copyright (c) 2023-2024 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ ******************************************************************************/
+
+#include "meta_reduce_plugin.h"
+
+#include <fstream>
+#include <sstream>
+
+#include "literal.h"
+
+namespace ethos {
+
+MetaReducePlugin::MetaReducePlugin(State& s, ConjectureType conjType)
+    : StdPlugin(s), d_conjectureType(conjType)
+{
+  initializeCommonMetaKinds();
+}
+
+MetaReducePlugin::~MetaReducePlugin() {}
+
+ConjectureType MetaReducePlugin::optionSmtMetaConjectureType() const
+{
+  return d_conjectureType;
+}
+
+void MetaReducePlugin::initializeCommonMetaKinds()
+{
+  // Note that the types of the deep embedding whose constructors are static
+  // in the backend templates are not listed here; they are declared via the
+  // $native_embed_* symbols in the Eunoia templates, which carry their
+  // embedded names (see getTypeMetaKindFor and getEmbedTypeName).
+  d_typeToMetaKind["$smt_Term"] = MetaKind::SMT;
+  d_typeToMetaKind["$smt_Type"] = MetaKind::SMT_TYPE;
+  d_typeToMetaKind["$smt_Value"] = MetaKind::SMT_VALUE;
+  d_typeToMetaKind["$smt_Map"] = MetaKind::SMT_MAP;
+  d_typeToMetaKind["$smt_Seq"] = MetaKind::SMT_SEQ;
+  d_typeToMetaKind["$native_BuiltinType"] = MetaKind::SMT_BUILTIN;
+
+  d_prefixToMetaKind["sm"] = MetaKind::SMT;
+  d_prefixToMetaKind["tsm"] = MetaKind::SMT_TYPE;
+  d_prefixToMetaKind["vsm"] = MetaKind::SMT_VALUE;
+  d_prefixToMetaKind["msm"] = MetaKind::SMT_MAP;
+  d_prefixToMetaKind["ssm"] = MetaKind::SMT_SEQ;
+}
+
+void MetaReducePlugin::bind(const std::string&, const Expr& e)
+{
+  if (e.getKind() != Kind::CONST)
+  {
+    return;
+  }
+  finalizeDecl(e);
+}
+
+std::string MetaReducePlugin::getName(const Expr& e)
+{
+  std::stringstream ss;
+  if (e.getNumChildren() == 0)
+  {
+    ss << e;
+  }
+  return ss.str();
+}
+
+bool MetaReducePlugin::isEmbedCons(const Expr& e)
+{
+  std::string sname = getName(e);
+  return (sname.compare(0, 5, "$emb_") == 0);
+}
+
+bool MetaReducePlugin::isSmtApplyApp(const Expr& oApp)
+{
+  if (oApp.getKind() != Kind::APPLY_OPAQUE || oApp.getNumChildren() <= 1
+      || oApp[1].getKind() != Kind::STRING)
+  {
+    return false;
+  }
+  std::string sname = getName(oApp[0]);
+  return (sname.compare(0, 14, "$native_apply_") == 0
+          || sname.compare(0, 13, "$native_type_") == 0
+          || sname.compare(0, 16, "$native_datatype") == 0);
+}
+
+MetaKind MetaReducePlugin::prefixToMetaKind(const std::string& str,
+                                            MetaKind elseKind) const
+{
+  std::map<std::string, MetaKind>::const_iterator it =
+      d_prefixToMetaKind.find(str);
+  if (it != d_prefixToMetaKind.end())
+  {
+    return it->second;
+  }
+  return elseKind;
+}
+
+MetaKind MetaReducePlugin::getTypeMetaKindFor(const Expr& typ,
+                                              MetaKind elseKind,
+                                              bool followFunctionRange) const
+{
+  Kind k = typ.getKind();
+  if (k == Kind::APPLY_OPAQUE)
+  {
+    std::string sname = getName(typ[0]);
+    if (sname.compare(0, 13, "$native_type_") == 0)
+    {
+      return MetaKind::SMT_BUILTIN;
+    }
+    if (sname.compare(0, 16, "$native_datatype") == 0)
+    {
+      return MetaKind::SMT_BUILTIN_DATATYPE;
+    }
+    if (sname == "$native_embed_eo")
+    {
+      return MetaKind::EO_EMBED;
+    }
+    if (sname == "$native_embed_smt")
+    {
+      return MetaKind::SMT_EMBED;
+    }
+    if (sname == "$native_embed_checker")
+    {
+      return MetaKind::CHECKER_EMBED;
+    }
+  }
+  if (followFunctionRange && k == Kind::FUNCTION_TYPE)
+  {
+    return getTypeMetaKindFor(
+        typ[typ.getNumChildren() - 1], elseKind, followFunctionRange);
+  }
+  std::string sname = getName(typ);
+  std::map<std::string, MetaKind>::const_iterator it =
+      d_typeToMetaKind.find(sname);
+  if (it != d_typeToMetaKind.end())
+  {
+    return it->second;
+  }
+  return elseKind;
+}
+
+MetaKind MetaReducePlugin::getMetaKindFor(const Expr& e,
+                                          std::string& cname) const
+{
+  std::string sname = getName(e);
+  if (isBuiltinMetaSymbol(sname))
+  {
+    cname = sname;
+    return MetaKind::SMT_BUILTIN;
+  }
+  if (sname.compare(0, 2, "@@") == 0 || sname.compare(0, 4, "$eo_") == 0)
+  {
+    cname = sname;
+    return MetaKind::EUNOIA;
+  }
+  if (isEmbedCons(e))
+  {
+    cname = sname.substr(5);
+    size_t firstDot = cname.find('.');
+    if (firstDot == std::string::npos)
+    {
+      return MetaKind::EUNOIA;
+    }
+    std::string prefix = cname.substr(0, firstDot);
+    cname = cname.substr(firstDot + 1);
+    MetaKind mk = prefixToMetaKind(prefix, MetaKind::NONE);
+    if (mk != MetaKind::NONE)
+    {
+      return mk;
+    }
+    // Otherwise the constructor may belong to a datatype declared via a
+    // $native_embed_* type, in which case we classify it by its return type.
+    Expr app = getEmbedTypeApp(e.getType());
+    if (!app.isNull())
+    {
+      return getTypeMetaKindFor(app, MetaKind::EUNOIA, false);
+    }
+    return MetaKind::EUNOIA;
+  }
+  cname = sname;
+  return MetaKind::EUNOIA;
+}
+
+Expr MetaReducePlugin::getEmbedTypeApp(const Expr& typ)
+{
+  Expr t = typ;
+  while (t.getKind() == Kind::FUNCTION_TYPE)
+  {
+    t = t[t.getNumChildren() - 1];
+  }
+  if (t.getKind() == Kind::APPLY_OPAQUE)
+  {
+    std::string sname = getName(t[0]);
+    if (sname.compare(0, 14, "$native_embed_") == 0)
+    {
+      return t;
+    }
+  }
+  return Expr();
+}
+
+std::string MetaReducePlugin::getEmbedTypeName(const Expr& app)
+{
+  Assert(app.getKind() == Kind::APPLY_OPAQUE && app.getNumChildren() == 2
+         && app[1].getKind() == Kind::STRING)
+      << "Bad embed type application " << app;
+  const Literal* l = app[1].getValue()->asLiteral();
+  return l->d_str.toString();
+}
+
+bool MetaReducePlugin::buildLambdaDefineProgram(const std::string& name,
+                                                const Expr& e,
+                                                Expr& symbol,
+                                                Expr& prog)
+{
+  if (name.compare(0, 4, "$eo_") != 0 || e.getKind() != Kind::LAMBDA)
+  {
+    return false;
+  }
+
+  std::vector<Expr> argTypes;
+  Assert(e[0].getKind() == Kind::TUPLE);
+  Assert(e[0].getNumChildren() != 0);
+  for (size_t i = 0, nargs = e[0].getNumChildren(); i < nargs; i++)
+  {
+    Expr arg = e[0][i];
+    argTypes.push_back(d_tc.getType(arg));
+  }
+  Expr retType = allocateTypeVariable();
+  Expr pt = d_state.mkProgramType(argTypes, retType);
+  symbol = d_state.mkSymbol(Kind::PROGRAM_CONST, name, pt);
+
+  std::vector<Expr> appChildren;
+  appChildren.push_back(symbol);
+  for (size_t i = 0, nargs = e[0].getNumChildren(); i < nargs; i++)
+  {
+    appChildren.push_back(e[0][i]);
+  }
+  Expr progApp = d_state.mkExpr(Kind::APPLY, appChildren);
+  Expr pcase = d_state.mkPair(progApp, e[1]);
+  prog = d_state.mkExpr(Kind::PROGRAM, {pcase});
+  return true;
+}
+
+bool MetaReducePlugin::beginFinalizeDecl(const Expr& e)
+{
+  if (d_declSeen.find(e) != d_declSeen.end())
+  {
+    return false;
+  }
+  d_declSeen.insert(e);
+  return true;
+}
+
+bool MetaReducePlugin::isProgramApp(const Expr& app)
+{
+  return (app.getKind() == Kind::APPLY
+          && app[0].getKind() == Kind::PROGRAM_CONST);
+}
+
+std::string MetaReducePlugin::emitResourceFile(
+    const std::string& resourcePath,
+    const std::string& outputPath,
+    const std::vector<Replacement>& replacements,
+    bool replAll) const
+{
+  std::ifstream in(getResourcePath(resourcePath));
+  if (!in.is_open())
+  {
+    EO_FATAL() << "MetaReducePlugin: failed to open resource " << resourcePath;
+  }
+
+  std::ostringstream ss;
+  ss << in.rdbuf();
+  std::string rendered = ss.str();
+  for (const Replacement& repl : replacements)
+  {
+    if (replAll)
+    {
+      rendered = replace_all(rendered, repl.first, repl.second);
+    }
+    else
+    {
+      replace(rendered, repl.first, repl.second);
+    }
+  }
+
+  std::string outPath = getOutputPath(outputPath);
+  std::ofstream out(outPath);
+  if (!out.is_open())
+  {
+    EO_FATAL() << "MetaReducePlugin: failed to open output " << outPath;
+  }
+  out << rendered;
+  return outPath;
+}
+
+}  // namespace ethos

--- a/plugins/meta_reduce_plugin.cpp
+++ b/plugins/meta_reduce_plugin.cpp
@@ -12,9 +12,28 @@
 #include <fstream>
 #include <sstream>
 
+#include "base/output.h"
 #include "literal.h"
 
 namespace ethos {
+
+namespace {
+
+/**
+ * Strip the eo::requires guards from t. The range of a function type may be
+ * wrapped in such guards, see State::mkRequires.
+ */
+Expr stripRequires(const Expr& t)
+{
+  Expr ret = t;
+  while (ret.getKind() == Kind::EVAL_REQUIRES)
+  {
+    ret = ret[2];
+  }
+  return ret;
+}
+
+}  // namespace
 
 MetaReducePlugin::MetaReducePlugin(State& s, ConjectureType conjType)
     : StdPlugin(s), d_conjectureType(conjType)
@@ -24,7 +43,7 @@ MetaReducePlugin::MetaReducePlugin(State& s, ConjectureType conjType)
 
 MetaReducePlugin::~MetaReducePlugin() {}
 
-ConjectureType MetaReducePlugin::optionSmtMetaConjectureType() const
+ConjectureType MetaReducePlugin::optionMetaConjectureType() const
 {
   return d_conjectureType;
 }
@@ -60,11 +79,23 @@ void MetaReducePlugin::bind(const std::string&, const Expr& e)
 
 std::string MetaReducePlugin::getName(const Expr& e)
 {
-  std::stringstream ss;
-  if (e.getNumChildren() == 0)
+  if (e.getNumChildren() != 0)
   {
-    ss << e;
+    return "";
   }
+  // Note we take the name of the literal here and not the printed form of e,
+  // which would add SMT-LIB quoting for symbols that are not simple symbols.
+  // For example, a symbol declared as |foo bar| is bound to the name "foo bar"
+  // and must be handed to the backends as such.
+  const Literal* l = e.getValue()->asLiteral();
+  if (l != nullptr)
+  {
+    return l->toString();
+  }
+  // Atomic terms that are not literals, e.g. Type, are printed by their
+  // builtin name.
+  std::stringstream ss;
+  ss << e;
   return ss.str();
 }
 
@@ -103,10 +134,12 @@ MetaKind MetaReducePlugin::getTypeMetaKindFor(const Expr& typ,
                                               MetaKind elseKind,
                                               bool followFunctionRange) const
 {
-  Kind k = typ.getKind();
+  // the type may be guarded, in which case we classify the type it guards
+  Expr t = stripRequires(typ);
+  Kind k = t.getKind();
   if (k == Kind::APPLY_OPAQUE)
   {
-    std::string sname = getName(typ[0]);
+    std::string sname = getName(t[0]);
     if (sname.compare(0, 13, "$native_type_") == 0)
     {
       return MetaKind::SMT_BUILTIN;
@@ -131,9 +164,9 @@ MetaKind MetaReducePlugin::getTypeMetaKindFor(const Expr& typ,
   if (followFunctionRange && k == Kind::FUNCTION_TYPE)
   {
     return getTypeMetaKindFor(
-        typ[typ.getNumChildren() - 1], elseKind, followFunctionRange);
+        t[t.getNumChildren() - 1], elseKind, followFunctionRange);
   }
-  std::string sname = getName(typ);
+  std::string sname = getName(t);
   std::map<std::string, MetaKind>::const_iterator it =
       d_typeToMetaKind.find(sname);
   if (it != d_typeToMetaKind.end())
@@ -187,12 +220,16 @@ MetaKind MetaReducePlugin::getMetaKindFor(const Expr& e,
 
 Expr MetaReducePlugin::getEmbedTypeApp(const Expr& typ)
 {
-  Expr t = typ;
+  // note the range of a function type may be guarded
+  Expr t = stripRequires(typ);
   while (t.getKind() == Kind::FUNCTION_TYPE)
   {
-    t = t[t.getNumChildren() - 1];
+    t = stripRequires(t[t.getNumChildren() - 1]);
   }
-  if (t.getKind() == Kind::APPLY_OPAQUE)
+  // we require the shape expected by getEmbedTypeName below, i.e. an
+  // application to a single SMT-LIB identifier
+  if (t.getKind() == Kind::APPLY_OPAQUE && t.getNumChildren() == 2
+      && t[1].getKind() == Kind::STRING)
   {
     std::string sname = getName(t[0]);
     if (sname.compare(0, 14, "$native_embed_") == 0)
@@ -205,11 +242,12 @@ Expr MetaReducePlugin::getEmbedTypeApp(const Expr& typ)
 
 std::string MetaReducePlugin::getEmbedTypeName(const Expr& app)
 {
-  Assert(app.getKind() == Kind::APPLY_OPAQUE && app.getNumChildren() == 2
-         && app[1].getKind() == Kind::STRING)
-      << "Bad embed type application " << app;
-  const Literal* l = app[1].getValue()->asLiteral();
-  return l->d_str.toString();
+  if (app.getKind() != Kind::APPLY_OPAQUE || app.getNumChildren() != 2
+      || app[1].getKind() != Kind::STRING)
+  {
+    EO_FATAL() << "MetaReducePlugin: bad embed type application " << app;
+  }
+  return getName(app[1]);
 }
 
 bool MetaReducePlugin::buildLambdaDefineProgram(const std::string& name,
@@ -279,6 +317,14 @@ std::string MetaReducePlugin::emitResourceFile(
   std::string rendered = ss.str();
   for (const Replacement& repl : replacements)
   {
+    // a tag that does not occur in the template is silently ignored by the
+    // methods below, which is always a mistake on the part of the caller
+    if (rendered.find(repl.first) == std::string::npos)
+    {
+      Warning() << "MetaReducePlugin: tag " << repl.first
+                << " does not occur in resource " << resourcePath << std::endl;
+      continue;
+    }
     if (replAll)
     {
       rendered = replace_all(rendered, repl.first, repl.second);
@@ -296,6 +342,11 @@ std::string MetaReducePlugin::emitResourceFile(
     EO_FATAL() << "MetaReducePlugin: failed to open output " << outPath;
   }
   out << rendered;
+  out.close();
+  if (!out)
+  {
+    EO_FATAL() << "MetaReducePlugin: failed to write output " << outPath;
+  }
   return outPath;
 }
 

--- a/plugins/meta_reduce_plugin.h
+++ b/plugins/meta_reduce_plugin.h
@@ -50,8 +50,12 @@ class MetaReducePlugin : public StdPlugin
 
  protected:
   /** The type of the emitted conjecture (VC or SyGuS), set at construction. */
-  ConjectureType optionSmtMetaConjectureType() const;
-  /** Get the name of e, or the empty string if e is not atomic. */
+  ConjectureType optionMetaConjectureType() const;
+  /**
+   * Get the name of e, or the empty string if e is not atomic. Note this is
+   * the name e was bound to, which is not necessarily how e is printed, e.g.
+   * a symbol declared as |foo bar| has name "foo bar".
+   */
   static std::string getName(const Expr& e);
   /**
    * Is e a constructor of one of the deep embedding datatypes? These are
@@ -68,12 +72,12 @@ class MetaReducePlugin : public StdPlugin
    * Get the meta-kind associated with the given constructor prefix, e.g.
    * SMT_VALUE for "vsm", or elseKind if the prefix is not registered.
    */
-  MetaKind prefixToMetaKind(const std::string& str,
-                            MetaKind elseKind = MetaKind::EUNOIA) const;
+  MetaKind prefixToMetaKind(const std::string& str, MetaKind elseKind) const;
   /**
    * Get the meta-kind of the type typ, or elseKind if typ is not one of the
    * types of the deep embedding. If followFunctionRange is true and typ is
-   * a function type, we classify its range instead.
+   * a function type, we classify its range instead. Note that eo::requires
+   * guards, which may wrap typ or the range of a function type, are ignored.
    */
   MetaKind getTypeMetaKindFor(const Expr& typ,
                               MetaKind elseKind,
@@ -87,13 +91,15 @@ class MetaReducePlugin : public StdPlugin
   MetaKind getMetaKindFor(const Expr& e, std::string& cname) const;
   /**
    * If typ, or the range of typ if it is a function type, is an application
-   * of a $native_embed_* symbol, return that application, otherwise return
-   * the null expression.
+   * of a $native_embed_* symbol to an SMT-LIB identifier, return that
+   * application, otherwise return the null expression. As above, eo::requires
+   * guards are ignored.
    */
   static Expr getEmbedTypeApp(const Expr& typ);
   /**
    * Get the name of the embedded datatype carried by a $native_embed_*
-   * application, e.g. "SmtRegLan" for ($native_embed_smt "SmtRegLan").
+   * application, e.g. "SmtRegLan" for ($native_embed_smt "SmtRegLan"). This
+   * aborts if app does not have that shape, see getEmbedTypeApp.
    */
   static std::string getEmbedTypeName(const Expr& app);
   /**
@@ -115,8 +121,9 @@ class MetaReducePlugin : public StdPlugin
   /**
    * Render the template resource file resourcePath by applying the given
    * replacements and write the result to outputPath. If replAll is true,
-   * every occurrence of each tag is replaced, otherwise only the first.
-   * Returns the full path of the written file.
+   * every occurrence of each tag is replaced, otherwise only the first. A tag
+   * that does not occur in the template is a no-op, which we warn about since
+   * it is always a mistake. Returns the full path of the written file.
    */
   std::string emitResourceFile(const std::string& resourcePath,
                                const std::string& outputPath,

--- a/plugins/meta_reduce_plugin.h
+++ b/plugins/meta_reduce_plugin.h
@@ -1,0 +1,152 @@
+/******************************************************************************
+ * This file is part of the ethos project.
+ *
+ * Copyright (c) 2023-2024 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ ******************************************************************************/
+#ifndef PLUGIN_META_REDUCE_PLUGIN_H
+#define PLUGIN_META_REDUCE_PLUGIN_H
+
+#include <map>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "std_plugin.h"
+#include "utils.h"
+
+namespace ethos {
+
+/** The kind of conjecture emitted by the meta-reduction backends. */
+enum class ConjectureType
+{
+  /** A verification condition, checked by an SMT solver. */
+  VC,
+  /** A syntax-guided synthesis conjecture. */
+  SYGUS
+};
+
+/**
+ * Base class for the meta-reduction backends (SmtMetaReduce, LeanMetaReduce).
+ * It implements the classification of the symbols of a (desugared) Eunoia
+ * signature into MetaKind, that is, into the datatypes of the final deep
+ * embedding, and provides utilities shared by the backends, e.g. for
+ * rendering their template resource files.
+ */
+class MetaReducePlugin : public StdPlugin
+{
+ public:
+  /** A (tag, replacement) pair used when rendering a resource file. */
+  using Replacement = std::pair<std::string, std::string>;
+
+  MetaReducePlugin(State& s, ConjectureType conjType = ConjectureType::VC);
+  ~MetaReducePlugin() override;
+
+  /** Notification that name was bound to e; dispatches to finalizeDecl. */
+  void bind(const std::string& name, const Expr& e) override;
+
+ protected:
+  /** The type of the emitted conjecture (VC or SyGuS), set at construction. */
+  ConjectureType optionSmtMetaConjectureType() const;
+  /** Get the name of e, or the empty string if e is not atomic. */
+  static std::string getName(const Expr& e);
+  /**
+   * Is e a constructor of one of the deep embedding datatypes? These are
+   * the constants whose names begin with "$emb_".
+   */
+  static bool isEmbedCons(const Expr& e);
+  /**
+   * Is oApp an (opaque) application of one of the symbols of the native
+   * embedding that carry an SMT-LIB identifier as their first argument,
+   * i.e. $native_apply_*, $native_type_* or $native_datatype?
+   */
+  static bool isSmtApplyApp(const Expr& oApp);
+  /**
+   * Get the meta-kind associated with the given constructor prefix, e.g.
+   * SMT_VALUE for "vsm", or elseKind if the prefix is not registered.
+   */
+  MetaKind prefixToMetaKind(const std::string& str,
+                            MetaKind elseKind = MetaKind::EUNOIA) const;
+  /**
+   * Get the meta-kind of the type typ, or elseKind if typ is not one of the
+   * types of the deep embedding. If followFunctionRange is true and typ is
+   * a function type, we classify its range instead.
+   */
+  MetaKind getTypeMetaKindFor(const Expr& typ,
+                              MetaKind elseKind,
+                              bool followFunctionRange) const;
+  /**
+   * Get the meta-kind of the term e, that is, the datatype of the deep
+   * embedding that e belongs to. Sets cname to the name e contributes to
+   * the final embedding, e.g. the constructor name without its "$emb_<prefix>."
+   * wrapper.
+   */
+  MetaKind getMetaKindFor(const Expr& e, std::string& cname) const;
+  /**
+   * If typ, or the range of typ if it is a function type, is an application
+   * of a $native_embed_* symbol, return that application, otherwise return
+   * the null expression.
+   */
+  static Expr getEmbedTypeApp(const Expr& typ);
+  /**
+   * Get the name of the embedded datatype carried by a $native_embed_*
+   * application, e.g. "SmtRegLan" for ($native_embed_smt "SmtRegLan").
+   */
+  static std::string getEmbedTypeName(const Expr& app);
+  /**
+   * If e is a lambda defining a $eo_ symbol named name, construct an
+   * equivalent single-case program. Sets symbol to a fresh program constant
+   * for name and prog to its definition, and returns true if successful.
+   */
+  bool buildLambdaDefineProgram(const std::string& name,
+                                const Expr& e,
+                                Expr& symbol,
+                                Expr& prog);
+  /**
+   * Called at the beginning of finalizeDecl for e. Returns true if e has not
+   * been finalized yet, and marks it as seen.
+   */
+  bool beginFinalizeDecl(const Expr& e);
+  /** Is app an application of a program constant? */
+  static bool isProgramApp(const Expr& app);
+  /**
+   * Render the template resource file resourcePath by applying the given
+   * replacements and write the result to outputPath. If replAll is true,
+   * every occurrence of each tag is replaced, otherwise only the first.
+   * Returns the full path of the written file.
+   */
+  std::string emitResourceFile(const std::string& resourcePath,
+                               const std::string& outputPath,
+                               const std::vector<Replacement>& replacements,
+                               bool replAll = false) const;
+
+  /**
+   * Is sname the name of a symbol supplied by the backend's templates? Such
+   * symbols are not included in the generated output.
+   */
+  virtual bool isBuiltinMetaSymbol(const std::string& sname) const = 0;
+  /** Process the declaration of constant e in the backend. */
+  virtual void finalizeDecl(const Expr& e) = 0;
+
+  /** The null expression. */
+  Expr d_null;
+  /** Maps $emb_ constructor prefixes (e.g. "vsm") to their meta-kind. */
+  std::map<std::string, MetaKind> d_prefixToMetaKind;
+  /** Maps names of types of the deep embedding to their meta-kind. */
+  std::map<std::string, MetaKind> d_typeToMetaKind;
+  /** The declarations processed so far, see beginFinalizeDecl. */
+  std::set<Expr> d_declSeen;
+
+ private:
+  /** The type of the emitted conjecture, set at construction. */
+  ConjectureType d_conjectureType;
+  /** Initialize the meta-kind maps shared by all backends. */
+  void initializeCommonMetaKinds();
+};
+
+}  // namespace ethos
+
+#endif

--- a/plugins/utils.cpp
+++ b/plugins/utils.cpp
@@ -44,12 +44,23 @@ std::string metaKindToPrefix(MetaKind k)
   std::stringstream ss;
   switch (k)
   {
+    // Note the cases below must cover every prefix registered in the
+    // d_prefixToMetaKind maps of the backends, see
+    // MetaReducePlugin::prefixToMetaKind, of which this method is the inverse.
     case MetaKind::EUNOIA: ss << "eo."; break;
     case MetaKind::SMT: ss << "sm."; break;
     case MetaKind::SMT_TYPE: ss << "tsm."; break;
     case MetaKind::SMT_VALUE: ss << "vsm."; break;
+    case MetaKind::SMT_MAP: ss << "msm."; break;
+    case MetaKind::SMT_SEQ: ss << "ssm."; break;
+    case MetaKind::CHECKER_RULE: ss << "r."; break;
+    case MetaKind::CHECKER_CMD: ss << "cmd."; break;
+    // builtin symbols have no prefix of their own; they are marked so that
+    // they are recognizable if they ever reach the generated output
     case MetaKind::SMT_BUILTIN: ss << "?"; break;
-    default: ss << "?MetaKindPrefix_" << metaKindToString(k); break;
+    default:
+      EO_FATAL() << "No prefix for meta-kind " << metaKindToString(k);
+      break;
   }
   return ss.str();
 }

--- a/plugins/utils.cpp
+++ b/plugins/utils.cpp
@@ -1,0 +1,94 @@
+/******************************************************************************
+ * This file is part of the ethos project.
+ *
+ * Copyright (c) 2023-2024 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ ******************************************************************************/
+
+#include "utils.h"
+
+#include <sstream>
+
+#include "base/check.h"
+
+namespace ethos {
+
+std::string metaKindToString(MetaKind k)
+{
+  std::stringstream ss;
+  switch (k)
+  {
+    case MetaKind::EUNOIA: ss << "EUNOIA"; break;
+    case MetaKind::PROOF: ss << "PROOF"; break;
+    case MetaKind::SMT: ss << "SMT"; break;
+    case MetaKind::SMT_BUILTIN: ss << "SMT_BUILTIN"; break;
+    case MetaKind::SMT_BUILTIN_DATATYPE: ss << "SMT_BUILTIN_DATATYPE"; break;
+    case MetaKind::SMT_TYPE: ss << "SMT_TYPE"; break;
+    case MetaKind::SMT_VALUE: ss << "SMT_VALUE"; break;
+    case MetaKind::SMT_MAP: ss << "SMT_MAP"; break;
+    case MetaKind::SMT_SEQ: ss << "SMT_SEQ"; break;
+    case MetaKind::CHECKER_RULE: ss << "CHECKER_RULE"; break;
+    case MetaKind::CHECKER_CMD: ss << "CHECKER_CMD"; break;
+    case MetaKind::EO_EMBED: ss << "EO_EMBED"; break;
+    case MetaKind::SMT_EMBED: ss << "SMT_EMBED"; break;
+    case MetaKind::CHECKER_EMBED: ss << "CHECKER_EMBED"; break;
+    case MetaKind::NONE: ss << "NONE"; break;
+    default: ss << "?MetaKind"; break;
+  }
+  return ss.str();
+}
+std::string metaKindToPrefix(MetaKind k)
+{
+  std::stringstream ss;
+  switch (k)
+  {
+    case MetaKind::EUNOIA: ss << "eo."; break;
+    case MetaKind::SMT: ss << "sm."; break;
+    case MetaKind::SMT_TYPE: ss << "tsm."; break;
+    case MetaKind::SMT_VALUE: ss << "vsm."; break;
+    case MetaKind::SMT_BUILTIN: ss << "?"; break;
+    default: ss << "?MetaKindPrefix_" << metaKindToString(k); break;
+  }
+  return ss.str();
+}
+bool isSmtMetaKind(MetaKind k)
+{
+  return k == MetaKind::SMT_BUILTIN || k == MetaKind::SMT_BUILTIN_DATATYPE
+         || k == MetaKind::SMT || k == MetaKind::SMT_TYPE
+         || k == MetaKind::SMT_VALUE || k == MetaKind::SMT_MAP
+         || k == MetaKind::SMT_SEQ || k == MetaKind::SMT_EMBED;
+}
+bool isCheckerMetaKind(MetaKind k)
+{
+  return k == MetaKind::CHECKER_RULE || k == MetaKind::CHECKER_CMD
+         || k == MetaKind::CHECKER_EMBED;
+}
+bool isEmbedMetaKind(MetaKind k)
+{
+  return k == MetaKind::EO_EMBED || k == MetaKind::SMT_EMBED
+         || k == MetaKind::CHECKER_EMBED;
+}
+
+const std::string& getParseDefPrefix()
+{
+  static const std::string prefix = "$parse_";
+  return prefix;
+}
+bool isParseDefName(const std::string& name)
+{
+  const std::string& prefix = getParseDefPrefix();
+  return name.compare(0, prefix.size(), prefix) == 0;
+}
+std::string mkParseDefName(const std::string& name)
+{
+  return getParseDefPrefix() + name;
+}
+std::string getParseDefSurfaceName(const std::string& name)
+{
+  Assert(isParseDefName(name));
+  return name.substr(getParseDefPrefix().size());
+}
+
+}  // namespace ethos

--- a/plugins/utils.h
+++ b/plugins/utils.h
@@ -1,0 +1,118 @@
+/******************************************************************************
+ * This file is part of the ethos project.
+ *
+ * Copyright (c) 2023-2024 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ ******************************************************************************/
+
+#ifndef PLUGIN_UTILS_H
+#define PLUGIN_UTILS_H
+
+#include <string>
+
+namespace ethos {
+
+/**
+ * Shared utilities for the experimental eoc meta-reduction plugins (see
+ * MetaReducePlugin). The central definition is MetaKind, which classifies the
+ * deep embedding of a term, together with helpers for naming and categorizing
+ * these kinds.
+ */
+
+/**
+ * Identifies the meta-level category of a term's deep embedding during
+ * meta-reduction. Each constant declared by a plugin is classified into one of
+ * these kinds, which determines how the term is embedded and printed, e.g. as a
+ * Eunoia term, an SMT-LIB term/type/value, a datatype, or a proof-checker
+ * construct.
+ */
+enum class MetaKind
+{
+  /** The deep embedding of the term is a Eunoia term. */
+  EUNOIA,
+  /** The deep embedding of the term is an SMT-LIB term. */
+  SMT,
+  /** The deep embedding of the term is an SMT-LIB type. */
+  SMT_TYPE,
+  /** The deep embedding of the term is an SMT-LIB value. */
+  SMT_VALUE,
+  /** The deep embedding of the term is an SMT-LIB map value. */
+  SMT_MAP,
+  /** The deep embedding of the term is an SMT-LIB sequence value. */
+  SMT_SEQ,
+  /** The deep embedding of the term is a builtin SMT-LIB term. */
+  SMT_BUILTIN,
+  /** The deep embedding of the term is a builtin SMT-LIB datatype (e.g. Nat). */
+  SMT_BUILTIN_DATATYPE,
+  /** The deep embedding of the term is a proof. */
+  PROOF,
+  /** The deep embedding of the term is a proof-checker rule. */
+  CHECKER_RULE,
+  /** The deep embedding of the term is a proof-checker command. */
+  CHECKER_CMD,
+  /**
+   * The deep embedding of the term is a datatype declared by a
+   * $native_embed_eo type in the Eunoia templates. Its embedded name is
+   * carried by that application; its constructors are static in the backend
+   * templates. Similarly for the _smt and _checker variants below, which
+   * additionally mark the term as belonging to the SMT-LIB model semantics
+   * (see isSmtMetaKind) resp. the proof checker (see isCheckerMetaKind).
+   */
+  EO_EMBED,
+  /** Datatype declared by a $native_embed_smt type. */
+  SMT_EMBED,
+  /** Datatype declared by a $native_embed_checker type. */
+  CHECKER_EMBED,
+  /** No meta-kind context. */
+  NONE
+};
+/** Get a human-readable name for the meta-kind k, e.g. "SMT_TYPE". */
+std::string metaKindToString(MetaKind k);
+/**
+ * Get the symbol-name prefix associated with meta-kind k, e.g. "eo." for
+ * EUNOIA or "vsm." for SMT_VALUE. Returns a placeholder string for kinds
+ * that have no dedicated prefix.
+ */
+std::string metaKindToPrefix(MetaKind k);
+/** Return true if k is one of the SMT-LIB meta-kinds. */
+bool isSmtMetaKind(MetaKind k);
+/** Return true if k is one of the proof-checker meta-kinds. */
+bool isCheckerMetaKind(MetaKind k);
+/** Return true if k is one of the $native_embed_* meta-kinds. */
+bool isEmbedMetaKind(MetaKind k);
+
+/**
+ * The prefix of the name of a "parse definition".
+ *
+ * A define command in the input introduces an identifier that is inlined by
+ * the parser, so it has no counterpart in the compiled signature. It may
+ * however occur in a proof, which means the generated proof parser still has
+ * to be able to resolve it. The desugar stage therefore re-emits every
+ * definition it can under this prefix, except that by convention a definition
+ * whose name begins with "$" is a helper of the signature itself and is not
+ * preserved, since a proof never mentions one. Each stage after desugaring reparses
+ * the definition, which is how its body is compiled along with the rest of the
+ * signature, but otherwise ignores it: a parse definition never contributes to
+ * a verification condition or to the generated proof checker. The Lean backend
+ * is the only consumer, which turns the definitions back into the tables of
+ * the generated parser (see LeanMetaReduce::finalizeParser).
+ */
+const std::string& getParseDefPrefix();
+/** Return true if name is the name of a parse definition. */
+bool isParseDefName(const std::string& name);
+/**
+ * Return the name of the parse definition for the definition named name, i.e.
+ * name prefixed by getParseDefPrefix().
+ */
+std::string mkParseDefName(const std::string& name);
+/**
+ * Return the name in the input of the parse definition named name, i.e. name
+ * with getParseDefPrefix() removed. Requires isParseDefName(name).
+ */
+std::string getParseDefSurfaceName(const std::string& name);
+
+}  // namespace ethos
+
+#endif


### PR DESCRIPTION
Add the common MetaKind classification and parse-definition naming helpers, together with MetaReducePlugin, the common base used by the SMT and Lean emitters in the forthcoming Eunoia compiler toolchain.

This builds on the generic StdPlugin already present on main without modifying it. Backend configuration remains private to each owning implementation.