### PR TITLE
Add linear-pattern transformation for Eunoia programs

### DIFF
--- a/plugins/linear_patterns/linear_patterns.cpp
+++ b/plugins/linear_patterns/linear_patterns.cpp
@@ -10,7 +10,6 @@
 #include "linear_patterns.h"
 
 #include <algorithm>
-#include <set>
 #include <sstream>
 
 #include "state.h"
@@ -35,16 +34,18 @@ std::vector<std::pair<Expr, Expr>> LinearPattern::linearize(State& s,
     std::pair<Expr, Expr> lpat = linearizePattern(s, pat);
     if (lpat.second.isNull())
     {
-      currCases.push_back(progDef[i]);
+      currCases.push_back(
+          s.mkPair(mkCasePattern(s, currProg, pat), progDef[i][1]));
       continue;
     }
     if (i + 1 == ncases)
     {
       // as an optimization, just do a requires if we are the last case
       Expr ctrue = s.mkTrue();
-      Expr ret =
+      Expr guardedRet =
           s.mkExpr(Kind::EVAL_REQUIRES, {lpat.second, ctrue, progDef[i][1]});
-      currCases.push_back(s.mkPair(lpat.first, ret));
+      currCases.push_back(
+          s.mkPair(mkCasePattern(s, currProg, lpat.first), guardedRet));
       continue;
     }
     // make a new copy of the program
@@ -69,7 +70,7 @@ std::vector<std::pair<Expr, Expr>> LinearPattern::linearize(State& s,
     Expr newApp = s.mkExpr(Kind::APPLY, newappc);
     Expr retLin =
         s.mkExpr(Kind::EVAL_IF_THEN_ELSE, {lpat.second, progDef[i][1], newApp});
-    Expr linCase = s.mkPair(lpat.first, retLin);
+    Expr linCase = s.mkPair(mkCasePattern(s, currProg, lpat.first), retLin);
     currCases.push_back(linCase);
     // only needs a default if the linearized case was not already fully general
     if (!wasDefault)
@@ -90,6 +91,23 @@ std::vector<std::pair<Expr, Expr>> LinearPattern::linearize(State& s,
   ret.emplace_back(currProg, currProgDef);
   std::reverse(ret.begin(), ret.end());
   return ret;
+}
+
+Expr LinearPattern::mkCasePattern(State& s, const Expr& prog, const Expr& pat)
+{
+  Assert(pat.getKind() == Kind::APPLY && pat.getNumChildren() > 0);
+  if (pat[0] == prog)
+  {
+    return pat;
+  }
+  std::vector<Expr> children;
+  children.push_back(prog);
+  for (size_t i = 1, nchild = pat.getNumChildren(); i < nchild; i++)
+  {
+    children.push_back(pat[i]);
+  }
+  // note we do not desugar here, see linearizeRec below
+  return s.mkRawExpr(Kind::APPLY, children);
 }
 
 std::pair<Expr, Expr> LinearPattern::linearizePattern(State& s, const Expr& pat)
@@ -147,7 +165,13 @@ Expr LinearPattern::linearizeRec(State& s,
     }
     if (childChanged)
     {
-      return s.mkExpr(pat.getKind(), nchildren);
+      // Note we construct the term without desugaring, since pat has already
+      // been desugared by the parser. In particular, using mkExpr here would
+      // reapply the constructor attributes of the head of an application, e.g.
+      // it would append a second nil terminator to a :right-assoc-nil
+      // application. This mirrors how TypeChecker::evaluate reconstructs
+      // terms.
+      return s.mkRawExpr(pat.getKind(), nchildren);
     }
   }
   return pat;

--- a/plugins/linear_patterns/linear_patterns.cpp
+++ b/plugins/linear_patterns/linear_patterns.cpp
@@ -1,0 +1,156 @@
+/******************************************************************************
+ * This file is part of the ethos project.
+ *
+ * Copyright (c) 2023-2024 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ ******************************************************************************/
+
+#include "linear_patterns.h"
+
+#include <algorithm>
+#include <set>
+#include <sstream>
+
+#include "state.h"
+
+namespace ethos {
+
+std::vector<std::pair<Expr, Expr>> LinearPattern::linearize(State& s,
+                                                            const Expr& prog,
+                                                            const Expr& progDef)
+{
+  Assert(!progDef.isNull() && progDef.getKind() == Kind::PROGRAM);
+  std::vector<std::pair<Expr, Expr>> ret;
+  std::vector<Expr> currCases;
+  Expr currProg = prog;
+  size_t progCount = 0;
+  Expr ptype = prog.getType();
+  for (size_t i = 0, ncases = progDef.getNumChildren(); i < ncases; i++)
+  {
+    Assert(progDef[i].getKind() == Kind::TUPLE
+           && progDef[i].getNumChildren() == 2);
+    Expr pat = progDef[i][0];
+    std::pair<Expr, Expr> lpat = linearizePattern(s, pat);
+    if (lpat.second.isNull())
+    {
+      currCases.push_back(progDef[i]);
+      continue;
+    }
+    if (i + 1 == ncases)
+    {
+      // as an optimization, just do a requires if we are the last case
+      Expr ctrue = s.mkTrue();
+      Expr ret =
+          s.mkExpr(Kind::EVAL_REQUIRES, {lpat.second, ctrue, progDef[i][1]});
+      currCases.push_back(s.mkPair(lpat.first, ret));
+      continue;
+    }
+    // make a new copy of the program
+    progCount++;
+    std::stringstream ss;
+    ss << "$eo.l." << progCount << "." << prog;
+    Expr newProg = s.mkSymbol(Kind::PROGRAM_CONST, ss.str(), ptype);
+    std::vector<Expr> newappc;
+    std::vector<Expr> defappc;
+    defappc.push_back(currProg);
+    newappc.push_back(newProg);
+    bool wasDefault = true;
+    for (size_t j = 1, ncallArgs = lpat.first.getNumChildren(); j < ncallArgs;
+         j++)
+    {
+      wasDefault = wasDefault && lpat.first[j].getKind() == Kind::PARAM;
+      newappc.push_back(lpat.first[j]);
+      std::stringstream ssd;
+      ssd << "$eo.dv." << j;
+      defappc.push_back(s.mkSymbol(Kind::PARAM, ssd.str(), pat[j].getType()));
+    }
+    Expr newApp = s.mkExpr(Kind::APPLY, newappc);
+    Expr retLin =
+        s.mkExpr(Kind::EVAL_IF_THEN_ELSE, {lpat.second, progDef[i][1], newApp});
+    Expr linCase = s.mkPair(lpat.first, retLin);
+    currCases.push_back(linCase);
+    // only needs a default if the linearized case was not already fully general
+    if (!wasDefault)
+    {
+      Expr defApp = s.mkExpr(Kind::APPLY, defappc);
+      defappc[0] = newProg;
+      Expr defRet = s.mkExpr(Kind::APPLY, defappc);
+      Expr defCase = s.mkPair(defApp, defRet);
+      currCases.push_back(defCase);
+    }
+    Expr currProgDef = s.mkExpr(Kind::PROGRAM, currCases);
+    ret.emplace_back(currProg, currProgDef);
+    currProg = newProg;
+    currCases.clear();
+  }
+  // finish with remainder
+  Expr currProgDef = s.mkExpr(Kind::PROGRAM, currCases);
+  ret.emplace_back(currProg, currProgDef);
+  std::reverse(ret.begin(), ret.end());
+  return ret;
+}
+
+std::pair<Expr, Expr> LinearPattern::linearizePattern(State& s, const Expr& pat)
+{
+  std::map<Expr, size_t> params;
+  std::vector<Expr> conds;
+  Expr lpat = linearizeRec(s, pat, params, conds);
+  if (conds.empty())
+  {
+    Assert(lpat == pat);
+    Expr nullExpr;
+    return std::pair<Expr, Expr>(lpat, nullExpr);
+  }
+  if (conds.size() == 1)
+  {
+    return std::pair<Expr, Expr>(lpat, conds[0]);
+  }
+  Expr cond = s.mkExpr(Kind::EVAL_AND, conds);
+  return std::pair<Expr, Expr>(lpat, cond);
+}
+
+Expr LinearPattern::linearizeRec(State& s,
+                                 const Expr& pat,
+                                 std::map<Expr, size_t>& params,
+                                 std::vector<Expr>& conds)
+{
+  if (pat.getKind() == Kind::PARAM)
+  {
+    std::map<Expr, size_t>::iterator it = params.find(pat);
+    if (it == params.end())
+    {
+      params[pat] = 1;
+    }
+    else
+    {
+      it->second++;
+      std::stringstream ss;
+      ss << "$eo.lv." << pat << "." << it->second;
+      Expr patType = pat.getType();
+      Expr npat = s.mkSymbol(Kind::PARAM, ss.str(), patType);
+      Expr cond = s.mkExpr(Kind::EVAL_EQ, {pat, npat});
+      conds.push_back(cond);
+      return npat;
+    }
+  }
+  else if (pat.getNumChildren() > 0)
+  {
+    std::vector<Expr> nchildren;
+    bool childChanged = false;
+    for (size_t i = 0, nchild = pat.getNumChildren(); i < nchild; i++)
+    {
+      Expr ns = linearizeRec(s, pat[i], params, conds);
+      nchildren.push_back(ns);
+      childChanged = childChanged || pat[i] != ns;
+    }
+    if (childChanged)
+    {
+      return s.mkExpr(pat.getKind(), nchildren);
+    }
+  }
+  return pat;
+}
+
+}  // namespace ethos

--- a/plugins/linear_patterns/linear_patterns.h
+++ b/plugins/linear_patterns/linear_patterns.h
@@ -29,6 +29,73 @@ class State;
  * by later cases, linearization may split the original program into helper
  * programs so the old fall-through behavior is preserved.
  *
+ * For example, consider the program below, whose first case matches the two
+ * arguments of `and` against the same parameter `x`:
+ *
+ *   (program $collapse ((x Bool) (y Bool))
+ *     :signature (Bool) Bool
+ *     (
+ *       (($collapse (and x x)) x)
+ *       (($collapse (and x y)) (and x y))
+ *     )
+ *   )
+ *
+ * The repeated occurrence of `x` becomes the fresh parameter `$eo.lv.x.2`,
+ * and the equality it stood for becomes the guard `(eo::eq x $eo.lv.x.2)`.
+ * Since the guarded case is not the last one, the guard must be able to fail
+ * into the cases that follow it, which a single program cannot express.  The
+ * remaining cases therefore move into a continuation program, and the guard
+ * is emitted as an `eo::ite` whose else branch calls it:
+ *
+ *   (program $eo.l.1.$collapse ((x Bool) (y Bool))
+ *     :signature (Bool) Bool
+ *     (
+ *       (($collapse (and x y)) (and x y))
+ *     )
+ *   )
+ *   (program $collapse ((x Bool) ($eo.lv.x.2 Bool) ($eo.dv.1 Bool))
+ *     :signature (Bool) Bool
+ *     (
+ *       (($collapse (and x $eo.lv.x.2))
+ *        (eo::ite (eo::eq x $eo.lv.x.2)
+ *                 x
+ *                 ($eo.l.1.$collapse (and x $eo.lv.x.2))))
+ *       (($collapse $eo.dv.1) ($eo.l.1.$collapse $eo.dv.1))
+ *     )
+ *   )
+ *
+ * The trailing case of `$collapse` is the catch-all that forwards inputs
+ * matching none of its patterns to the continuation.  It is required here
+ * because `(and x $eo.lv.x.2)` is not fully general: an input that is not an
+ * application of `and` would otherwise get stuck instead of reaching the
+ * second case.  When the linearized pattern happens to be fully general, that
+ * is, when every argument is a plain parameter, the case already matches
+ * everything and no catch-all is added.
+ *
+ * A non-linear pattern in the *last* case needs no split, since there is
+ * nothing to fall through to.  Its guard is emitted as an `eo::requires`
+ * instead, so the case simply gets stuck when the guard fails:
+ *
+ *   (($collapse (and x x)) x)
+ *   ==>
+ *   (($collapse (and x $eo.lv.x.2))
+ *    (eo::requires (eo::eq x $eo.lv.x.2) true x))
+ *
+ * Note the two naming schemes above: `$eo.lv.<param>.<n>` for the parameter
+ * standing for the n-th occurrence of `<param>`, `$eo.dv.<i>` for the i-th
+ * argument of a catch-all case, and `$eo.l.<n>.<prog>` for the n-th
+ * continuation program split off from `<prog>`.
+ *
+ * Two details of the result are worth noting.  First, `linearize` returns only
+ * program symbols paired with their case lists; the `program` declarations
+ * shown above are how a consumer renders those pairs, and the parameter lists
+ * and signatures are supplied by the consumer rather than by this utility.
+ * Second, the case patterns carried into a continuation program keep the
+ * application head of the *original* program, as `($collapse (and x y))` does
+ * above, rather than being renamed to the continuation.  Consumers of this
+ * utility read a case pattern only for its arguments, so the head is ignored;
+ * the output is not intended to be re-parsed as Eunoia as-is.
+ *
  * The utility is exposed as static methods because callers typically need a
  * one-shot transformation of an already-built program definition.
  */
@@ -39,6 +106,12 @@ class LinearPattern
    * Linearize patterns in prog whose definition is progDef.
    * This returns a list of programs and their definitions that do
    * not have non-linear patterns.
+   *
+   * The first component of each pair is the program symbol and the second is
+   * its list of cases.  The original program is always present; splitting a
+   * guarded case appends further continuation programs.  The list is ordered
+   * so that a program appears after every continuation it calls, which lets a
+   * consumer emit them in order without forward declarations.
    */
   static std::vector<std::pair<Expr, Expr>> linearize(State& s,
                                                       const Expr& prog,

--- a/plugins/linear_patterns/linear_patterns.h
+++ b/plugins/linear_patterns/linear_patterns.h
@@ -1,0 +1,62 @@
+/******************************************************************************
+ * This file is part of the ethos project.
+ *
+ * Copyright (c) 2023-2024 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ ******************************************************************************/
+#ifndef LINEAR_PATTERNS_H
+#define LINEAR_PATTERNS_H
+
+#include <map>
+#include <utility>
+#include <vector>
+
+#include "expr.h"
+
+namespace ethos {
+
+class State;
+
+/**
+ * Utility for rewriting non-linear EO program patterns into linear patterns.
+ *
+ * Some target encodings, including Lean pattern matching, require each pattern
+ * variable to occur at most once.  `LinearPattern` rewrites repeated variables
+ * by replacing later occurrences with fresh parameters and collecting equality
+ * guards that enforce the original sharing.  When a guarded case is followed
+ * by later cases, linearization may split the original program into helper
+ * programs so the old fall-through behavior is preserved.
+ *
+ * The utility is exposed as static methods because callers typically need a
+ * one-shot transformation of an already-built program definition.
+ */
+class LinearPattern
+{
+ public:
+  /**
+   * Linearize patterns in prog whose definition is progDef.
+   * This returns a list of programs and their definitions that do
+   * not have non-linear patterns.
+   */
+  static std::vector<std::pair<Expr, Expr>> linearize(State& s,
+                                                      const Expr& prog,
+                                                      const Expr& progDef);
+
+ private:
+  /**
+   * Returns a pair (new pattern, condition) where new pattern is linear.
+   * If condition is null, then no linearization was necessary.
+   */
+  static std::pair<Expr, Expr> linearizePattern(State& s, const Expr& pat);
+  /** Recursively replace repeated parameters and collect equality guards. */
+  static Expr linearizeRec(State& s,
+                           const Expr& pat,
+                           std::map<Expr, size_t>& params,
+                           std::vector<Expr>& conds);
+};
+
+}  // namespace ethos
+
+#endif /* LINEAR_PATTERNS_H */

--- a/plugins/linear_patterns/linear_patterns.h
+++ b/plugins/linear_patterns/linear_patterns.h
@@ -50,7 +50,7 @@ class State;
  *   (program $eo.l.1.$collapse ((x Bool) (y Bool))
  *     :signature (Bool) Bool
  *     (
- *       (($collapse (and x y)) (and x y))
+ *       (($eo.l.1.$collapse (and x y)) (and x y))
  *     )
  *   )
  *   (program $collapse ((x Bool) ($eo.lv.x.2 Bool) ($eo.dv.1 Bool))
@@ -86,15 +86,15 @@ class State;
  * argument of a catch-all case, and `$eo.l.<n>.<prog>` for the n-th
  * continuation program split off from `<prog>`.
  *
- * Two details of the result are worth noting.  First, `linearize` returns only
- * program symbols paired with their case lists; the `program` declarations
- * shown above are how a consumer renders those pairs, and the parameter lists
- * and signatures are supplied by the consumer rather than by this utility.
- * Second, the case patterns carried into a continuation program keep the
- * application head of the *original* program, as `($collapse (and x y))` does
- * above, rather than being renamed to the continuation.  Consumers of this
- * utility read a case pattern only for its arguments, so the head is ignored;
- * the output is not intended to be re-parsed as Eunoia as-is.
+ * Note that `linearize` returns only program symbols paired with their case
+ * lists; the `program` declarations shown above are how a consumer renders
+ * those pairs, and the parameter lists and signatures are supplied by the
+ * consumer rather than by this utility.  Each case pattern is headed by the
+ * program that owns it, as `($eo.l.1.$collapse (and x y))` above shows for a
+ * case that was carried over from `$collapse`.  Note that the head of a case
+ * pattern is ignored when a program is evaluated, so this renaming is
+ * immaterial to the semantics; it matters only for consumers that read the
+ * head, e.g. to determine which programs a program calls.
  *
  * The utility is exposed as static methods because callers typically need a
  * one-shot transformation of an already-built program definition.
@@ -110,14 +110,23 @@ class LinearPattern
    * The first component of each pair is the program symbol and the second is
    * its list of cases.  The original program is always present; splitting a
    * guarded case appends further continuation programs.  The list is ordered
-   * so that a program appears after every continuation it calls, which lets a
-   * consumer emit them in order without forward declarations.
+   * so that a program appears after the continuations it calls, although note
+   * this is not a topological order in general: if a case of the original
+   * program is recursive, then it is called by the continuation that carries
+   * that case, and the group is mutually recursive.  A consumer that requires
+   * forward declarations must handle this case.
    */
   static std::vector<std::pair<Expr, Expr>> linearize(State& s,
                                                       const Expr& prog,
                                                       const Expr& progDef);
 
  private:
+  /**
+   * Returns the case pattern pat with prog as its head, which is pat itself if
+   * it is already headed by prog. This ensures each case of a program is
+   * headed by that program, see above.
+   */
+  static Expr mkCasePattern(State& s, const Expr& prog, const Expr& pat);
   /**
    * Returns a pair (new pattern, condition) where new pattern is linear.
    * If condition is null, then no linearization was necessary.


### PR DESCRIPTION
Eunoia permits patterns with duplicated variables while Lean does not.

This introduces a transformation from Eunoia to Eunoia that eliminates such patterns, which will be used in the compiler to Lean.