### PR TITLE
Release ExprValues with delete, run Linux debug CI under ASan

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,9 +147,25 @@ jobs:
           echo "num_proc=$(( $(nproc) + 1 ))" >> $GITHUB_ENV
         fi
 
+    # Run the Linux debug builds under AddressSanitizer. ASan cannot be
+    # combined with --static, but the debug binaries are never uploaded (see
+    # the artifact step below), so the static link is not needed there. This is
+    # Linux-only because the mingw gcc used for windows-x86_64 has no ASan.
+    - name: Set up sanitizer configuration
+      run: |
+        if [ "${{ runner.os }}" = "Linux" ] && [ "${{ matrix.build-type }}" = "debug" ]; then
+          echo "configure_flags=--asan" >> $GITHUB_ENV
+          # ethos deliberately exits via exit(0) without tearing down its State
+          # (see main.cpp), so every run leaks by design and LeakSanitizer would
+          # report all of it. Only the memory errors are of interest here.
+          echo "ASAN_OPTIONS=detect_leaks=0" >> $GITHUB_ENV
+        else
+          echo "configure_flags=--static" >> $GITHUB_ENV
+        fi
+
     - name: Build
       run: |
-        ./configure.sh ${{ matrix.build-type  }} --static --werror
+        ./configure.sh ${{ matrix.build-type  }} ${{ env.configure_flags }} --werror
         cd build
         make -j${{ env.num_proc }}
 

--- a/configure.sh
+++ b/configure.sh
@@ -22,6 +22,7 @@ Features:
 The following flags enable optional features (disable with --no-<option name>).
   --static                 build static binary [default=no]
   --werror                 build with -Werror
+  --asan                   build with AddressSanitizer [default=no]
 
 
 CMake Options (Advanced)
@@ -57,6 +58,7 @@ buildtype=default
 
 build_static=default
 werror=default
+asan=default
 
 #--------------------------------------------------------------------------#
 
@@ -87,6 +89,9 @@ do
 
     --werror) werror=ON;;
 
+    --asan) asan=ON;;
+    --no-asan) asan=OFF;;
+
     -D*) cmake_opts="${cmake_opts} $1" ;;
 
     -*) die "invalid option '$1' (try -h)";;
@@ -103,10 +108,28 @@ done
 
 #--------------------------------------------------------------------------#
 
-if [ $werror != default ]; then
-  export CFLAGS=-Werror
-  export CXXFLAGS=-Werror
+if [ $asan = ON ] && [ $build_static = ON ]; then
+  die "--asan is incompatible with --static (cannot specify -static with -fsanitize=address)"
 fi
+
+cflags=""
+cxxflags=""
+ldflags=""
+
+if [ $werror != default ]; then
+  cflags="$cflags -Werror"
+  cxxflags="$cxxflags -Werror"
+fi
+
+if [ $asan = ON ]; then
+  cflags="$cflags -fsanitize=address -fno-omit-frame-pointer"
+  cxxflags="$cxxflags -fsanitize=address -fno-omit-frame-pointer"
+  ldflags="$ldflags -fsanitize=address"
+fi
+
+[ -n "$cflags" ] && export CFLAGS="${cflags# }"
+[ -n "$cxxflags" ] && export CXXFLAGS="${cxxflags# }"
+[ -n "$ldflags" ] && export LDFLAGS="${ldflags# }"
 
 [ $buildtype != default ] \
   && cmake_opts="$cmake_opts -DCMAKE_BUILD_TYPE=$buildtype"

--- a/src/expr.h
+++ b/src/expr.h
@@ -36,7 +36,7 @@ class ExprValue
  public:
   ExprValue();
   ExprValue(Kind k, const std::vector<ExprValue*>& children);
-  ~ExprValue();
+  virtual ~ExprValue();
   /** as literal */
   virtual const Literal* asLiteral() const { return nullptr; }
   /** is null? */

--- a/src/literal.cpp
+++ b/src/literal.cpp
@@ -47,7 +47,9 @@ Literal::Literal(const Literal& other)
   }
 }
 
-Literal::~Literal()
+Literal::~Literal() { destroyPayload(); }
+
+void Literal::destroyPayload()
 {
   // Destroy the active member of the union, mirroring the copy constructor.
   switch (d_kind)
@@ -74,6 +76,11 @@ Literal& Literal::operator=(const Literal& other)
 {
   if (this != &other)
   {
+    // The members of the union below are constructed in place, so whichever
+    // one is currently active has to be destroyed first. Note destroyPayload
+    // selects that member using d_kind, so it must run before d_kind is
+    // overwritten.
+    destroyPayload();
     d_kind = other.d_kind;
     switch (d_kind)
     {

--- a/src/literal.cpp
+++ b/src/literal.cpp
@@ -47,6 +47,29 @@ Literal::Literal(const Literal& other)
   }
 }
 
+Literal::~Literal()
+{
+  // Destroy the active member of the union, mirroring the copy constructor.
+  switch (d_kind)
+  {
+    case Kind::BOOLEAN: break;
+    case Kind::DECIMAL:
+    case Kind::RATIONAL: d_rat.~Rational(); break;
+    case Kind::NUMERAL: d_int.~Integer(); break;
+    case Kind::HEXADECIMAL:
+    case Kind::BINARY: d_bv.~BitVector(); break;
+    case Kind::STRING: d_str.~String(); break;
+    case Kind::NONE: break;
+    default:
+      if (isSymbol(d_kind))
+      {
+        using StdString = std::string;
+        d_sym.~StdString();
+      }
+      break;
+  }
+}
+
 Literal& Literal::operator=(const Literal& other)
 {
   if (this != &other)

--- a/src/literal.h
+++ b/src/literal.h
@@ -46,6 +46,11 @@ public:
   Literal& operator=(const Literal& other);
 
   ~Literal();
+  /**
+   * Destroy the active member of the union, if any. After this call the union
+   * holds raw storage and d_kind no longer describes a live member.
+   */
+  void destroyPayload();
   /** as literal */
   const Literal* asLiteral() const override { return this; }
   std::string toString() const;

--- a/src/literal.h
+++ b/src/literal.h
@@ -45,7 +45,7 @@ public:
 
   Literal& operator=(const Literal& other);
 
-  ~Literal() {}
+  ~Literal();
   /** as literal */
   const Literal* asLiteral() const override { return this; }
   std::string toString() const;

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -448,8 +448,11 @@ void State::markDeleted(ExprValue* e)
     Assert(et != nullptr);
     const std::vector<ExprValue*>& children = e->d_children;
     et->remove(children);
-    // now, free the expression
-    free(e);
+    // now, free the expression. Note this invokes ~ExprValue, which
+    // decrements the reference counts of the children of e. Those calls
+    // re-enter markDeleted, which appends to d_toDelete since we are already
+    // in garbage collection, and are processed by the loop below.
+    delete e;
     if (!d_toDelete.empty())
     {
       e = d_toDelete.back();


### PR DESCRIPTION
## Problem

`ExprValue`s are allocated with `new` (`State::mkExprInternal`, `State::mkSymbolInternal`, `State::mkLiteralInternal`) but `State::markDeleted` released them with `free()`:

```cpp
    // now, free the expression
    free(e);
```

Besides being an allocator mismatch, this skipped `~ExprValue()` — which is not empty:

```cpp
ExprValue::~ExprValue()
{
  for (ExprValue * c : d_children)
  {
    c->dec();
  }
}
```

So collecting a term never released the terms it was built from, and the union member of a collected `Literal` was never destroyed.

`markDeleted` already anticipates the destructor running: the `d_inGarbageCollection` guard and the `d_toDelete` worklist exist precisely so that the nested `dec()` calls made by `~ExprValue` are queued rather than recursing.

## Fix

`delete e` instead of `free(e)`. That requires two supporting changes:

- **`~ExprValue` must be virtual.** `ExprValue` is polymorphic (`asLiteral()`) and `Literal`s are deleted through an `ExprValue*`. It already had a vtable, so this does not change its layout or size.
- **`~Literal` must destroy the active member of its union**, mirroring what the copy constructor already does. It was previously `~Literal() {}`.

## Second commit: `Literal::operator=`

Giving `Literal` a destructor exposes a second problem in the same class. The union members are constructed in place, so `operator=` placement-new'd over whichever member was already active without destroying it — including on *same-kind* assignment, since the new member is constructed over the old one either way.

**This is not reachable today.** `operator=` has a single caller, `State::mkLiteral`, which assigns exactly once to a freshly declared `Literal` whose kind is `NONE`, so the placement-new lands on uninitialized storage. I instrumented `operator=` to report any assignment over a live member and ran the full suite: it is called in 88 of 179 test files and overwrites a live member in **none** of them.

It is folded in here because the destructor is what makes it matter. Before, the union was never destroyed at all, so this was invisible among everything else leaking. After, `Literal` has a correct copy constructor and a correct destructor but an assignment operator that respects neither — and the first caller to assign to a live `Literal` leaks silently. Landing the destructor without this would be leaving a Rule-of-Three violation behind.

Constructed directly, under LeakSanitizer:

| case | before | after |
|---|---|---|
| construct + destroy a `String` literal | no leak | no leak |
| assign a `NUMERAL` over a live `String` | 144 bytes leaked | no leak |
| assign a `String` over a live `String` | 144 bytes leaked | no leak |

The teardown is factored out of `~Literal` into `destroyPayload()` so both can use it. It selects the member using `d_kind`, so it must run before `d_kind` is overwritten.

## Detection

AddressSanitizer reports the mismatch on **80 of the 178 tests** on current `main` (`d431466a`). With both commits the full suite is ASan-clean.

As a side effect the fixes also cut the failures seen with LeakSanitizer enabled, though not to zero:

| | `detect_leaks=0` | leak detection on |
|---|---|---|
| unfixed `main` | 80 fail | 122 fail |
| this PR | **0 fail** | 16 fail |

Turning LeakSanitizer on in CI is a plausible follow-up once those remaining 16 are chased down, but it is out of scope here, hence `detect_leaks=0` below.

## Keeping it from coming back

The Linux debug matrix jobs now build under ASan:

- `configure.sh` gains `--asan`. The flags are now accumulated rather than assigned, so `--asan` and `--werror` compose. This matters: passing `-DCMAKE_CXX_FLAGS=-fsanitize=address` from the workflow instead would have *silently dropped* `--werror`, because `configure.sh` implements it via the `CXXFLAGS` environment variable, which CMake only uses to initialize the cache. `--asan` and `--static` are rejected together, since `-static` cannot be combined with `-fsanitize=address`.
- The Linux debug jobs pass `--asan` in place of `--static`. Debug binaries are never uploaded (the artifact step is gated on `matrix.build-type == 'release'`), so they do not need the static link. Release jobs are unchanged.
- Those jobs set `ASAN_OPTIONS=detect_leaks=0`, because `main()` deliberately exits via `exit(0)` without tearing down the `State`, so every run leaks by design. Without this, 122 of 178 tests "fail" on that expected noise instead of the 80 real errors.

Linux-only because the mingw gcc used for `windows-x86_64` has no ASan support.

Runtime cost is negligible — `ctest` goes from 1.10s to 1.13s, in a job that already checks out and installs.

## Validation

All run locally on this branch:

| Configuration | Result |
|---|---|
| `debug --asan --werror` + `ctest` | 178/178, 0 ASan errors |
| the three `operator=` cases above under LSan | all clean |
| `release --static --werror` + `ctest` | 178/178 |
| `debug --static --werror` + `ctest` | 178/178 |
| `debug --asan --static` | correctly rejected |
| `make plugins-compile-check` | builds |
| `cpp-compiler-roundtrip` | builds and passes |

Also confirmed `CMAKE_CXX_FLAGS` ends up as `-Werror -fsanitize=address -fno-omit-frame-pointer`, i.e. `--werror` is genuinely preserved.

## Notes for reviewers

- I have **not** measured whether reclaiming children changes the memory or time profile. The `exit(0)` in `main.cpp` is commented as *"avoids deleting all expressions which can take time"*, so the maintainers may care about this; the teardown path there is unaffected either way, but garbage collection during parsing now does strictly more work than before.
- Note that `ExprTrie::remove` had a related use-after-free that was already fixed on `main` in 0735540; this PR does not touch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
