### PR TITLE
Add model smt plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,16 +76,3 @@ else()
   add_custom_target(plugins-compile-check
     COMMAND ${CMAKE_COMMAND} -E echo "No plugin sources to check.")
 endif()
-
-# Plugin-local checks register themselves with plugins-compile-check. Discover
-# their CMake files by convention so this list needs no plugin-specific cases.
-file(GLOB plugin_test_CMAKES CONFIGURE_DEPENDS
-     "plugins/*/test/CMakeLists.txt")
-foreach(plugin_test_CMAKE ${plugin_test_CMAKES})
-  get_filename_component(plugin_test_DIR "${plugin_test_CMAKE}" DIRECTORY)
-  get_filename_component(plugin_DIR "${plugin_test_DIR}/.." ABSOLUTE)
-  get_filename_component(plugin_NAME "${plugin_DIR}" NAME)
-  add_subdirectory("${plugin_test_DIR}"
-                   "${CMAKE_CURRENT_BINARY_DIR}/plugin-tests/${plugin_NAME}"
-                   EXCLUDE_FROM_ALL)
-endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,3 +76,16 @@ else()
   add_custom_target(plugins-compile-check
     COMMAND ${CMAKE_COMMAND} -E echo "No plugin sources to check.")
 endif()
+
+# Plugin-local checks register themselves with plugins-compile-check. Discover
+# their CMake files by convention so this list needs no plugin-specific cases.
+file(GLOB plugin_test_CMAKES CONFIGURE_DEPENDS
+     "plugins/*/test/CMakeLists.txt")
+foreach(plugin_test_CMAKE ${plugin_test_CMAKES})
+  get_filename_component(plugin_test_DIR "${plugin_test_CMAKE}" DIRECTORY)
+  get_filename_component(plugin_DIR "${plugin_test_DIR}/.." ABSOLUTE)
+  get_filename_component(plugin_NAME "${plugin_DIR}" NAME)
+  add_subdirectory("${plugin_test_DIR}"
+                   "${CMAKE_CURRENT_BINARY_DIR}/plugin-tests/${plugin_NAME}"
+                   EXCLUDE_FROM_ALL)
+endforeach()

--- a/plugins/model_smt/cpc_defs.eo
+++ b/plugins/model_smt/cpc_defs.eo
@@ -1,0 +1,2091 @@
+; The CPC signature written *directly* as a transformation into the deep
+; embedding.
+;
+; This is what the model-smt stage compiles the CPC half of a model from. For
+; each of the 180 symbols it covers it gives one thing:
+;
+;   $eoc_transform_X       the cases X contributes to $eo_to_smt, i.e.
+;                            T -> $smt_Term for a Eunoia term of any type T;
+;   $eoc_transform_type_X  the cases a *type* constructor X contributes to
+;                            $eo_to_smt_type, i.e. Type -> $smt_Type.
+;
+; It declares no constant: the constants are those of the SMT-LIB signature,
+; see plugins/model_smt/smt_defs.eo. A symbol of CPC is *eliminated* here, in
+; the sense that what it denotes is written in the vocabulary of that file
+; rather than in its own.
+;
+; The stage that reads this file has only to concatenate the cases of every
+; $eoc_transform_X into $eo_to_smt, and to copy everything else through. Note
+; the recursive call is to $eo_to_smt rather than to any $eoc_transform_X: what
+; an argument is, is not known here. A type is transformed by $eo_to_smt_type,
+; which stands to types as $eo_to_smt stands to terms; both are declared by
+; plugins/model_smt/model_smt.eo.
+;
+; A case that walks a structure the desugar stage built rather than a term of
+; the input calls a helper program, e.g. the list a distinctness gathered or
+; the variables a quantifier binds. Each such helper is written out just above
+; the symbol that names it; they live in plugins/model_smt/eo_to_smt_aux.eo
+; today. A symbol comes after the ones its cases name, so that nothing here has
+; to be declared before it is defined.
+;
+; Every case below is the one the model-smt stage generates today, copied as it
+; stands, so that what is compiled from this file is what is compiled now. Each
+; program declares the parameters its own cases name, and no others.
+;
+; What stays in $eo_to_smt_type itself is the 6 cases that belong to no symbol
+; of the input: the function type, the ones a datatype or an uninterpreted sort
+; is built by ($eot_DatatypeType, $eot_DatatypeTypeRef, $eot_DtcAppType,
+; $eot_USort), and the default case.
+;
+; What stays in $eo_to_smt itself is the 11 cases that belong to no symbol: the
+; constructors of a Eunoia literal ($eot_bool, $eot_numeral, $eot_rational,
+; $eot_string, $eot_binary), those of a term the input declares ($eot_Var,
+; $eot_UConst, $eot_DtCons, $eot_DtSel), the application of one term to
+; another, and the default case, which gives $sm_none to everything else.
+;
+; This file is not included by anything yet.
+
+; -----------------------------------------------------------------------------
+; What this file contributes to, and the helpers its cases name
+; -----------------------------------------------------------------------------
+
+; The two aggregates this file contributes to, $eo_to_smt and
+; $eo_to_smt_type, are declared by plugins/model_smt/model_smt.eo, which is
+; what lets a case below recurse into them.
+
+; A helper a case names belongs to the symbol that names it and is written
+; out just above that symbol below, the first time it is needed.
+
+; -- ite
+(program $eoc_transform_ite
+  ((T Type) (T1 Type) (T2 Type) (T3 Type) (x1 T1) (x2 T2) (x3 T3))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_ite (ite x1 x2 x3)) ($sm_ite ($eo_to_smt x1) ($eo_to_smt x2) ($eo_to_smt x3)))
+  )
+)
+
+; -- not
+(program $eoc_transform_not
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_not (not x1)) ($sm_not ($eo_to_smt x1)))
+  )
+)
+
+; -- or
+(program $eoc_transform_or
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_or (or x1 x2)) ($sm_or ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- and
+(program $eoc_transform_and
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_and (and x1 x2)) ($sm_and ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- =>
+(program $eoc_transform_=>
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_=> (=> x1 x2)) ($sm_=> ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- xor
+(program $eoc_transform_xor
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_xor (xor x1 x2)) ($sm_xor ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- =
+(program $eoc_transform_=
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_= (= x1 x2)) ($sm_= ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- distinct
+(program $eo_to_smt_distinct_pairs
+  ((T Type) (s $smt_Term) (x T) (xs (@@TypedList T)))
+  :signature ($smt_Term (@@TypedList T)) $smt_Term
+  (
+  (($eo_to_smt_distinct_pairs s (@@TypedList.cons x xs))
+     ($sm_and ($sm_not ($sm_= s ($eo_to_smt x))) ($eo_to_smt_distinct_pairs s xs)))
+  (($eo_to_smt_distinct_pairs s (@@TypedList.nil T)) $sm_true)
+  (($eo_to_smt_distinct_pairs s xs) $sm_none)
+  )
+)
+(program $eo_to_smt_distinct
+  ((T Type) (s $smt_Term) (x T) (xs (@@TypedList T)))
+  :signature ((@@TypedList T)) $smt_Term
+  (
+  (($eo_to_smt_distinct (@@TypedList.cons x xs))
+     ($sm_and ($eo_to_smt_distinct_pairs ($eo_to_smt x) xs) ($eo_to_smt_distinct xs)))
+  (($eo_to_smt_distinct (@@TypedList.nil T)) $sm_true)
+  (($eo_to_smt_distinct xs) $sm_none)
+  )
+)
+(program $eo_to_smt_typed_list_elem_type ((T Type) (t T) (ts (@@TypedList T)))
+  :signature (T) $smt_Type
+  (
+  (($eo_to_smt_typed_list_elem_type (@@TypedList.nil T))
+    (eo::define ((eT ($eo_to_smt_type T)))
+      ($native_ite ($smtx_type_wf eT) eT $tsm_none)))
+  (($eo_to_smt_typed_list_elem_type (@@TypedList.cons t ts))
+    (eo::define ((eT ($smtx_typeof ($eo_to_smt t))))
+      ($native_ite ($native_Teq eT ($eo_to_smt_typed_list_elem_type ts))
+        eT
+        $tsm_none)))    
+  (($eo_to_smt_typed_list_elem_type t) $tsm_none)
+  )
+)
+(program $eoc_transform_distinct
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_distinct (distinct x1)) ($native_ite ($native_Teq ($eo_to_smt_typed_list_elem_type x1) $tsm_none) $sm_none ($eo_to_smt_distinct x1)))
+  )
+)
+
+; -- @purify
+(program $eoc_transform_@purify
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_@purify (@purify x1)) ($sm_@purify ($eo_to_smt x1)))
+  )
+)
+
+; -- +
+(program $eoc_transform_+
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_+ (+ x1 x2)) ($sm_+ ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+(program $eoc_is_list_nil_+ ((T Type) (x1 T))
+  :signature (T) Bool
+  (
+  (($eoc_is_list_nil_+ x1) (eo::is_eq (eo::to_q x1) 0/1))
+  )
+)
+
+; -- -
+(program $eoc_transform_-
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_- (- x1 x2)) ($sm_- ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- *
+(program $eoc_transform_*
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_* (* x1 x2)) ($sm_* ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+(program $eoc_is_list_nil_* ((T Type) (x1 T))
+  :signature (T) Bool
+  (
+  (($eoc_is_list_nil_* x1) (eo::is_eq (eo::to_q x1) 1/1))
+  )
+)
+
+; -- <
+(program $eoc_transform_<
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_< (< x1 x2)) ($sm_< ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- <=
+(program $eoc_transform_<=
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_<= (<= x1 x2)) ($sm_<= ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- >
+(program $eoc_transform_>
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_> (> x1 x2)) ($sm_> ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- >=
+(program $eoc_transform_>=
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_>= (>= x1 x2)) ($sm_>= ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- to_real
+(program $eoc_transform_to_real
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_to_real (to_real x1)) ($sm_to_real ($eo_to_smt x1)))
+  )
+)
+
+; -- to_int
+(program $eoc_transform_to_int
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_to_int (to_int x1)) ($sm_to_int ($eo_to_smt x1)))
+  )
+)
+
+; -- is_int
+(program $eoc_transform_is_int
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_is_int (is_int x1)) ($sm_is_int ($eo_to_smt x1)))
+  )
+)
+
+; -- abs
+(program $eoc_transform_abs
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_abs (abs x1)) ($sm_abs ($eo_to_smt x1)))
+  )
+)
+
+; -- $eoo_-.2
+; The second symbol the input overloads - with, which is unary minus. The
+; desugar stage is what gives an overload a name of its own, and no signature
+; declares that name, so this block is the only thing that says what it means:
+; it denotes what uneg does, whose block gives the constructor named here.
+(program $eoc_transform_$eoo_-.2
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_$eoo_-.2 ($eoo_-.2 x1)) ($sm_uneg ($eo_to_smt x1)))
+  )
+)
+
+; -- div
+(program $eoc_transform_div
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_div (div x1 x2)) ($sm_div ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- mod
+(program $eoc_transform_mod
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_mod (mod x1 x2)) ($sm_mod ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- divisible
+(program $eoc_transform_divisible
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_divisible (divisible x1 x2)) ($sm_divisible ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- int.pow2
+(program $eoc_transform_int.pow2
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_int.pow2 (int.pow2 x1)) ($sm_int.pow2 ($eo_to_smt x1)))
+  )
+)
+
+; -- int.log2
+(program $eoc_transform_int.log2
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_int.log2 (int.log2 x1)) ($sm_int.log2 ($eo_to_smt x1)))
+  )
+)
+
+; -- int.ispow2
+(program $eoc_transform_int.ispow2
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_int.ispow2 (int.ispow2 x1)) ($sm_and ($sm_>= ($eo_to_smt x1) ($sm_numeral ($native_apply_0 "0"))) ($sm_= ($eo_to_smt x1) ($sm_int.pow2 ($sm_int.log2 ($eo_to_smt x1))))))
+  )
+)
+
+; -- div_total
+(program $eoc_transform_div_total
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_div_total (div_total x1 x2)) ($sm_div_total ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- mod_total
+(program $eoc_transform_mod_total
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_mod_total (mod_total x1 x2)) ($sm_mod_total ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- @int_div_by_zero
+(program $eoc_transform_@int_div_by_zero
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_@int_div_by_zero (@int_div_by_zero x1)) ($sm_div ($eo_to_smt x1) ($sm_numeral ($native_apply_0 "0"))))
+  )
+)
+
+; -- @mod_by_zero
+(program $eoc_transform_@mod_by_zero
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_@mod_by_zero (@mod_by_zero x1)) ($sm_mod ($eo_to_smt x1) ($sm_numeral ($native_apply_0 "0"))))
+  )
+)
+
+; -- select
+(program $eoc_transform_select
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_select (select x1 x2)) ($sm_select ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- store
+(program $eoc_transform_store
+  ((T Type) (T1 Type) (T2 Type) (T3 Type) (x1 T1) (x2 T2) (x3 T3))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_store (store x1 x2 x3)) ($sm_store ($eo_to_smt x1) ($eo_to_smt x2) ($eo_to_smt x3)))
+  )
+)
+
+; -- @array_deq_diff
+(program $eo_to_smt_array_deq_diff 
+  ((a $smt_Term) (aT $smt_Type) (aU $smt_Type) (b $smt_Term) (bT $smt_Type) (bU $smt_Type))
+  :signature ($smt_Term $smt_Type $smt_Term $smt_Type) $smt_Term
+  (
+  (($eo_to_smt_array_deq_diff a ($tsm_Map aT aU) b ($tsm_Map bT bU)) ($sm_map_diff a b))
+  (($eo_to_smt_array_deq_diff a aT b bT) $sm_none)  
+  )
+)
+(program $eoc_transform_@array_deq_diff
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_@array_deq_diff (@array_deq_diff x1 x2)) ($eo_to_smt_array_deq_diff ($eo_to_smt x1) ($smtx_typeof ($eo_to_smt x1)) ($eo_to_smt x2) ($smtx_typeof ($eo_to_smt x2))))
+  )
+)
+
+; -- $eo_to_smt_bv_size
+; The width a bit-vector type is of, or minus one if the type is not one.
+(program $eo_to_smt_bv_size ((x1 $native_Nat) (t1 $smt_Value))
+  :signature ($smt_Type) $native_Int
+  (
+  (($eo_to_smt_bv_size ($tsm_BitVec x1)) ($native_n_to_z x1))
+  (($eo_to_smt_bv_size t1) $native_z_neg_one)
+  )
+)
+
+; -- @bvsize
+(program $eoc_transform_@bvsize
+  ((n $native_Int) (T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_@bvsize (@bvsize x1)) (eo::define ((n ($eo_to_smt_bv_size ($smtx_typeof ($eo_to_smt x1))))) ($native_ite ($native_z_<= $native_z_zero n) ($sm_@purify ($sm_numeral n)) $sm_none)))
+  )
+)
+
+; -- concat
+(program $eoc_transform_concat
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_concat (concat x1 x2)) ($sm_concat ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- extract
+(program $eoc_transform_extract
+  ((T Type) (T1 Type) (T2 Type) (T3 Type) (x1 T1) (x2 T2) (x3 T3))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_extract (extract x1 x2 x3)) ($sm_extract ($eo_to_smt x1) ($eo_to_smt x2) ($eo_to_smt x3)))
+  )
+)
+
+; -- repeat
+(program $eoc_transform_repeat
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_repeat (repeat x1 x2)) ($sm_repeat ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvnot
+(program $eoc_transform_bvnot
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvnot (bvnot x1)) ($sm_bvnot ($eo_to_smt x1)))
+  )
+)
+
+; -- bvand
+(program $eoc_transform_bvand
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvand (bvand x1 x2)) ($sm_bvand ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+(program $eoc_is_list_nil_bvand ((T Type) (x1 T))
+  :signature (T) Bool
+  (
+  (($eoc_is_list_nil_bvand x1) (eo::is_eq (eo::to_z (eo::not x1)) 0))
+  )
+)
+
+; -- bvor
+(program $eoc_transform_bvor
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvor (bvor x1 x2)) ($sm_bvor ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+(program $eoc_is_list_nil_bvor ((T Type) (x1 T))
+  :signature (T) Bool
+  (
+  (($eoc_is_list_nil_bvor x1) (eo::is_eq (eo::to_z x1) 0))
+  )
+)
+
+; -- bvnand
+(program $eoc_transform_bvnand
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvnand (bvnand x1 x2)) ($sm_bvnand ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvnor
+(program $eoc_transform_bvnor
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvnor (bvnor x1 x2)) ($sm_bvnor ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvxor
+(program $eoc_transform_bvxor
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvxor (bvxor x1 x2)) ($sm_bvxor ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+(program $eoc_is_list_nil_bvxor ((T Type) (x1 T))
+  :signature (T) Bool
+  (
+  (($eoc_is_list_nil_bvxor x1) (eo::is_eq (eo::to_z x1) 0))
+  )
+)
+
+; -- bvxnor
+(program $eoc_transform_bvxnor
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvxnor (bvxnor x1 x2)) ($sm_bvxnor ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvcomp
+(program $eoc_transform_bvcomp
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvcomp (bvcomp x1 x2)) ($sm_bvcomp ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvneg
+(program $eoc_transform_bvneg
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvneg (bvneg x1)) ($sm_bvneg ($eo_to_smt x1)))
+  )
+)
+
+; -- bvadd
+(program $eoc_transform_bvadd
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvadd (bvadd x1 x2)) ($sm_bvadd ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+(program $eoc_is_list_nil_bvadd ((T Type) (x1 T))
+  :signature (T) Bool
+  (
+  (($eoc_is_list_nil_bvadd x1) (eo::is_eq (eo::to_z x1) 0))
+  )
+)
+
+; -- bvmul
+(program $eoc_transform_bvmul
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvmul (bvmul x1 x2)) ($sm_bvmul ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+(program $eoc_is_list_nil_bvmul ((T Type) (x1 T))
+  :signature (T) Bool
+  (
+  (($eoc_is_list_nil_bvmul x1) (eo::is_eq (eo::to_z x1) 1))
+  )
+)
+
+; -- bvudiv
+(program $eoc_transform_bvudiv
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvudiv (bvudiv x1 x2)) ($sm_bvudiv ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvurem
+(program $eoc_transform_bvurem
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvurem (bvurem x1 x2)) ($sm_bvurem ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvsub
+(program $eoc_transform_bvsub
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvsub (bvsub x1 x2)) ($sm_bvsub ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvsdiv
+(program $eoc_transform_bvsdiv
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvsdiv (bvsdiv x1 x2)) ($sm_bvsdiv ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvsrem
+(program $eoc_transform_bvsrem
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvsrem (bvsrem x1 x2)) ($sm_bvsrem ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvsmod
+(program $eoc_transform_bvsmod
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvsmod (bvsmod x1 x2)) ($sm_bvsmod ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvult
+(program $eoc_transform_bvult
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvult (bvult x1 x2)) ($sm_bvult ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvule
+(program $eoc_transform_bvule
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvule (bvule x1 x2)) ($sm_bvule ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvugt
+(program $eoc_transform_bvugt
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvugt (bvugt x1 x2)) ($sm_bvugt ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvuge
+(program $eoc_transform_bvuge
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvuge (bvuge x1 x2)) ($sm_bvuge ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvslt
+(program $eoc_transform_bvslt
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvslt (bvslt x1 x2)) ($sm_bvslt ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvsle
+(program $eoc_transform_bvsle
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvsle (bvsle x1 x2)) ($sm_bvsle ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvsgt
+(program $eoc_transform_bvsgt
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvsgt (bvsgt x1 x2)) ($sm_bvsgt ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvsge
+(program $eoc_transform_bvsge
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvsge (bvsge x1 x2)) ($sm_bvsge ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvshl
+(program $eoc_transform_bvshl
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvshl (bvshl x1 x2)) ($sm_bvshl ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvlshr
+(program $eoc_transform_bvlshr
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvlshr (bvlshr x1 x2)) ($sm_bvlshr ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvashr
+(program $eoc_transform_bvashr
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvashr (bvashr x1 x2)) ($sm_bvashr ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- zero_extend
+(program $eoc_transform_zero_extend
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_zero_extend (zero_extend x1 x2)) ($sm_zero_extend ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- sign_extend
+(program $eoc_transform_sign_extend
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_sign_extend (sign_extend x1 x2)) ($sm_sign_extend ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- rotate_left
+(program $eoc_transform_rotate_left
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_rotate_left (rotate_left x1 x2)) ($sm_rotate_left ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- rotate_right
+(program $eoc_transform_rotate_right
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_rotate_right (rotate_right x1 x2)) ($sm_rotate_right ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvite
+(program $eoc_transform_bvite
+  ((T Type) (T1 Type) (T2 Type) (T3 Type) (x1 T1) (x2 T2) (x3 T3))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvite (bvite x1 x2 x3)) ($sm_ite ($sm_= ($eo_to_smt x1) ($sm_binary ($native_apply_0 "1") ($native_apply_0 "1"))) ($eo_to_smt x2) ($eo_to_smt x3)))
+  )
+)
+
+; -- bvuaddo
+(program $eoc_transform_bvuaddo
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvuaddo (bvuaddo x1 x2)) ($sm_bvuaddo ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvnego
+(program $eoc_transform_bvnego
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvnego (bvnego x1)) ($sm_bvnego ($eo_to_smt x1)))
+  )
+)
+
+; -- bvsaddo
+(program $eoc_transform_bvsaddo
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvsaddo (bvsaddo x1 x2)) ($sm_bvsaddo ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvumulo
+(program $eoc_transform_bvumulo
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvumulo (bvumulo x1 x2)) ($sm_bvumulo ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvsmulo
+(program $eoc_transform_bvsmulo
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvsmulo (bvsmulo x1 x2)) ($sm_bvsmulo ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvusubo
+(program $eoc_transform_bvusubo
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvusubo (bvusubo x1 x2)) ($sm_bvusubo ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvssubo
+(program $eoc_transform_bvssubo
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvssubo (bvssubo x1 x2)) ($sm_bvssubo ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvsdivo
+(program $eoc_transform_bvsdivo
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvsdivo (bvsdivo x1 x2)) ($sm_bvsdivo ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- bvultbv
+(program $eoc_transform_bvultbv
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvultbv (bvultbv x1 x2)) ($sm_ite ($sm_bvult ($eo_to_smt x1) ($eo_to_smt x2)) ($sm_binary ($native_apply_0 "1") ($native_apply_0 "1")) ($sm_binary ($native_apply_0 "1") ($native_apply_0 "0"))))
+  )
+)
+
+; -- bvsltbv
+(program $eoc_transform_bvsltbv
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvsltbv (bvsltbv x1 x2)) ($sm_ite ($sm_bvslt ($eo_to_smt x1) ($eo_to_smt x2)) ($sm_binary ($native_apply_0 "1") ($native_apply_0 "1")) ($sm_binary ($native_apply_0 "1") ($native_apply_0 "0"))))
+  )
+)
+
+; -- bvredand
+(program $eoc_transform_bvredand
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvredand (bvredand x1)) ($sm_bvcomp ($eo_to_smt x1) ($sm_bvnot ($emb_sm.Binary ($eo_to_smt_bv_size ($smtx_typeof ($eo_to_smt x1))) ($native_apply_0 "0")))))
+  )
+)
+
+; -- bvredor
+(program $eoc_transform_bvredor
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_bvredor (bvredor x1)) ($sm_bvnot ($sm_bvcomp ($eo_to_smt x1) ($emb_sm.Binary ($eo_to_smt_bv_size ($smtx_typeof ($eo_to_smt x1))) ($native_apply_0 "0")))))
+  )
+)
+
+; -- @bit
+(program $eoc_transform_@bit
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_@bit (@bit x1 x2)) ($sm_= ($sm_extract ($eo_to_smt x1) ($eo_to_smt x1) ($eo_to_smt x2)) ($sm_binary ($native_apply_0 "1") ($native_apply_0 "1"))))
+  )
+)
+
+; -- @from_bools
+(program $eoc_transform_@from_bools
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_@from_bools (@from_bools x1 x2)) ($sm_concat ($eo_to_smt x2) ($sm_ite ($eo_to_smt x1) ($sm_binary ($native_apply_0 "1") ($native_apply_0 "1")) ($sm_binary ($native_apply_0 "1") ($native_apply_0 "0")))))
+  )
+)
+
+; -- seq.empty
+(program $eo_to_smt_seq.empty ((T $smt_Type))
+  :signature ($smt_Type) $smt_Term
+  (
+  (($eo_to_smt_seq.empty ($tsm_Seq T)) ($sm_seq.empty T))
+  (($eo_to_smt_seq.empty T) $sm_none)
+  )
+)
+(program $eoc_transform_seq.empty
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_seq.empty (seq.empty x1)) ($eo_to_smt_seq.empty ($eo_to_smt_type x1)))
+  )
+)
+
+; -- str.len
+(program $eoc_transform_str.len
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_str.len (str.len x1)) ($sm_str.len ($eo_to_smt x1)))
+  )
+)
+
+; -- str.++
+(program $eoc_transform_str.++
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_str.++ (str.++ x1 x2)) ($sm_str.++ ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+(program $eoc_is_list_nil_str.++ ((T Type) (t T))
+  :signature (T) Bool
+  (
+  (($eoc_is_list_nil_str.++ (seq.empty T)) true)
+  (($eoc_is_list_nil_str.++ t) (eo::eq t ""))
+  )
+)
+
+; -- str.substr
+(program $eoc_transform_str.substr
+  ((T Type) (T1 Type) (T2 Type) (T3 Type) (x1 T1) (x2 T2) (x3 T3))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_str.substr (str.substr x1 x2 x3)) ($sm_str.substr ($eo_to_smt x1) ($eo_to_smt x2) ($eo_to_smt x3)))
+  )
+)
+
+; -- str.contains
+(program $eoc_transform_str.contains
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_str.contains (str.contains x1 x2)) ($sm_str.contains ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- str.replace
+(program $eoc_transform_str.replace
+  ((T Type) (T1 Type) (T2 Type) (T3 Type) (x1 T1) (x2 T2) (x3 T3))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_str.replace (str.replace x1 x2 x3)) ($sm_str.replace ($eo_to_smt x1) ($eo_to_smt x2) ($eo_to_smt x3)))
+  )
+)
+
+; -- str.indexof
+(program $eoc_transform_str.indexof
+  ((T Type) (T1 Type) (T2 Type) (T3 Type) (x1 T1) (x2 T2) (x3 T3))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_str.indexof (str.indexof x1 x2 x3)) ($sm_str.indexof ($eo_to_smt x1) ($eo_to_smt x2) ($eo_to_smt x3)))
+  )
+)
+
+; -- str.at
+(program $eoc_transform_str.at
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_str.at (str.at x1 x2)) ($sm_str.at ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- str.prefixof
+(program $eoc_transform_str.prefixof
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_str.prefixof (str.prefixof x1 x2)) ($sm_str.prefixof ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- str.suffixof
+(program $eoc_transform_str.suffixof
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_str.suffixof (str.suffixof x1 x2)) ($sm_str.suffixof ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- str.rev
+(program $eoc_transform_str.rev
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_str.rev (str.rev x1)) ($sm_str.rev ($eo_to_smt x1)))
+  )
+)
+
+; -- str.update
+(program $eoc_transform_str.update
+  ((T Type) (T1 Type) (T2 Type) (T3 Type) (x1 T1) (x2 T2) (x3 T3))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_str.update (str.update x1 x2 x3)) ($sm_str.update ($eo_to_smt x1) ($eo_to_smt x2) ($eo_to_smt x3)))
+  )
+)
+
+; -- str.to_lower
+(program $eoc_transform_str.to_lower
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_str.to_lower (str.to_lower x1)) ($sm_str.to_lower ($eo_to_smt x1)))
+  )
+)
+
+; -- str.to_upper
+(program $eoc_transform_str.to_upper
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_str.to_upper (str.to_upper x1)) ($sm_str.to_upper ($eo_to_smt x1)))
+  )
+)
+
+; -- str.to_code
+(program $eoc_transform_str.to_code
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_str.to_code (str.to_code x1)) ($sm_str.to_code ($eo_to_smt x1)))
+  )
+)
+
+; -- str.from_code
+(program $eoc_transform_str.from_code
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_str.from_code (str.from_code x1)) ($sm_str.from_code ($eo_to_smt x1)))
+  )
+)
+
+; -- str.is_digit
+(program $eoc_transform_str.is_digit
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_str.is_digit (str.is_digit x1)) ($sm_str.is_digit ($eo_to_smt x1)))
+  )
+)
+
+; -- str.to_int
+(program $eoc_transform_str.to_int
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_str.to_int (str.to_int x1)) ($sm_str.to_int ($eo_to_smt x1)))
+  )
+)
+
+; -- str.from_int
+(program $eoc_transform_str.from_int
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_str.from_int (str.from_int x1)) ($sm_str.from_int ($eo_to_smt x1)))
+  )
+)
+
+; -- str.<
+(program $eoc_transform_str.<
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_str.< (str.< x1 x2)) ($sm_str.< ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- str.<=
+(program $eoc_transform_str.<=
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_str.<= (str.<= x1 x2)) ($sm_str.<= ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- str.replace_all
+(program $eoc_transform_str.replace_all
+  ((T Type) (T1 Type) (T2 Type) (T3 Type) (x1 T1) (x2 T2) (x3 T3))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_str.replace_all (str.replace_all x1 x2 x3)) ($sm_str.replace_all ($eo_to_smt x1) ($eo_to_smt x2) ($eo_to_smt x3)))
+  )
+)
+
+; -- str.replace_re
+(program $eoc_transform_str.replace_re
+  ((T Type) (T1 Type) (T2 Type) (T3 Type) (x1 T1) (x2 T2) (x3 T3))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_str.replace_re (str.replace_re x1 x2 x3)) ($sm_str.replace_re ($eo_to_smt x1) ($eo_to_smt x2) ($eo_to_smt x3)))
+  )
+)
+
+; -- str.replace_re_all
+(program $eoc_transform_str.replace_re_all
+  ((T Type) (T1 Type) (T2 Type) (T3 Type) (x1 T1) (x2 T2) (x3 T3))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_str.replace_re_all (str.replace_re_all x1 x2 x3)) ($sm_str.replace_re_all ($eo_to_smt x1) ($eo_to_smt x2) ($eo_to_smt x3)))
+  )
+)
+
+; -- str.indexof_re
+(program $eoc_transform_str.indexof_re
+  ((T Type) (T1 Type) (T2 Type) (T3 Type) (x1 T1) (x2 T2) (x3 T3))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_str.indexof_re (str.indexof_re x1 x2 x3)) ($sm_str.indexof_re ($eo_to_smt x1) ($eo_to_smt x2) ($eo_to_smt x3)))
+  )
+)
+
+; -- re.allchar
+(program $eoc_transform_re.allchar
+  ((T Type))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_re.allchar re.allchar) $sm_re.allchar)
+  )
+)
+
+; -- re.none
+(program $eoc_transform_re.none
+  ((T Type))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_re.none re.none) $sm_re.none)
+  )
+)
+
+; -- re.all
+(program $eoc_transform_re.all
+  ((T Type))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_re.all re.all) $sm_re.all)
+  )
+)
+
+; -- str.to_re
+(program $eoc_transform_str.to_re
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_str.to_re (str.to_re x1)) ($sm_str.to_re ($eo_to_smt x1)))
+  )
+)
+
+; -- re.*
+(program $eoc_transform_re.*
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_re.* (re.* x1)) ($sm_re.* ($eo_to_smt x1)))
+  )
+)
+
+; -- re.+
+(program $eoc_transform_re.+
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_re.+ (re.+ x1)) ($sm_re.+ ($eo_to_smt x1)))
+  )
+)
+
+; -- re.^
+(program $eoc_transform_re.^
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_re.^ (re.^ x1 x2)) ($sm_re.^ ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- re.opt
+(program $eoc_transform_re.opt
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_re.opt (re.opt x1)) ($sm_re.opt ($eo_to_smt x1)))
+  )
+)
+
+; -- re.comp
+(program $eoc_transform_re.comp
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_re.comp (re.comp x1)) ($sm_re.comp ($eo_to_smt x1)))
+  )
+)
+
+; -- re.range
+(program $eoc_transform_re.range
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_re.range (re.range x1 x2)) ($sm_re.range ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- re.++
+(program $eoc_transform_re.++
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_re.++ (re.++ x1 x2)) ($sm_re.++ ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- re.inter
+(program $eoc_transform_re.inter
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_re.inter (re.inter x1 x2)) ($sm_re.inter ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- re.union
+(program $eoc_transform_re.union
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_re.union (re.union x1 x2)) ($sm_re.union ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- re.diff
+(program $eoc_transform_re.diff
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_re.diff (re.diff x1 x2)) ($sm_re.diff ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- re.loop
+(program $eoc_transform_re.loop
+  ((T Type) (T1 Type) (T2 Type) (T3 Type) (x1 T1) (x2 T2) (x3 T3))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_re.loop (re.loop x1 x2 x3)) ($sm_re.loop ($eo_to_smt x1) ($eo_to_smt x2) ($eo_to_smt x3)))
+  )
+)
+
+; -- str.in_re
+(program $eoc_transform_str.in_re
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_str.in_re (str.in_re x1 x2)) ($sm_str.in_re ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- str.indexof_re_split
+(program $eoc_transform_str.indexof_re_split
+  ((T Type) (T1 Type) (T2 Type) (T3 Type) (x1 T1) (x2 T2) (x3 T3))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_str.indexof_re_split (str.indexof_re_split x1 x2 x3)) ($sm_str.indexof_re_split ($eo_to_smt x1) ($eo_to_smt x2) ($eo_to_smt x3)))
+  )
+)
+
+; -- seq.unit
+(program $eoc_transform_seq.unit
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_seq.unit (seq.unit x1)) ($sm_seq.unit ($eo_to_smt x1)))
+  )
+)
+
+; -- seq.nth
+(program $eoc_transform_seq.nth
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_seq.nth (seq.nth x1 x2)) ($sm_seq.nth ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- $eo_to_smt_nat
+(program $eo_to_smt_nat_is_valid ((n $native_Int) (t $eo_Term))
+  :signature ($eo_Term) $native_Bool
+  (
+  (($eo_to_smt_nat_is_valid ($eot_numeral n)) ($native_z_<= $native_z_zero n))
+  (($eo_to_smt_nat_is_valid t) $native_false)
+  )
+)
+
+(program $eo_to_smt_nat ((n $native_Int) (t $eo_Term))
+  :signature ($eo_Term) $native_Nat
+  (
+  (($eo_to_smt_nat ($eot_numeral n)) ($native_z_to_n n))
+  (($eo_to_smt_nat t) $native_n_zero)
+  )
+)
+
+; -- @re_unfold_pos_component
+(program $eo_to_smt_re_unfold_pos_component ((_y2 $smt_Term) (_y3 ($native_datatype "Nat")) (n ($native_datatype "Nat")) (r1 $smt_Term) (r2 $smt_Term) (s $smt_Term))
+  :signature ($smt_Term $smt_Term ($native_datatype "Nat")) $smt_Term
+  (
+  (($eo_to_smt_re_unfold_pos_component s ($sm_re.++ r1 r2) ($native_apply_0 "nat.zero")) ($sm_str.substr s ($sm_numeral ($native_apply_0 "0")) ($sm_str.indexof_re_split s r1 r2)))
+  (($eo_to_smt_re_unfold_pos_component s ($sm_re.++ r1 r2) ($native_apply_1 "nat.succ" n)) ($eo_to_smt_re_unfold_pos_component ($sm_str.substr s ($sm_str.indexof_re_split s r1 r2) ($sm_- ($sm_str.len s) ($sm_str.indexof_re_split s r1 r2))) r2 n))
+  (($eo_to_smt_re_unfold_pos_component s _y2 _y3) $sm_none)
+  )
+)
+(program $eoc_transform_@re_unfold_pos_component
+  ((T Type) (T1 Type) (T2 Type) (T3 Type) (x1 T1) (x2 T2) (x3 T3))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_@re_unfold_pos_component (@re_unfold_pos_component x1 x2 x3)) ($native_ite ($eo_to_smt_nat_is_valid x3) ($eo_to_smt_re_unfold_pos_component ($eo_to_smt x1) ($eo_to_smt x2) ($eo_to_smt_nat x3)) $sm_none))
+  )
+)
+
+; -- @strings_deq_diff
+(program $eoc_transform_@strings_deq_diff
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_@strings_deq_diff (@strings_deq_diff x1 x2)) ($emb_sm.seq_diff ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- @strings_stoi_result
+(program $eoc_transform_@strings_stoi_result
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_@strings_stoi_result (@strings_stoi_result x1 x2)) ($sm_ite ($sm_= ($eo_to_smt x2) ($sm_numeral ($native_apply_0 "0"))) ($sm_numeral ($native_apply_0 "0")) ($sm_str.to_int ($sm_str.substr ($eo_to_smt x1) ($sm_numeral ($native_apply_0 "0")) ($eo_to_smt x2)))))
+  )
+)
+
+; -- @strings_stoi_non_digit
+(program $eoc_transform_@strings_stoi_non_digit
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_@strings_stoi_non_digit (@strings_stoi_non_digit x1)) ($sm_str.indexof_re ($eo_to_smt x1) ($sm_re.inter $sm_re.allchar ($sm_re.comp ($sm_re.range ($sm_string ($native_apply_0 """0""")) ($sm_string ($native_apply_0 """9"""))))) ($sm_numeral ($native_apply_0 "0"))))
+  )
+)
+
+; -- @strings_itos_result
+(program $eoc_transform_@strings_itos_result
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_@strings_itos_result (@strings_itos_result x1 x2)) ($sm_ite ($sm_= ($eo_to_smt x2) ($sm_numeral ($native_apply_0 "0"))) ($sm_numeral ($native_apply_0 "0")) ($sm_str.to_int ($sm_str.substr ($sm_str.from_int ($eo_to_smt x1)) ($sm_numeral ($native_apply_0 "0")) ($eo_to_smt x2)))))
+  )
+)
+
+; -- @strings_num_occur
+(program $eoc_transform_@strings_num_occur
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_@strings_num_occur (@strings_num_occur x1 x2)) ($sm_- ($sm_str.len ($sm_str.replace_all ($eo_to_smt x1) ($eo_to_smt x2) ($sm_str.substr ($eo_to_smt x1) ($sm_numeral ($native_apply_0 "0")) ($sm_numeral ($native_apply_0 "1"))))) ($sm_str.len ($sm_str.replace_all ($eo_to_smt x1) ($eo_to_smt x2) ($sm_str.substr ($eo_to_smt x1) ($sm_numeral ($native_apply_0 "0")) ($sm_numeral ($native_apply_0 "0")))))))
+  )
+)
+
+; -- @strings_num_occur_re
+(program $eoc_transform_@strings_num_occur_re
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_@strings_num_occur_re (@strings_num_occur_re x1 x2)) ($sm_- ($sm_str.len ($sm_str.replace_re_all ($eo_to_smt x1) ($eo_to_smt x2) ($sm_str.substr ($eo_to_smt x1) ($sm_numeral ($native_apply_0 "0")) ($sm_numeral ($native_apply_0 "1"))))) ($sm_str.len ($sm_str.replace_re_all ($eo_to_smt x1) ($eo_to_smt x2) ($sm_str.substr ($eo_to_smt x1) ($sm_numeral ($native_apply_0 "0")) ($sm_numeral ($native_apply_0 "0")))))))
+  )
+)
+
+; -- @strings_occur_index
+(program $eoc_transform_@strings_occur_index
+  ((T Type) (T1 Type) (T2 Type) (T3 Type) (x1 T1) (x2 T2) (x3 T3))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_@strings_occur_index (@strings_occur_index x1 x2 x3)) ($sm_@strings_occur_index ($eo_to_smt x1) ($eo_to_smt x2) ($eo_to_smt x3)))
+  )
+)
+
+; -- @strings_occur_index_re
+(program $eoc_transform_@strings_occur_index_re
+  ((T Type) (T1 Type) (T2 Type) (T3 Type) (x1 T1) (x2 T2) (x3 T3))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_@strings_occur_index_re (@strings_occur_index_re x1 x2 x3)) ($sm_@strings_occur_index_re ($eo_to_smt x1) ($eo_to_smt x2) ($eo_to_smt x3)))
+  )
+)
+
+; -- @strings_replace_all_result
+(program $eoc_transform_@strings_replace_all_result
+  ((T Type) (T1 Type) (T2 Type) (T3 Type) (T4 Type) (x1 T1) (x2 T2) (x3 T3) (x4 T4))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_@strings_replace_all_result (@strings_replace_all_result x1 x2 x3 x4)) ($sm_str.replace_all ($sm_str.substr ($eo_to_smt x1) ($sm_@strings_occur_index ($eo_to_smt x1) ($eo_to_smt x2) ($eo_to_smt x4)) ($sm_str.len ($eo_to_smt x1))) ($eo_to_smt x2) ($eo_to_smt x3)))
+  )
+)
+
+; -- @strings_replace_re_all_result
+(program $eoc_transform_@strings_replace_re_all_result
+  ((T Type) (T1 Type) (T2 Type) (T3 Type) (T4 Type) (x1 T1) (x2 T2) (x3 T3) (x4 T4))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_@strings_replace_re_all_result (@strings_replace_re_all_result x1 x2 x3 x4)) ($sm_str.replace_re_all ($sm_str.substr ($eo_to_smt x1) ($sm_@strings_occur_index_re ($eo_to_smt x1) ($eo_to_smt x2) ($eo_to_smt x4)) ($sm_str.len ($eo_to_smt x1))) ($eo_to_smt x2) ($eo_to_smt x3)))
+  )
+)
+
+; -- @witness_string_length
+(program $eoc_transform_@witness_string_length
+  ((T Type) (T1 Type) (T2 Type) (T3 Type) (x1 T1) (x2 T2) (x3 T3))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_@witness_string_length (@witness_string_length x1 x2 x3)) ($native_ite ($eo_to_smt_nat_is_valid x2) ($native_ite ($eo_to_smt_nat_is_valid x3) (eo::define (($T ($eo_to_smt_type x1))) (eo::define (($i ($sm_Var $native_str_vname $T))) ($sm_choice $native_str_vname $T ($sm_= ($sm_str.len $i) ($eo_to_smt x2))))) $sm_none) $sm_none))
+  )
+)
+
+; -- is
+; In eo_to_smt, (is x1) returns ($eo_to_smt_tester ($eo_to_smt x1)).
+(program $eo_to_smt_tester
+  ((s $native_String) (dd $smt_DatatypeDecl) (n $native_Nat) (t $smt_Term))
+  :signature ($smt_Term) $smt_Term
+  (
+  (($eo_to_smt_tester ($sm_DtCons s dd n))  ($sm_DtTester s dd n))
+  (($eo_to_smt_tester t)                   $sm_none)
+  )
+)
+
+(program $eoc_transform_is
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_is (is x1 x2)) ($emb_sm.Apply ($eo_to_smt_tester ($eo_to_smt x1)) ($eo_to_smt x2)))
+  )
+)
+
+; -- update
+; ($eo_to_smt_updater_rec s mn k t u acc)
+; returns the constructor app that is equivalent to u
+; but where the selector s field is updated to t.
+(program $eo_to_smt_updater_rec
+  ((s $native_String) (dd $smt_DatatypeDecl) (n $native_Nat) (m $native_Nat)
+   (k $native_Nat) (t $smt_Term) (u $smt_Term) (acc $smt_Term) (v $smt_Term))
+  :signature ($smt_Term $native_Nat $smt_Term $smt_Term $smt_Term) $smt_Term
+  (
+  (($eo_to_smt_updater_rec ($sm_DtSel s dd n m) $native_n_zero t u acc) acc)
+  (($eo_to_smt_updater_rec ($sm_DtSel s dd n m) ($native_n_succ k) t u acc)
+    (eo::define ((arg ($native_ite ($native_n_= m k) u ($sm_apply ($sm_DtSel s dd n k) t))))
+      ($sm_apply ($eo_to_smt_updater_rec ($sm_DtSel s dd n m) k t u acc) arg)))
+  (($eo_to_smt_updater_rec v k t u acc) $sm_none)
+  )
+)
+
+; (update x1 x2 x3) returns
+;   ($eo_to_smt_updater ($eo_to_smt x1) ($eo_to_smt x2) ($eo_to_smt_x3))
+(program $eo_to_smt_updater
+  ((s $native_String) (dd $smt_DatatypeDecl)
+   (n $native_Nat) (m $native_Nat) (sel $smt_Term) (t $smt_Term) (u $smt_Term))
+  :signature ($smt_Term $smt_Term $smt_Term) $smt_Term
+  (
+  (($eo_to_smt_updater ($sm_DtSel s dd n m) t u)
+    (eo::define ((nargs ($smtx_dt_num_sels ($smtx_dd_lookup s dd) n)))
+    ($native_ite ($native_z_< ($native_n_to_z m) ($native_n_to_z nargs))
+      ($sm_ite ($sm_apply ($sm_DtTester s dd n) t)
+        ($eo_to_smt_updater_rec ($sm_DtSel s dd n m) nargs t u ($sm_DtCons s dd n))
+        t)
+      $sm_none)))
+  (($eo_to_smt_updater sel t u)                     $sm_none)
+  )
+)
+
+(program $eoc_transform_update
+  ((T Type) (T1 Type) (T2 Type) (T3 Type) (x1 T1) (x2 T2) (x3 T3))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_update (update x1 x2 x3)) ($eo_to_smt_updater ($eo_to_smt x1) ($eo_to_smt x2) ($eo_to_smt x3)))
+  )
+)
+
+; -- tuple.unit
+(program $eoc_transform_tuple.unit
+  ((T Type))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_tuple.unit tuple.unit) ($emb_sm.DtCons ($native_apply_0 """@Tuple""") ($emb_dd.cons ($native_apply_0 """@Tuple""") ($emb_dt.sum $emb_dtc.unit $emb_dt.null) $emb_dd.nil) ($native_apply_0 "nat.zero")))
+  )
+)
+
+; -- $eo_to_smt_tuple_decl
+; The declaration a tuple type is of. SMT-LIB has no tuples, so there is no
+; symbol of the target for this: the type is modelled as a datatype whose
+; declaration holds one datatype under the conventional name, which is what
+; this builds from the datatype the fields give. See the blocks for tuple and
+; for Tuple, whose $eo_to_smt_type_tuple reads a declaration back apart.
+(program $eo_to_smt_tuple_decl
+  ((d $smt_Datatype))
+  :signature ($smt_Datatype) $smt_DatatypeDecl
+  (
+  (($eo_to_smt_tuple_decl d) ($dd_cons $native_str_tuple_name d $dd_nil))
+  )
+)
+
+; -- tuple
+; helper for CPC tuple constructor
+; Given an application of (tuple a1 a2), returns the same application
+; but where now tuple is the instance of the tuple constructor that expects
+; another argument of type T.
+(program $eo_to_smt_tuple_prepend_rec
+  ((dd $smt_DatatypeDecl) (d $smt_Datatype) (tail $smt_Term) (n $native_Nat)
+   (acc $smt_Term))
+  :signature ($smt_DatatypeDecl $smt_Datatype $smt_Term $native_Nat $smt_Term) $smt_Term
+  (
+  (($eo_to_smt_tuple_prepend_rec dd d tail $native_n_zero acc) acc)
+  (($eo_to_smt_tuple_prepend_rec dd d tail ($native_n_succ n) acc)
+    ($sm_apply
+      ($eo_to_smt_tuple_prepend_rec dd d tail n acc)
+      ($sm_apply
+        ($sm_DtSel $native_str_tuple_name dd $native_n_zero n) tail)))
+  )
+)
+
+(program $eo_to_smt_tuple_prepend_of_type
+  ((T $smt_Type) (h $smt_Term) (hT $smt_Type) (tail $smt_Term) 
+   (c $smt_DatatypeCons) (s $native_String) (s2 $native_String))
+  :signature ($smt_Type $smt_Term $smt_Type $smt_Term) $smt_Term
+  (
+  (($eo_to_smt_tuple_prepend_of_type 
+    ($tsm_Datatype s ($dd_cons s2 ($dt_sum c $dt_null) $dd_nil)) h hT tail)
+      (eo::define ((d ($dt_sum c $dt_null)))
+      (eo::define ((d2 ($dt_sum ($dtc_cons hT c) $dt_null)))
+      (eo::define ((dd ($eo_to_smt_tuple_decl d)))
+      (eo::define ((dd2 ($eo_to_smt_tuple_decl d2)))
+      ($native_ite
+        ($native_and
+          ($native_and
+            ($native_str_= s $native_str_tuple_name)
+            ($native_str_= s2 $native_str_tuple_name))
+          ($smtx_type_wf ($tsm_Datatype $native_str_tuple_name dd2)))
+        ($eo_to_smt_tuple_prepend_rec dd d tail ($smtx_dt_num_sels d $native_n_zero)
+          ($sm_apply ($sm_DtCons $native_str_tuple_name dd2 $native_n_zero) h))
+        $sm_none))))))
+  (($eo_to_smt_tuple_prepend_of_type T h hT tail) $sm_none)
+  )
+)
+
+(program $eo_to_smt_tuple_prepend
+  ((h $smt_Term) (hT $smt_Type) (tail $smt_Term) (c $smt_DatatypeCons))
+  :signature ($smt_Term $smt_Type $smt_Term) $smt_Term
+  (
+  (($eo_to_smt_tuple_prepend h hT tail)
+    ($eo_to_smt_tuple_prepend_of_type ($smtx_typeof tail) h hT tail))
+  )
+)
+
+(program $eoc_transform_tuple
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_tuple (tuple x1 x2)) ($eo_to_smt_tuple_prepend ($eo_to_smt x1) ($smtx_typeof ($eo_to_smt x1)) ($eo_to_smt x2)))
+  )
+)
+
+; -- tuple.select
+; In eo_to_smt, (tuple.select x1 x2) returns
+;   ($eo_to_smt_tuple_select ($eo_to_smt_type ($eo_typeof x2)) ($eo_to_smt x1) ($eo_to_smt x2))
+(program $eo_to_smt_tuple_select
+  ((T $smt_Type) (s $native_String) (s2 $native_String) (d $smt_Datatype)
+   (n $native_Int) (t $smt_Term))
+  :signature ($smt_Type $smt_Term $smt_Term) $smt_Term
+  (
+  (($eo_to_smt_tuple_select ($tsm_Datatype s ($dd_cons s2 d $dd_nil)) ($sm_numeral n) t)
+    ($native_ite 
+      ($native_and
+        ($native_and
+          ($native_str_= s $native_str_tuple_name)
+          ($native_str_= s2 $native_str_tuple_name))
+        ($native_z_<= $native_z_zero n))
+      ($sm_apply
+        ($sm_DtSel $native_str_tuple_name ($eo_to_smt_tuple_decl d) $native_n_zero ($native_z_to_n n))
+        t)
+      $sm_none))
+  (($eo_to_smt_tuple_select T n t)                    $sm_none)
+  )
+)
+
+(program $eoc_transform_tuple.select
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_tuple.select (tuple.select x1 x2)) ($eo_to_smt_tuple_select ($smtx_typeof ($eo_to_smt x2)) ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- tuple.update
+; In eo_to_smt, (tuple.update x1 x2) returns
+;   ($eo_to_smt_tuple_update
+;     ($eo_to_smt_type ($eo_typeof x2)) ($eo_to_smt x1) ($eo_to_smt x2) ($eo_to_smt x3))
+(program $eo_to_smt_tuple_update
+  ((T $smt_Type) (d $smt_Datatype) (n $native_Int) (t $smt_Term) (u $smt_Term)
+   (s $native_String) (s2 $native_String))
+  :signature ($smt_Type $smt_Term $smt_Term $smt_Term) $smt_Term
+  (
+  (($eo_to_smt_tuple_update ($tsm_Datatype s ($dd_cons s2 d $dd_nil)) ($sm_numeral n) t u)
+    ($native_ite 
+      ($native_and
+        ($native_and
+          ($native_str_= s $native_str_tuple_name)
+          ($native_str_= s2 $native_str_tuple_name))
+        ($native_z_<= $native_z_zero n))
+      ($eo_to_smt_updater
+        ($sm_DtSel $native_str_tuple_name ($eo_to_smt_tuple_decl d) $native_n_zero ($native_z_to_n n))
+        t
+        u)
+      $sm_none))
+  (($eo_to_smt_tuple_update T n t u)                    $sm_none)
+  )
+)
+
+(program $eoc_transform_tuple.update
+  ((T Type) (T1 Type) (T2 Type) (T3 Type) (x1 T1) (x2 T2) (x3 T3))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_tuple.update (tuple.update x1 x2 x3)) ($eo_to_smt_tuple_update ($smtx_typeof ($eo_to_smt x2)) ($eo_to_smt x1) ($eo_to_smt x2) ($eo_to_smt x3)))
+  )
+)
+
+; -- set.empty
+(program $eo_to_smt_set.empty ((T $smt_Type))
+  :signature ($smt_Type) $smt_Term
+  (
+  (($eo_to_smt_set.empty ($tsm_Set T)) ($sm_set.empty T))
+  (($eo_to_smt_set.empty T) $sm_none)
+  )
+)
+(program $eoc_transform_set.empty
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_set.empty (set.empty x1)) ($eo_to_smt_set.empty ($eo_to_smt_type x1)))
+  )
+)
+
+; -- set.singleton
+(program $eoc_transform_set.singleton
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_set.singleton (set.singleton x1)) ($sm_set.singleton ($eo_to_smt x1)))
+  )
+)
+
+; -- set.union
+(program $eoc_transform_set.union
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_set.union (set.union x1 x2)) ($sm_set.union ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- set.inter
+(program $eoc_transform_set.inter
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_set.inter (set.inter x1 x2)) ($sm_set.inter ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- set.minus
+(program $eoc_transform_set.minus
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_set.minus (set.minus x1 x2)) ($sm_set.minus ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- set.member
+(program $eoc_transform_set.member
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_set.member (set.member x1 x2)) ($sm_set.member ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- set.subset
+(program $eoc_transform_set.subset
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_set.subset (set.subset x1 x2)) ($sm_set.subset ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- $eo_to_smt_set_elem_type
+(program $eo_to_smt_set_elem_type ((T $smt_Type))
+  :signature ($smt_Type) $smt_Type
+  (
+  (($eo_to_smt_set_elem_type ($tsm_Set T)) T)
+  (($eo_to_smt_set_elem_type T) $tsm_none)
+  )
+)
+
+; -- set.choose
+(program $eoc_transform_set.choose
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_set.choose (set.choose x1)) (eo::define ((T ($eo_to_smt_set_elem_type ($smtx_typeof ($eo_to_smt x1))))) ($sm_map_diff ($eo_to_smt x1) ($sm_set.empty T))))
+  )
+)
+
+; -- set.is_empty
+(program $eoc_transform_set.is_empty
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_set.is_empty (set.is_empty x1)) ($sm_= ($eo_to_smt x1) ($sm_set.empty ($eo_to_smt_set_elem_type ($smtx_typeof ($eo_to_smt x1))))))
+  )
+)
+
+; -- set.is_singleton
+(program $eoc_transform_set.is_singleton
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_set.is_singleton (set.is_singleton x1)) ($sm_= ($eo_to_smt x1) ($sm_set.singleton (eo::define ((T ($eo_to_smt_set_elem_type ($smtx_typeof ($eo_to_smt x1))))) ($sm_map_diff ($eo_to_smt x1) ($sm_set.empty T))))))
+  )
+)
+
+; -- set.insert
+(program $eo_to_smt_set.insert ((T Type) (t1 T) (t2 $eo_List) (t3 $smt_Term))
+  :signature ($eo_List $smt_Term) $smt_Term
+  (
+  (($eo_to_smt_set.insert (@@TypedList.cons t1 t2) t3)
+    ($sm_set.union ($sm_set.singleton ($eo_to_smt t1)) ($eo_to_smt_set.insert t2 t3)))
+  (($eo_to_smt_set.insert (@@TypedList.nil T) t3) ($native_ite ($native_Teq ($smtx_typeof t3) ($tsm_Set ($eo_to_smt_type T))) t3 $sm_none))
+  (($eo_to_smt_set.insert t2 t3) $sm_none)
+  )
+)
+(program $eoc_transform_set.insert
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_set.insert (set.insert x1 x2)) ($eo_to_smt_set.insert x1 ($eo_to_smt x2)))
+  )
+)
+
+; -- @sets_deq_diff
+(program $eo_to_smt_sets_deq_diff 
+  ((a $smt_Term) (aT $smt_Type) (b $smt_Term) (bT $smt_Type))
+  :signature ($smt_Term $smt_Type $smt_Term $smt_Type) $smt_Term
+  (
+  (($eo_to_smt_sets_deq_diff a ($tsm_Set aT) b ($tsm_Set bT)) ($sm_map_diff a b))
+  (($eo_to_smt_sets_deq_diff a aT b bT) $sm_none)
+  )
+)
+(program $eoc_transform_@sets_deq_diff
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_@sets_deq_diff (@sets_deq_diff x1 x2)) ($eo_to_smt_sets_deq_diff ($eo_to_smt x1) ($smtx_typeof ($eo_to_smt x1)) ($eo_to_smt x2) ($smtx_typeof ($eo_to_smt x2))))
+  )
+)
+
+; -- /
+(program $eoc_transform_/
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_/ (/ x1 x2)) ($sm_/ ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- /_total
+(program $eoc_transform_/_total
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_/_total (/_total x1 x2)) ($sm_/_total ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- @div_by_zero
+(program $eoc_transform_@div_by_zero
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_@div_by_zero (@div_by_zero x1)) ($sm_/ ($eo_to_smt x1) ($sm_rational ($native_z_/_total ($native_apply_0 "0") ($native_apply_0 "1")))))
+  )
+)
+
+; -- $eo_to_smt_exists
+(program $eo_to_smt_exists
+  ((s $native_String) (T $eo_Term) (vs $eo_List) (F $eo_Term))
+  :signature ($eo_List $smt_Term) $smt_Term
+  (
+  (($eo_to_smt_exists $eo_List_nil F) F)
+  (($eo_to_smt_exists ($eo_List_cons ($eot_Var ($eot_string s) T) vs) F)
+    ($sm_exists s ($eo_to_smt_type T) ($eo_to_smt_exists vs F)))
+  (($eo_to_smt_exists vs F) $sm_none)
+  )
+)
+
+; -- forall
+(program $eoc_transform_forall
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_forall (forall $eo_List_nil x1)) $sm_none)
+  (($eoc_transform_forall (forall x1 x2)) ($sm_not ($eo_to_smt_exists x1 ($sm_not ($eo_to_smt x2)))))
+  )
+)
+
+; -- exists
+(program $eoc_transform_exists
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_exists (exists $eo_List_nil x1)) $sm_none)
+  (($eoc_transform_exists (exists x1 x2)) ($eo_to_smt_exists x1 ($eo_to_smt x2)))
+  )
+)
+
+; -- @quantifiers_skolemize
+(program $eo_to_smt_quantifiers_skolemize
+  ((s $native_String) (T $eo_Term) (vs $eo_List) (F $smt_Term) (G $smt_Term) (n $native_Nat) (t $smt_Term))
+  :signature ($eo_List $smt_Term $native_Nat) $smt_Term
+  (
+  (($eo_to_smt_quantifiers_skolemize ($eo_List_cons ($eot_Var ($eot_string s) T) vs) G $native_n_zero)
+    ($sm_choice s ($eo_to_smt_type T) ($eo_to_smt_exists vs G)))
+  (($eo_to_smt_quantifiers_skolemize ($eo_List_cons ($eot_Var ($eot_string s) T) vs) G ($native_n_succ n))
+    ($eo_to_smt_quantifiers_skolemize vs
+      ($sm_bind s ($eo_to_smt_type T) ($sm_choice s ($eo_to_smt_type T) ($eo_to_smt_exists vs G)) G) n))
+  (($eo_to_smt_quantifiers_skolemize vs G t) $sm_none)
+  )
+)
+(program $eoc_transform_@quantifiers_skolemize
+  ((T Type) (T1 Type) (T2 Type) (T3 Type) (x1 T1) (x2 T2) (x3 T3))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_@quantifiers_skolemize (@quantifiers_skolemize (forall x1 x2) x3)) ($native_ite ($eo_to_smt_nat_is_valid x3) ($eo_to_smt_quantifiers_skolemize x1 ($sm_not ($eo_to_smt x2))($eo_to_smt_nat x3)) $sm_none))
+  )
+)
+
+; -- int_to_bv
+(program $eoc_transform_int_to_bv
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_int_to_bv (int_to_bv x1 x2)) ($sm_int_to_bv ($eo_to_smt x1) ($eo_to_smt x2)))
+  )
+)
+
+; -- ubv_to_int
+(program $eoc_transform_ubv_to_int
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_ubv_to_int (ubv_to_int x1)) ($sm_ubv_to_int ($eo_to_smt x1)))
+  )
+)
+
+; -- sbv_to_int
+(program $eoc_transform_sbv_to_int
+  ((T Type) (T1 Type) (x1 T1))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_sbv_to_int (sbv_to_int x1)) ($sm_sbv_to_int ($eo_to_smt x1)))
+  )
+)
+
+; -- @const
+(program $eoc_transform_@const
+  ((T Type) (T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (T) $smt_Term
+  (
+  (($eoc_transform_@const (@const x1 x2)) ($native_ite ($eo_to_smt_nat_is_valid x1) ($sm_UConst ($native_to_const_id ($eo_to_smt_nat x1)) ($eo_to_smt_type x2)) $sm_none))
+  )
+)
+
+
+
+; -- Bool
+(program $eoc_transform_type_Bool
+  ()
+  :signature (Type) $smt_Type
+  (
+  (($eoc_transform_type_Bool Bool)                     $tsm_Bool)
+  )
+)
+
+; -- Int
+(program $eoc_transform_type_Int
+  ()
+  :signature (Type) $smt_Type
+  (
+  (($eoc_transform_type_Int Int) $tsm_Int)
+  )
+)
+
+; -- Real
+(program $eoc_transform_type_Real
+  ()
+  :signature (Type) $smt_Type
+  (
+  (($eoc_transform_type_Real Real) $tsm_Real)
+  )
+)
+
+; -- Char
+(program $eoc_transform_type_Char
+  ()
+  :signature (Type) $smt_Type
+  (
+  (($eoc_transform_type_Char Char) $tsm_Char)
+  )
+)
+
+; -- RegLan
+(program $eoc_transform_type_RegLan
+  ()
+  :signature (Type) $smt_Type
+  (
+  (($eoc_transform_type_RegLan RegLan) $tsm_RegLan)
+  )
+)
+
+; -- BitVec
+(program $eoc_transform_type_BitVec
+  ((n1 $native_Int))
+  :signature (Type) $smt_Type
+  (
+  (($eoc_transform_type_BitVec (BitVec ($eot_numeral n1))) ($native_ite ($native_z_<= $native_z_zero n1) ($tsm_BitVec ($native_z_to_n n1)) $tsm_none))
+  )
+)
+
+; -- Seq
+(program $eoc_transform_type_Seq
+  ((T1 Type) (x1 T1))
+  :signature (Type) $smt_Type
+  (
+  (($eoc_transform_type_Seq (Seq x1)) ($smtx_typeof_guard ($eo_to_smt_type x1) ($tsm_Seq ($eo_to_smt_type x1))))
+  )
+)
+
+; -- Set
+(program $eoc_transform_type_Set
+  ((T1 Type) (x1 T1))
+  :signature (Type) $smt_Type
+  (
+  (($eoc_transform_type_Set (Set x1)) ($smtx_typeof_guard ($eo_to_smt_type x1) ($tsm_Set ($eo_to_smt_type x1))))
+  )
+)
+
+; -- Array
+(program $eoc_transform_type_Array
+  ((T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (Type) $smt_Type
+  (
+  (($eoc_transform_type_Array (Array x1 x2)) ($smtx_typeof_guard ($eo_to_smt_type x1) ($smtx_typeof_guard ($eo_to_smt_type x2) ($tsm_Array ($eo_to_smt_type x1) ($eo_to_smt_type x2)))))
+  )
+)
+
+; -- UnitTuple
+(program $eoc_transform_type_UnitTuple
+  ()
+  :signature (Type) $smt_Type
+  (
+  (($eoc_transform_type_UnitTuple UnitTuple) ($emb_tsm.Datatype ($native_apply_0 """@Tuple""") ($emb_dd.cons ($native_apply_0 """@Tuple""") ($emb_dt.sum $emb_dtc.unit $emb_dt.null) $emb_dd.nil)))
+  )
+)
+
+; -- Tuple
+(program $eo_to_smt_type_tuple
+  ((U $smt_Type) (T $smt_Type) (s $native_String) (s2 $native_String)
+   (c $smt_DatatypeCons))
+  :signature ($smt_Type $smt_Type) $smt_Type
+  (
+  (($eo_to_smt_type_tuple U ($tsm_Datatype s ($dd_cons s2 ($dt_sum c $dt_null) $dd_nil)))
+    (eo::define ((d ($dt_sum ($dtc_cons U c) $dt_null)))
+      ($native_ite
+        ($native_and
+          ($native_and
+            ($native_str_= s $native_str_tuple_name)
+            ($native_str_= s2 $native_str_tuple_name))
+          ($smtx_type_wf_component U))
+        ($tsm_Datatype $native_str_tuple_name ($eo_to_smt_tuple_decl d))
+        $tsm_none)))
+  (($eo_to_smt_type_tuple U T) $tsm_none)
+  )
+)
+
+(program $eoc_transform_type_Tuple
+  ((T1 Type) (T2 Type) (x1 T1) (x2 T2))
+  :signature (Type) $smt_Type
+  (
+  (($eoc_transform_type_Tuple (Tuple x1 x2)) ($native_apply_3 "ite" ($smtx_type_wf ($eo_to_smt_type_tuple ($eo_to_smt_type x1) ($eo_to_smt_type x2))) ($eo_to_smt_type_tuple ($eo_to_smt_type x1) ($eo_to_smt_type x2)) $emb_tsm.None))
+  )
+)
+
+
+; The desugar stage gathers an n-ary application into a list, and to do so it
+; has to know which term is the *nil* of the operator, i.e. the unit it may
+; drop. Deciding that from the term alone is not possible in general: whether 0
+; is the nil of + depends on whether the application is over Int or Real, and
+; whether a bit-vector is the nil of bvand depends on how wide it is.
+;
+; Asking for the type would make every list operator depend on $eo_typeof,
+; which is what this avoids: instead each n-ary symbol carries a predicate of
+; its own, $eoc_is_list_nil_X, which the stage calls on the term. It is a
+; workaround rather than a definition, and it is written here, beside the
+; symbol it belongs to, rather than being hardcoded in the compiler.
+;
+; Note the program is written $eoc_ and emitted $eo_, since the desugar stage
+; calls it by name rather than splicing its cases into an aggregate.
+
+; -- @@TypedList.cons
+(program $eoc_is_list_nil_@@TypedList.cons ((T Type))
+  :signature (T) Bool
+  (
+  (($eoc_is_list_nil_@@TypedList.cons (@@TypedList.nil T)) true)
+  )
+)
+
+; -- lambda
+; The proof-level binder of CPC, together with the methods and the rule that
+; reduce an application of one. SMT-LIB gives these no meaning at all, so
+; instead of a model this block says they are left out of the compilation
+; altogether: the desugar stage drops what an eoc-exclude directive names, and
+; a symbol that never reaches the model-smt stage needs no case below. See
+; Desugar::echo for the directives and Pipeline.defs_excludes in
+; tools/eoc/driver.py for how they are taken from this file.
+;
+; Note the list is literal, since no dependency closure is computed: what a
+; dropped declaration would leave behind has to be named here as well, which
+; is what the methods and the rule are.
+(echo "eoc-exclude symbol lambda")
+(echo "eoc-exclude method $get_lambda_type")
+(echo "eoc-exclude method $beta_reduce_type")
+(echo "eoc-exclude method $beta_reduce")
+(echo "eoc-exclude rule beta-reduce")

--- a/plugins/model_smt/cpc_defs.eo
+++ b/plugins/model_smt/cpc_defs.eo
@@ -2,7 +2,7 @@
 ; embedding.
 ;
 ; This is what the model-smt stage compiles the CPC half of a model from. For
-; each of the 180 symbols it covers it gives one thing:
+; each of the 181 symbols it covers it gives one thing:
 ;
 ;   $eoc_transform_X       the cases X contributes to $eo_to_smt, i.e.
 ;                            T -> $smt_Term for a Eunoia term of any type T;

--- a/plugins/model_smt/defs_reader.cpp
+++ b/plugins/model_smt/defs_reader.cpp
@@ -1,9 +1,18 @@
+/******************************************************************************
+ * This file is part of the ethos project.
+ *
+ * Copyright (c) 2023-2024 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ ******************************************************************************/
+
 #include "defs_reader.h"
 
+#include <cctype>
 #include <fstream>
+#include <functional>
 #include <sstream>
-
-#include "base/check.h"
 
 namespace ethos {
 
@@ -118,7 +127,12 @@ std::string formKind(const std::string& form)
   return form.substr(1, j - 1);
 }
 
-/** Every name form uses, i.e. every word of it that begins with a dollar. */
+/**
+ * Every dollar-prefixed word form uses. This deliberately over-approximates
+ * dependencies: bound parameters such as $T are included as uses as well.
+ * They normally have no owner and are therefore harmless; keeping them avoids
+ * duplicating the parser's binding logic in this text-only reader.
+ */
 void namesOf(const std::string& form, std::set<std::string>& out)
 {
   for (size_t i = 0, n = form.size(); i < n; i++)
@@ -172,9 +186,10 @@ std::vector<std::string> casesOf(const std::string& prog,
   {
     std::string cs = c;
     size_t p = cs.find(name);
-    if (p != std::string::npos)
+    while (p != std::string::npos)
     {
-      cs = cs.substr(0, p) + agg + cs.substr(p + name.size());
+      cs.replace(p, name.size(), agg);
+      p = cs.find(name, p + agg.size());
     }
     ret.push_back(cs);
   }
@@ -250,19 +265,24 @@ void DefsFile::addBlock(const std::string& sym, const std::string& text)
     }
     else if (isPre("$eoc_eval_"))
     {
-      b.d_evalCases = casesOf(f, name, "$smtx_model_eval");
+      std::vector<std::string> cases = casesOf(f, name, "$smtx_model_eval");
+      b.d_evalCases.insert(b.d_evalCases.end(), cases.begin(), cases.end());
     }
     else if (isPre("$eoc_typeof_"))
     {
-      b.d_typeofCases = casesOf(f, name, "$smtx_typeof");
+      std::vector<std::string> cases = casesOf(f, name, "$smtx_typeof");
+      b.d_typeofCases.insert(b.d_typeofCases.end(), cases.begin(), cases.end());
     }
     else if (isPre("$eoc_transform_type_"))
     {
-      b.d_transTypeCases = casesOf(f, name, "$eo_to_smt_type");
+      std::vector<std::string> cases = casesOf(f, name, "$eo_to_smt_type");
+      b.d_transTypeCases.insert(
+          b.d_transTypeCases.end(), cases.begin(), cases.end());
     }
     else if (isPre("$eoc_transform_"))
     {
-      b.d_transCases = casesOf(f, name, "$eo_to_smt");
+      std::vector<std::string> cases = casesOf(f, name, "$eo_to_smt");
+      b.d_transCases.insert(b.d_transCases.end(), cases.begin(), cases.end());
     }
     else if (isPre("$smtx_typeof_"))
     {
@@ -302,6 +322,8 @@ void DefsFile::addBlock(const std::string& sym, const std::string& text)
 
 bool DefsFile::read(const std::string& path)
 {
+  d_blocks.clear();
+  d_owner.clear();
   std::ifstream in(path);
   if (!in.is_open())
   {
@@ -309,7 +331,12 @@ bool DefsFile::read(const std::string& path)
   }
   std::stringstream ss;
   ss << in.rdbuf();
-  const std::string text = ss.str();
+  if (in.bad())
+  {
+    return false;
+  }
+  // Prepending a newline lets the same marker recognize a block on line one.
+  const std::string text = "\n" + ss.str();
   // A block runs from the line that names its symbol to the next one.
   const std::string mark = "\n; -- ";
   size_t i = text.find(mark);
@@ -317,26 +344,18 @@ bool DefsFile::read(const std::string& path)
   {
     size_t ns = i + mark.size();
     size_t ne = text.find('\n', ns);
+    if (ne == std::string::npos)
+    {
+      return false;
+    }
     size_t next = text.find(mark, ns);
     addBlock(text.substr(ns, ne - ns),
-             text.substr(ne + 1,
-                         (next == std::string::npos ? text.size() : next)
-                             - (ne + 1)));
+             text.substr(
+                 ne + 1,
+                 (next == std::string::npos ? text.size() : next) - (ne + 1)));
     i = next;
   }
-  return true;
-}
-
-bool DefsFile::hasSymbol(const std::string& sym) const
-{
-  for (const DefsBlock& b : d_blocks)
-  {
-    if (b.d_sym == sym)
-    {
-      return true;
-    }
-  }
-  return false;
+  return !d_blocks.empty();
 }
 
 std::set<std::string> DefsFile::externalUses(
@@ -357,8 +376,7 @@ std::set<std::string> DefsFile::externalUses(
 }
 
 std::vector<const DefsBlock*> DefsFile::select(
-    const std::set<std::string>& syms,
-    const std::set<std::string>& names) const
+    const std::set<std::string>& syms, const std::set<std::string>& names) const
 {
   std::set<size_t> keep;
   std::vector<size_t> todo;
@@ -397,6 +415,58 @@ std::vector<const DefsBlock*> DefsFile::select(
     ret.push_back(&d_blocks[i]);
   }
   return ret;
+}
+
+std::vector<const DefsBlock*> orderByDeclarations(
+    const std::vector<const DefsBlock*>& blocks,
+    const std::vector<std::string>& declarations)
+{
+  std::map<std::string, const DefsBlock*> owner;
+  for (const DefsBlock* b : blocks)
+  {
+    for (const std::string& d : b->d_defs)
+    {
+      owner[d] = b;
+    }
+  }
+  std::set<std::string> declared(declarations.begin(), declarations.end());
+  std::vector<const DefsBlock*> ordered;
+  std::set<const DefsBlock*> placed;
+  std::function<void(const DefsBlock*)> placeDependencies =
+      [&](const DefsBlock* b) {
+        for (const std::string& u : b->d_uses)
+        {
+          std::map<std::string, const DefsBlock*>::const_iterator it =
+              owner.find(u);
+          if (it != owner.end() && declared.count(it->second->d_sym) == 0
+              && placed.insert(it->second).second)
+          {
+            placeDependencies(it->second);
+            ordered.push_back(it->second);
+          }
+        }
+      };
+  for (const std::string& declaration : declarations)
+  {
+    for (const DefsBlock* b : blocks)
+    {
+      if (b->d_sym != declaration || placed.count(b) != 0)
+      {
+        continue;
+      }
+      placeDependencies(b);
+      placed.insert(b);
+      ordered.push_back(b);
+    }
+  }
+  for (const DefsBlock* b : blocks)
+  {
+    if (placed.insert(b).second)
+    {
+      ordered.push_back(b);
+    }
+  }
+  return ordered;
 }
 
 }  // namespace ethos

--- a/plugins/model_smt/defs_reader.cpp
+++ b/plugins/model_smt/defs_reader.cpp
@@ -1,0 +1,402 @@
+#include "defs_reader.h"
+
+#include <fstream>
+#include <sstream>
+
+#include "base/check.h"
+
+namespace ethos {
+
+namespace {
+
+/** True if c may occur in a name of the signature. */
+bool isNameChar(char c)
+{
+  return !isspace(static_cast<unsigned char>(c)) && c != '(' && c != ')'
+         && c != ';' && c != '"';
+}
+
+/**
+ * The end of the parenthesised form of text that begins at i, i.e. one past
+ * its closing parenthesis. Note a string is stepped over whole, so that a
+ * parenthesis it holds is not counted.
+ */
+size_t formEnd(const std::string& text, size_t i)
+{
+  size_t depth = 0;
+  for (size_t n = text.size(); i < n; i++)
+  {
+    if (text[i] == '"')
+    {
+      // an SMT-LIB string, in which a quote is written twice
+      i++;
+      while (i < n && !(text[i] == '"' && (i + 1 >= n || text[i + 1] != '"')))
+      {
+        i += (text[i] == '"' ? 2 : 1);
+      }
+      continue;
+    }
+    if (text[i] == ';')
+    {
+      while (i < n && text[i] != '\n')
+      {
+        i++;
+      }
+      continue;
+    }
+    if (text[i] == '(')
+    {
+      depth++;
+    }
+    else if (text[i] == ')')
+    {
+      depth--;
+      if (depth == 0)
+      {
+        return i + 1;
+      }
+    }
+  }
+  return std::string::npos;
+}
+
+/** The top-level forms of text, in order. */
+std::vector<std::string> forms(const std::string& text)
+{
+  std::vector<std::string> ret;
+  for (size_t i = 0, n = text.size(); i < n; i++)
+  {
+    if (text[i] == ';')
+    {
+      while (i < n && text[i] != '\n')
+      {
+        i++;
+      }
+    }
+    else if (text[i] == '(')
+    {
+      size_t e = formEnd(text, i);
+      if (e == std::string::npos)
+      {
+        return ret;
+      }
+      ret.push_back(text.substr(i, e - i));
+      i = e - 1;
+    }
+  }
+  return ret;
+}
+
+/** The word of form that follows its keyword, i.e. the name it is of. */
+std::string formName(const std::string& form)
+{
+  size_t i = form.find_first_of(" \t\n", 1);
+  if (i == std::string::npos)
+  {
+    return "";
+  }
+  while (i < form.size() && isspace(static_cast<unsigned char>(form[i])))
+  {
+    i++;
+  }
+  size_t j = i;
+  while (j < form.size() && isNameChar(form[j]))
+  {
+    j++;
+  }
+  return form.substr(i, j - i);
+}
+
+/** The keyword of form, e.g. program or define. */
+std::string formKind(const std::string& form)
+{
+  size_t j = 1;
+  while (j < form.size() && isNameChar(form[j]))
+  {
+    j++;
+  }
+  return form.substr(1, j - 1);
+}
+
+/** Every name form uses, i.e. every word of it that begins with a dollar. */
+void namesOf(const std::string& form, std::set<std::string>& out)
+{
+  for (size_t i = 0, n = form.size(); i < n; i++)
+  {
+    if (form[i] == '"')
+    {
+      i++;
+      while (i < n && !(form[i] == '"' && (i + 1 >= n || form[i + 1] != '"')))
+      {
+        i += (form[i] == '"' ? 2 : 1);
+      }
+      continue;
+    }
+    if (form[i] == ';')
+    {
+      while (i < n && form[i] != '\n')
+      {
+        i++;
+      }
+      continue;
+    }
+    if (form[i] == '$')
+    {
+      size_t j = i;
+      while (j < n && isNameChar(form[j]))
+      {
+        j++;
+      }
+      out.insert(form.substr(i, j - i));
+      i = j - 1;
+    }
+  }
+}
+
+/**
+ * The cases of a program, i.e. the forms of the last form of its body, with
+ * the head of each rewritten from name to agg.
+ */
+std::vector<std::string> casesOf(const std::string& prog,
+                                 const std::string& name,
+                                 const std::string& agg)
+{
+  std::vector<std::string> body = forms(prog.substr(1, prog.size() - 2));
+  std::vector<std::string> ret;
+  if (body.empty())
+  {
+    return ret;
+  }
+  const std::string& cl = body.back();
+  for (const std::string& c : forms(cl.substr(1, cl.size() - 2)))
+  {
+    std::string cs = c;
+    size_t p = cs.find(name);
+    if (p != std::string::npos)
+    {
+      cs = cs.substr(0, p) + agg + cs.substr(p + name.size());
+    }
+    ret.push_back(cs);
+  }
+  return ret;
+}
+
+/** The forward declaration of the program prog, which is named name. */
+std::string fwdOf(const std::string& prog, const std::string& name)
+{
+  size_t s = prog.find(":signature");
+  if (s == std::string::npos)
+  {
+    return "";
+  }
+  size_t e = prog.find('\n', s);
+  std::stringstream ss;
+  ss << "(program " << name << " () " << prog.substr(s, e - s) << ")";
+  return ss.str();
+}
+
+}  // namespace
+
+void DefsFile::addBlock(const std::string& sym, const std::string& text)
+{
+  DefsBlock b;
+  b.d_sym = sym;
+  for (const std::string& f : forms(text))
+  {
+    const std::string kind = formKind(f);
+    if (kind == "echo")
+    {
+      // A directive to another stage of the compiler rather than something
+      // the model says, e.g. one that leaves the symbol out of the
+      // compilation altogether, see Desugar::echo. It names nothing here.
+      continue;
+    }
+    const std::string name = formName(f);
+    namesOf(f, b.d_uses);
+    b.d_defs.insert(name);
+    if (kind == "declare-const" || kind == "declare-parameterized-const"
+        || kind == "define")
+    {
+      // the constructor of the embedding for the symbol, and its macro
+      b.d_cons.push_back(f);
+      continue;
+    }
+    if (kind != "program")
+    {
+      continue;
+    }
+    // A program is either one of the per-symbol programs, whose cases the
+    // aggregate it feeds takes, or an auxiliary one the cases call, which is
+    // copied as it stands.
+    auto isPre = [&name](const char* p) {
+      const std::string pre(p);
+      return name.size() > pre.size() && name.compare(0, pre.size(), pre) == 0;
+    };
+    if (isPre("$eoc_is_list_nil_"))
+    {
+      // The nil of an n-ary symbol, which the desugar stage looks up by name.
+      // It is written here as $eoc_ and emitted as $eo_, since it is the
+      // program that stage calls rather than a case of an aggregate.
+      const std::string from = "$eoc_is_list_nil_";
+      const std::string to = "$eo_is_list_nil_";
+      std::string out = f;
+      size_t pos = out.find(from);
+      while (pos != std::string::npos)
+      {
+        out = out.substr(0, pos) + to + out.substr(pos + from.size());
+        pos = out.find(from, pos + to.size());
+      }
+      b.d_desugarAux.push_back(out);
+    }
+    else if (isPre("$eoc_eval_"))
+    {
+      b.d_evalCases = casesOf(f, name, "$smtx_model_eval");
+    }
+    else if (isPre("$eoc_typeof_"))
+    {
+      b.d_typeofCases = casesOf(f, name, "$smtx_typeof");
+    }
+    else if (isPre("$eoc_transform_type_"))
+    {
+      b.d_transTypeCases = casesOf(f, name, "$eo_to_smt_type");
+    }
+    else if (isPre("$eoc_transform_"))
+    {
+      b.d_transCases = casesOf(f, name, "$eo_to_smt");
+    }
+    else if (isPre("$smtx_typeof_"))
+    {
+      b.d_typeofAux.push_back(f);
+    }
+    else if (isPre("$smtx_model_eval_"))
+    {
+      b.d_evalProgs.push_back(f);
+      std::string fwd = fwdOf(f, name);
+      if (!fwd.empty())
+      {
+        b.d_evalFwd.push_back(fwd);
+      }
+    }
+    else if (isPre("$eo_to_smt"))
+    {
+      b.d_eoAux.push_back(f);
+    }
+    else
+    {
+      // A method of the symbol that is neither of the two above, e.g. the one
+      // that reads a sequence at an index. It goes with the evaluators, which
+      // the generated file has before every case that may call one.
+      b.d_evalProgs.push_back(f);
+    }
+  }
+  for (const std::string& d : b.d_defs)
+  {
+    b.d_uses.erase(d);
+  }
+  for (const std::string& d : b.d_defs)
+  {
+    d_owner[d] = d_blocks.size();
+  }
+  d_blocks.push_back(b);
+}
+
+bool DefsFile::read(const std::string& path)
+{
+  std::ifstream in(path);
+  if (!in.is_open())
+  {
+    return false;
+  }
+  std::stringstream ss;
+  ss << in.rdbuf();
+  const std::string text = ss.str();
+  // A block runs from the line that names its symbol to the next one.
+  const std::string mark = "\n; -- ";
+  size_t i = text.find(mark);
+  while (i != std::string::npos)
+  {
+    size_t ns = i + mark.size();
+    size_t ne = text.find('\n', ns);
+    size_t next = text.find(mark, ns);
+    addBlock(text.substr(ns, ne - ns),
+             text.substr(ne + 1,
+                         (next == std::string::npos ? text.size() : next)
+                             - (ne + 1)));
+    i = next;
+  }
+  return true;
+}
+
+bool DefsFile::hasSymbol(const std::string& sym) const
+{
+  for (const DefsBlock& b : d_blocks)
+  {
+    if (b.d_sym == sym)
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::set<std::string> DefsFile::externalUses(
+    const std::vector<const DefsBlock*>& blocks) const
+{
+  std::set<std::string> ret;
+  for (const DefsBlock* b : blocks)
+  {
+    for (const std::string& u : b->d_uses)
+    {
+      if (d_owner.find(u) == d_owner.end())
+      {
+        ret.insert(u);
+      }
+    }
+  }
+  return ret;
+}
+
+std::vector<const DefsBlock*> DefsFile::select(
+    const std::set<std::string>& syms,
+    const std::set<std::string>& names) const
+{
+  std::set<size_t> keep;
+  std::vector<size_t> todo;
+  for (size_t i = 0, n = d_blocks.size(); i < n; i++)
+  {
+    bool wanted = syms.count(d_blocks[i].d_sym) != 0;
+    for (std::set<std::string>::const_iterator it = names.begin();
+         !wanted && it != names.end();
+         ++it)
+    {
+      wanted = d_blocks[i].d_defs.count(*it) != 0;
+    }
+    if (wanted)
+    {
+      keep.insert(i);
+      todo.push_back(i);
+    }
+  }
+  // what a block kept above names, and what that names in turn
+  while (!todo.empty())
+  {
+    size_t i = todo.back();
+    todo.pop_back();
+    for (const std::string& u : d_blocks[i].d_uses)
+    {
+      std::map<std::string, size_t>::const_iterator it = d_owner.find(u);
+      if (it != d_owner.end() && keep.insert(it->second).second)
+      {
+        todo.push_back(it->second);
+      }
+    }
+  }
+  std::vector<const DefsBlock*> ret;
+  for (size_t i : keep)
+  {
+    ret.push_back(&d_blocks[i]);
+  }
+  return ret;
+}
+
+}  // namespace ethos

--- a/plugins/model_smt/defs_reader.h
+++ b/plugins/model_smt/defs_reader.h
@@ -1,0 +1,89 @@
+#ifndef PLUGINS__MODEL_SMT__DEFS_READER_H
+#define PLUGINS__MODEL_SMT__DEFS_READER_H
+
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace ethos {
+
+/**
+ * What one symbol of a signature contributes to the generated file, i.e. the
+ * block a `; -- X` line opens in a definitions file, see
+ * plugins/model_smt/smt_defs.eo and plugins/model_smt/cpc_defs.eo.
+ *
+ * A block is read as *text* rather than as terms. What it says is copied into
+ * the generated file as it stands, which is what keeps the definitions of the
+ * embedding it names, e.g. $vsm_bool, from being expanded on the way; a term
+ * would have to be printed back, and printing expands them.
+ */
+struct DefsBlock
+{
+  /** The symbol the block is of, as its `; -- X` line names it. */
+  std::string d_sym;
+  /** The names it defines. */
+  std::set<std::string> d_defs;
+  /** The names it uses that it does not define. */
+  std::set<std::string> d_uses;
+  /** The constructor of the embedding for the symbol, and the macro. */
+  std::vector<std::string> d_cons;
+  /** The auxiliary programs, by the stream each belongs to. */
+  std::vector<std::string> d_typeofAux, d_evalProgs, d_eoAux;
+  /**
+   * What the *desugar* stage asks about the symbol rather than the model, i.e.
+   * the program that decides whether a term is the nil of it.
+   */
+  std::vector<std::string> d_desugarAux;
+  /** A forward declaration of each program of d_evalProgs. */
+  std::vector<std::string> d_evalFwd;
+  /**
+   * The cases it contributes, with the head of each rewritten from the name of
+   * the per-symbol program to the name of the aggregate it feeds.
+   */
+  std::vector<std::string> d_typeofCases, d_evalCases, d_transCases,
+      d_transTypeCases;
+};
+
+/**
+ * A definitions file, i.e. a signature written directly in the deep embedding.
+ * Reading one gives the blocks it holds and says which block defines what, so
+ * that the blocks a signature needs can be taken and the rest left, see
+ * DefsFile::select.
+ */
+class DefsFile
+{
+ public:
+  /** Read the file at path. Returns false if it could not be read. */
+  bool read(const std::string& path);
+  /**
+   * The blocks whose symbol is in syms, together with every block those
+   * depend on, in the order the file gives them. A block depends on the one
+   * that defines a name it uses, e.g. the value of div is the value of
+   * div_total away from zero, so keeping div keeps div_total. A block that
+   * defines one of names is kept as well, which is how a block of another
+   * file is answered: the transformation of - names the constructor of uneg,
+   * which the SMT-LIB file is what defines.
+   */
+  std::vector<const DefsBlock*> select(const std::set<std::string>& syms,
+                                      const std::set<std::string>& names =
+                                          {}) const;
+  /** The names the blocks use that no block of this file defines. */
+  std::set<std::string> externalUses(
+      const std::vector<const DefsBlock*>& blocks) const;
+  /** The blocks, in the order the file gives them. */
+  const std::vector<DefsBlock>& getBlocks() const { return d_blocks; }
+  /** True if some block is of the symbol sym. */
+  bool hasSymbol(const std::string& sym) const;
+
+ private:
+  /** Read one block from text, having already taken its symbol. */
+  void addBlock(const std::string& sym, const std::string& text);
+  std::vector<DefsBlock> d_blocks;
+  /** The block that defines each name. */
+  std::map<std::string, size_t> d_owner;
+};
+
+}  // namespace ethos
+
+#endif

--- a/plugins/model_smt/defs_reader.h
+++ b/plugins/model_smt/defs_reader.h
@@ -1,3 +1,12 @@
+/******************************************************************************
+ * This file is part of the ethos project.
+ *
+ * Copyright (c) 2023-2024 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ ******************************************************************************/
+
 #ifndef PLUGINS__MODEL_SMT__DEFS_READER_H
 #define PLUGINS__MODEL_SMT__DEFS_READER_H
 
@@ -54,7 +63,10 @@ struct DefsBlock
 class DefsFile
 {
  public:
-  /** Read the file at path. Returns false if it could not be read. */
+  /**
+   * Read the file at path. Returns false if it could not be read or contained
+   * no definition blocks.
+   */
   bool read(const std::string& path);
   /**
    * The blocks whose symbol is in syms, together with every block those
@@ -65,16 +77,14 @@ class DefsFile
    * file is answered: the transformation of - names the constructor of uneg,
    * which the SMT-LIB file is what defines.
    */
-  std::vector<const DefsBlock*> select(const std::set<std::string>& syms,
-                                      const std::set<std::string>& names =
-                                          {}) const;
+  std::vector<const DefsBlock*> select(
+      const std::set<std::string>& syms,
+      const std::set<std::string>& names = {}) const;
   /** The names the blocks use that no block of this file defines. */
   std::set<std::string> externalUses(
       const std::vector<const DefsBlock*>& blocks) const;
   /** The blocks, in the order the file gives them. */
   const std::vector<DefsBlock>& getBlocks() const { return d_blocks; }
-  /** True if some block is of the symbol sym. */
-  bool hasSymbol(const std::string& sym) const;
 
  private:
   /** Read one block from text, having already taken its symbol. */
@@ -83,6 +93,14 @@ class DefsFile
   /** The block that defines each name. */
   std::map<std::string, size_t> d_owner;
 };
+
+/**
+ * Order blocks by the input declaration order. Before each declared block,
+ * recursively place any dependency block whose symbol is not itself declared.
+ */
+std::vector<const DefsBlock*> orderByDeclarations(
+    const std::vector<const DefsBlock*>& blocks,
+    const std::vector<std::string>& declarations);
 
 }  // namespace ethos
 

--- a/plugins/model_smt/model_smt.cpp
+++ b/plugins/model_smt/model_smt.cpp
@@ -12,11 +12,20 @@
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <type_traits>
 
 #include "../utils.h"
 #include "state.h"
 
 namespace ethos {
+
+static_assert(std::is_constructible<ModelSmt, State&>::value,
+              "ModelSmt must support the generic plugin factory");
+
+ModelSmt::ModelSmt(State& s)
+    : ModelSmt(s, getResourcePath("plugins/model_smt/cpc_defs.eo"))
+{
+}
 
 ModelSmt::ModelSmt(State& s, const std::string& defsFile)
     : StdPlugin(s), d_defsFile(defsFile)
@@ -37,7 +46,7 @@ void ModelSmt::bind(const std::string& name, const Expr& e)
   d_declSeen.emplace_back(name, e);
 }
 
-void ModelSmt::finalizeDecl(const std::string& name, const Expr& e)
+void ModelSmt::finalizeDecl(const std::string& name)
 {
   if (d_defsCovered.count(name) != 0)
   {
@@ -55,7 +64,6 @@ void ModelSmt::finalizeDecl(const std::string& name, const Expr& e)
   // interpret the symbol, we cannot claim this verification condition
   // accurately models SMT-LIB semantics.
   EO_FATAL() << "ERROR: no model semantics found for " << name;
-  Assert(false) << "No model semantics found for " << name;
 }
 
 void ModelSmt::loadDefs()
@@ -67,9 +75,7 @@ void ModelSmt::loadDefs()
   }
   if (d_defsFile.empty())
   {
-    EO_FATAL() << "ModelSmt: no signature was given for the input; name the"
-                  " one written in the deep embedding with --defs, e.g."
-                  " plugins/model_smt/cpc_defs.eo for CPC";
+    EO_FATAL() << "ModelSmt: no input signature resource was given";
   }
   if (!d_inputDefs.read(d_defsFile))
   {
@@ -98,52 +104,13 @@ void ModelSmt::loadDefs()
   // block of a symbol the input does not declare goes just before the one that
   // needs it, e.g. the constructor of uneg before the case for the overloaded
   // minus that names it.
-  std::map<std::string, const DefsBlock*> owner;
-  for (const DefsBlock* b : blocks)
-  {
-    for (const std::string& d : b->d_defs)
-    {
-      owner[d] = b;
-    }
-  }
-  std::vector<const DefsBlock*> byDecl;
-  std::set<const DefsBlock*> placed;
-  std::set<std::string> declared;
+  std::vector<std::string> declarations;
   for (const std::pair<std::string, Expr>& d : d_declSeen)
   {
-    declared.insert(d.first);
+    declarations.push_back(d.first);
   }
-  for (const std::pair<std::string, Expr>& d : d_declSeen)
-  {
-    for (const DefsBlock* b : blocks)
-    {
-      if (b->d_sym != d.first || placed.count(b) != 0)
-      {
-        continue;
-      }
-      // what it needs that the input does not declare, which has no place of
-      // its own to go to
-      for (const std::string& u : b->d_uses)
-      {
-        std::map<std::string, const DefsBlock*>::const_iterator it =
-            owner.find(u);
-        if (it != owner.end() && declared.count(it->second->d_sym) == 0
-            && placed.insert(it->second).second)
-        {
-          byDecl.push_back(it->second);
-        }
-      }
-      placed.insert(b);
-      byDecl.push_back(b);
-    }
-  }
-  for (const DefsBlock* b : blocks)
-  {
-    if (placed.insert(b).second)
-    {
-      byDecl.push_back(b);
-    }
-  }
+  std::vector<const DefsBlock*> byDecl =
+      orderByDeclarations(blocks, declarations);
   for (const DefsBlock* b : byDecl)
   {
     // A block that says nothing about the model, e.g. one that only gives the
@@ -211,46 +178,72 @@ void ModelSmt::finalize()
   loadDefs();
   for (std::pair<std::string, Expr>& d : d_declSeen)
   {
-    finalizeDecl(d.first, d.second);
+    finalizeDecl(d.first);
   }
   // Each placeholder is commented out in the template, which is what lets that
   // template be parsed on its own, see plugins/model_smt/model_smt.eo. The
   // comment is part of what a substitution replaces, so that the generated
   // content takes the whole line.
-  auto replace = [](std::string& txt,
-                    const std::string& tag,
-                    const std::string& replacement) {
+  auto replacePlaceholder = [](std::string& txt,
+                               const std::string& tag,
+                               const std::string& replacement) {
     const std::string guarded = ";" + tag;
     auto pos = txt.find(guarded);
-    if (pos != std::string::npos)
+    if (pos == std::string::npos)
     {
-      txt.replace(pos, guarded.length(), replacement);
+      EO_FATAL() << "ModelSmt: template is missing placeholder " << tag;
     }
+    StdPlugin::replace(txt, guarded, replacement);
   };
 
   // note that the deep embedding is *not* re-incorporated into
   // the final input to smt-meta.
 
   // now, go back and compile *.eo for the proof rules
-  std::ifstream ins(getResourcePath("plugins/model_smt/model_smt.eo"));
+  const std::string templatePath =
+      getResourcePath("plugins/model_smt/model_smt.eo");
+  std::ifstream ins(templatePath);
+  if (!ins.is_open())
+  {
+    EO_FATAL() << "ModelSmt: failed to open resource " << templatePath;
+  }
   std::ostringstream sss;
   sss << ins.rdbuf();
+  if (ins.bad())
+  {
+    EO_FATAL() << "ModelSmt: failed to read resource " << templatePath;
+  }
   std::string finalSmt = sss.str();
   // plug in the evaluation cases handled by this plugin
-  replace(finalSmt, "$SMT_EVAL_CASES$", d_eval.str());
-  replace(finalSmt, "$SMT_EVAL_PROGS_FWD_DECL$", d_modelEvalProgsFwd.str());
-  replace(finalSmt, "$SMT_EVAL_PROGS$", d_modelEvalProgs.str());
-  replace(finalSmt, "$EO_TO_SMT_AUX$", d_eoToSmtAux.str());
-  replace(finalSmt, "$EO_DESUGAR_AUX$", d_desugarAux.str());
-  replace(finalSmt, "$EO_TO_SMT_CASES$", d_eoToSmt.str());
-  replace(finalSmt, "$EO_TO_SMT_TYPE_CASES$", d_eoToSmtType.str());
-  replace(finalSmt, "$SMT_TERM_CONSTRUCTORS$", d_smtTerms.str());
-  replace(finalSmt, "$SMT_TYPEOF_CASES$", d_smtTypeof.str());
-  replace(finalSmt, "$SMT_TYPEOF_AUX$", d_smtTypeofAux.str());
+  replacePlaceholder(finalSmt, "$SMT_EVAL_CASES$", d_eval.str());
+  replacePlaceholder(
+      finalSmt, "$SMT_EVAL_PROGS_FWD_DECL$", d_modelEvalProgsFwd.str());
+  replacePlaceholder(finalSmt, "$SMT_EVAL_PROGS$", d_modelEvalProgs.str());
+  replacePlaceholder(finalSmt, "$EO_TO_SMT_AUX$", d_eoToSmtAux.str());
+  replacePlaceholder(finalSmt, "$EO_DESUGAR_AUX$", d_desugarAux.str());
+  replacePlaceholder(finalSmt, "$EO_TO_SMT_CASES$", d_eoToSmt.str());
+  replacePlaceholder(finalSmt, "$EO_TO_SMT_TYPE_CASES$", d_eoToSmtType.str());
+  replacePlaceholder(finalSmt, "$SMT_TERM_CONSTRUCTORS$", d_smtTerms.str());
+  replacePlaceholder(finalSmt, "$SMT_TYPEOF_CASES$", d_smtTypeof.str());
+  replacePlaceholder(finalSmt, "$SMT_TYPEOF_AUX$", d_smtTypeofAux.str());
+  if (finalSmt.find("$eoc_") != std::string::npos)
+  {
+    EO_FATAL() << "ModelSmt: generated output contains an unexpanded $eoc_ "
+                  "name";
+  }
 
   std::string outPath = getOutputPath("plugins/model_smt/model_smt_gen.eo");
   std::ofstream oute(outPath);
+  if (!oute.is_open())
+  {
+    EO_FATAL() << "ModelSmt: failed to open output " << outPath;
+  }
   oute << finalSmt;
+  oute.close();
+  if (!oute)
+  {
+    EO_FATAL() << "ModelSmt: failed to write output " << outPath;
+  }
 }
 
 }  // namespace ethos

--- a/plugins/model_smt/model_smt.cpp
+++ b/plugins/model_smt/model_smt.cpp
@@ -1,0 +1,256 @@
+/******************************************************************************
+ * This file is part of the ethos project.
+ *
+ * Copyright (c) 2023-2024 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ ******************************************************************************/
+
+#include "model_smt.h"
+
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "../utils.h"
+#include "state.h"
+
+namespace ethos {
+
+ModelSmt::ModelSmt(State& s, const std::string& defsFile)
+    : StdPlugin(s), d_defsFile(defsFile)
+{
+  // What each symbol of a signature means to the model is said by the
+  // signatures written in the deep embedding rather than here, see loadDefs
+  // and plugins/model_smt/smt_defs.eo.
+}
+
+ModelSmt::~ModelSmt() {}
+
+void ModelSmt::bind(const std::string& name, const Expr& e)
+{
+  if (e.getKind() != Kind::CONST)
+  {
+    return;
+  }
+  d_declSeen.emplace_back(name, e);
+}
+
+void ModelSmt::finalizeDecl(const std::string& name, const Expr& e)
+{
+  if (d_defsCovered.count(name) != 0)
+  {
+    // a symbol one of the signatures written in the deep embedding is of,
+    // whose block is what says its meaning, see loadDefs
+    return;
+  }
+  // A name of the desugar stage or of a signature helper rather than a symbol
+  // a proof may write, so no model has to say anything about it.
+  if (name.compare(0, 1, "$") == 0 || name.compare(0, 2, "@@") == 0)
+  {
+    return;
+  }
+  // This assertion is critical for soundness: if we do not know how to
+  // interpret the symbol, we cannot claim this verification condition
+  // accurately models SMT-LIB semantics.
+  EO_FATAL() << "ERROR: no model semantics found for " << name;
+  Assert(false) << "No model semantics found for " << name;
+}
+
+void ModelSmt::loadDefs()
+{
+  if (!d_smtDefs.read(getResourcePath("plugins/model_smt/smt_defs.eo")))
+  {
+    EO_FATAL() << "ModelSmt: could not read the SMT-LIB signature written in"
+                  " the deep embedding";
+  }
+  if (d_defsFile.empty())
+  {
+    EO_FATAL() << "ModelSmt: no signature was given for the input; name the"
+                  " one written in the deep embedding with --defs, e.g."
+                  " plugins/model_smt/cpc_defs.eo for CPC";
+  }
+  if (!d_inputDefs.read(d_defsFile))
+  {
+    EO_FATAL() << "ModelSmt: could not read the signature of the input at "
+               << d_defsFile;
+  }
+  // The blocks the input needs are the ones of a symbol it declares, together
+  // with the ones those name, see DefsFile::select.
+  std::set<std::string> syms;
+  for (const std::pair<std::string, Expr>& d : d_declSeen)
+  {
+    syms.insert(d.first);
+  }
+  // The transformation of a symbol names the constructor of what it denotes,
+  // which is a block of the other file, so what the one needs of the other is
+  // taken as well.
+  std::vector<const DefsBlock*> in = d_inputDefs.select(syms);
+  std::vector<const DefsBlock*> blocks =
+      d_smtDefs.select(syms, d_inputDefs.externalUses(in));
+  blocks.insert(blocks.end(), in.begin(), in.end());
+  // A program has to be defined before it is called, which the order of the
+  // files is what gives; a constructor and a case have no such order, since a
+  // case matches a head of its own and a constructor names nothing of another
+  // symbol. So the two are emitted in the order the *input* declares its
+  // symbols, which is the order the generated file has had them in, and a
+  // block of a symbol the input does not declare goes just before the one that
+  // needs it, e.g. the constructor of uneg before the case for the overloaded
+  // minus that names it.
+  std::map<std::string, const DefsBlock*> owner;
+  for (const DefsBlock* b : blocks)
+  {
+    for (const std::string& d : b->d_defs)
+    {
+      owner[d] = b;
+    }
+  }
+  std::vector<const DefsBlock*> byDecl;
+  std::set<const DefsBlock*> placed;
+  std::set<std::string> declared;
+  for (const std::pair<std::string, Expr>& d : d_declSeen)
+  {
+    declared.insert(d.first);
+  }
+  for (const std::pair<std::string, Expr>& d : d_declSeen)
+  {
+    for (const DefsBlock* b : blocks)
+    {
+      if (b->d_sym != d.first || placed.count(b) != 0)
+      {
+        continue;
+      }
+      // what it needs that the input does not declare, which has no place of
+      // its own to go to
+      for (const std::string& u : b->d_uses)
+      {
+        std::map<std::string, const DefsBlock*>::const_iterator it =
+            owner.find(u);
+        if (it != owner.end() && declared.count(it->second->d_sym) == 0
+            && placed.insert(it->second).second)
+        {
+          byDecl.push_back(it->second);
+        }
+      }
+      placed.insert(b);
+      byDecl.push_back(b);
+    }
+  }
+  for (const DefsBlock* b : blocks)
+  {
+    if (placed.insert(b).second)
+    {
+      byDecl.push_back(b);
+    }
+  }
+  for (const DefsBlock* b : byDecl)
+  {
+    // A block that says nothing about the model, e.g. one that only gives the
+    // nil of an n-ary symbol, leaves that symbol to be compiled as any other.
+    if (!b->d_cons.empty() || !b->d_typeofCases.empty()
+        || !b->d_evalCases.empty() || !b->d_transCases.empty()
+        || !b->d_transTypeCases.empty())
+    {
+      d_defsCovered.insert(b->d_sym);
+    }
+    for (const std::string& f : b->d_cons)
+    {
+      d_smtTerms << f << std::endl;
+    }
+    for (const std::string& c : b->d_typeofCases)
+    {
+      d_smtTypeof << "  " << c << std::endl;
+    }
+    for (const std::string& c : b->d_evalCases)
+    {
+      d_eval << "  " << c << std::endl;
+    }
+    for (const std::string& c : b->d_transCases)
+    {
+      d_eoToSmt << "  " << c << std::endl;
+    }
+    for (const std::string& c : b->d_transTypeCases)
+    {
+      d_eoToSmtType << "  " << c << std::endl;
+    }
+  }
+  // The programs follow the same order, which they may because each evaluator
+  // is forward declared above; a method that is not, having been written
+  // beside the symbol it belongs to, is ordered by the file it comes from,
+  // which is what puts it before whatever calls it.
+  for (const DefsBlock* b : byDecl)
+  {
+    for (const std::string& f : b->d_typeofAux)
+    {
+      d_smtTypeofAux << f << std::endl;
+    }
+    for (const std::string& f : b->d_evalFwd)
+    {
+      d_modelEvalProgsFwd << f << std::endl;
+    }
+    for (const std::string& f : b->d_evalProgs)
+    {
+      d_modelEvalProgs << f << std::endl;
+    }
+    for (const std::string& f : b->d_eoAux)
+    {
+      d_eoToSmtAux << f << std::endl;
+    }
+    for (const std::string& f : b->d_desugarAux)
+    {
+      d_desugarAux << f << std::endl;
+    }
+  }
+}
+
+void ModelSmt::finalize()
+{
+  // What each symbol of the signatures written in the deep embedding says,
+  // which this plugin copies rather than deriving, see loadDefs.
+  loadDefs();
+  for (std::pair<std::string, Expr>& d : d_declSeen)
+  {
+    finalizeDecl(d.first, d.second);
+  }
+  // Each placeholder is commented out in the template, which is what lets that
+  // template be parsed on its own, see plugins/model_smt/model_smt.eo. The
+  // comment is part of what a substitution replaces, so that the generated
+  // content takes the whole line.
+  auto replace = [](std::string& txt,
+                    const std::string& tag,
+                    const std::string& replacement) {
+    const std::string guarded = ";" + tag;
+    auto pos = txt.find(guarded);
+    if (pos != std::string::npos)
+    {
+      txt.replace(pos, guarded.length(), replacement);
+    }
+  };
+
+  // note that the deep embedding is *not* re-incorporated into
+  // the final input to smt-meta.
+
+  // now, go back and compile *.eo for the proof rules
+  std::ifstream ins(getResourcePath("plugins/model_smt/model_smt.eo"));
+  std::ostringstream sss;
+  sss << ins.rdbuf();
+  std::string finalSmt = sss.str();
+  // plug in the evaluation cases handled by this plugin
+  replace(finalSmt, "$SMT_EVAL_CASES$", d_eval.str());
+  replace(finalSmt, "$SMT_EVAL_PROGS_FWD_DECL$", d_modelEvalProgsFwd.str());
+  replace(finalSmt, "$SMT_EVAL_PROGS$", d_modelEvalProgs.str());
+  replace(finalSmt, "$EO_TO_SMT_AUX$", d_eoToSmtAux.str());
+  replace(finalSmt, "$EO_DESUGAR_AUX$", d_desugarAux.str());
+  replace(finalSmt, "$EO_TO_SMT_CASES$", d_eoToSmt.str());
+  replace(finalSmt, "$EO_TO_SMT_TYPE_CASES$", d_eoToSmtType.str());
+  replace(finalSmt, "$SMT_TERM_CONSTRUCTORS$", d_smtTerms.str());
+  replace(finalSmt, "$SMT_TYPEOF_CASES$", d_smtTypeof.str());
+  replace(finalSmt, "$SMT_TYPEOF_AUX$", d_smtTypeofAux.str());
+
+  std::string outPath = getOutputPath("plugins/model_smt/model_smt_gen.eo");
+  std::ofstream oute(outPath);
+  oute << finalSmt;
+}
+
+}  // namespace ethos

--- a/plugins/model_smt/model_smt.cpp
+++ b/plugins/model_smt/model_smt.cpp
@@ -193,7 +193,7 @@ void ModelSmt::finalize()
     {
       EO_FATAL() << "ModelSmt: template is missing placeholder " << tag;
     }
-    StdPlugin::replace(txt, guarded, replacement);
+    txt.replace(pos, guarded.length(), replacement);
   };
 
   // note that the deep embedding is *not* re-incorporated into

--- a/plugins/model_smt/model_smt.eo
+++ b/plugins/model_smt/model_smt.eo
@@ -1,0 +1,1490 @@
+; This file defines SMT-LIB model semantics in Eunoia.
+;
+; It is a template: the model_smt plugin substitutes the content it generates
+; for each of the `;$...$` placeholders below. Every placeholder is commented
+; out so that this file parses as it stands, which is what lets the SMT-LIB
+; signature be written in the vocabulary it declares, see
+; plugins/model_smt/smt.eo. A substitution replaces the comment character along
+; with the placeholder, so the generated content takes the whole line.
+; The programs in this file operate on datatypes that correspond to
+; a deep embedding of SMT-LIB values.
+; In particular, we use the following types:
+; 1. $smt_Value, the type of SMT-LIB values.
+; 2. Further types defining specific SMT-LIB values, e.g. $smt_Map.
+
+;;; remaining desugar definitions e.g. is_list_nil
+;$EO_DESUGAR_AUX$
+
+;;;;;; SMT terms
+
+; An SMT term.
+(declare-const $smt_Term Type)
+
+; An (atomic) SMT theory op.
+(declare-const $smt_TheoryOp Type)
+
+; An SMT type.
+(declare-const $smt_Type Type)
+; utilities
+(define $native_inhabited_type ((T $smt_Type)) ($native_apply_1 "inhabited_type" T))
+; Assumes that Teq is defined to be equality over $smt_Type
+(define $native_Teq ((x1 $smt_Type) (x2 $smt_Type)) ($native_apply_2 "Teq" x1 x2))
+
+; A datatype constructor
+(define $smt_DatatypeCons () ($native_embed_smt "SmtDatatypeCons"))
+
+; A datatype
+(define $smt_Datatype () ($native_embed_smt "SmtDatatype"))
+
+; A datatype declaration
+(define $smt_DatatypeDecl () ($native_embed_smt "SmtDatatypeDecl"))
+
+; An SMT-LIB value.
+(declare-const $smt_Value Type)
+; utilities
+; Assumes that veq is defined to be equality over $smt_Value
+(define $native_veq ((x1 $smt_Value) (x2 $smt_Value)) ($native_apply_2 "veq" x1 x2))
+
+;;;;;; SMT term constructors
+
+(declare-const $emb_sm.None $smt_Term)
+(define $sm_none () $emb_sm.None)
+
+; the literal types
+(declare-parameterized-const $emb_sm.Boolean
+  ((b $native_Bool :opaque)) $smt_Term)
+(define $sm_bool ((b $native_Bool)) ($emb_sm.Boolean b))
+(define $sm_true () ($sm_bool $native_true))
+(define $sm_false () ($sm_bool $native_false))
+
+(declare-parameterized-const $emb_sm.Numeral
+  ((n $native_Int :opaque)) $smt_Term)
+(define $sm_numeral ((n $native_Int)) ($emb_sm.Numeral n))
+; helpers
+(define $sm_z_zero () ($sm_numeral $native_z_zero))
+(define $sm_z_one () ($sm_numeral $native_z_one))
+
+(declare-parameterized-const $emb_sm.Rational
+  ((r $native_Rat :opaque)) $smt_Term)
+(define $sm_rational ((r $native_Rat)) ($emb_sm.Rational r))
+; helpers
+(define $sm_q_zero () ($sm_rational $native_q_zero))
+
+(declare-parameterized-const $emb_sm.String
+  ((s $native_String :opaque)) $smt_Term)
+(define $sm_string ((s $native_String)) ($emb_sm.String s))
+
+(declare-parameterized-const $emb_sm.Binary
+  ((w $native_Int :opaque) (v $native_Int :opaque)) $smt_Term)
+(define $sm_binary ((w $native_Int) (v $native_Int))
+  ($emb_sm.Binary w v))
+; helpers
+(define $sm_binary_bit_false () ($sm_binary $native_z_one $native_z_zero))
+(define $sm_binary_bit_true () ($sm_binary $native_z_one $native_z_one))
+
+; An application of a Eunoia term
+(declare-parameterized-const $emb_sm.Apply
+  ((f $smt_Term :opaque) (a $smt_Term :opaque))
+  $smt_Term)
+(define $sm_apply ((x $smt_Term) (y $smt_Term)) ($emb_sm.Apply x y))
+
+; Represents a SMT-LIB variable in the final deep embedding.
+(declare-parameterized-const $emb_sm.Var
+  ((s $native_String :opaque) (T $smt_Type :opaque))
+  $smt_Term)
+(define $sm_Var ((s $native_String) (T $smt_Type)) ($emb_sm.Var s T))
+
+; ITE
+(declare-parameterized-const $emb_sm.ite
+  ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque) (x3 $smt_Term :opaque))
+  $smt_Term)
+(define $sm_ite ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  ($emb_sm.ite x1 x2 x3))
+
+; equality
+(declare-parameterized-const $emb_sm.= 
+  ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_= ((x1 $smt_Term) (x2 $smt_Term))
+  ($emb_sm.= x1 x2))
+
+; exists
+; this takes the variable to quantify over, which should then be applied
+; to a formula, similarly for the other quantifiers
+(declare-parameterized-const $emb_sm.exists
+  ((s $native_String :opaque) (T $smt_Type :opaque) (F $smt_Term :opaque)) 
+  $smt_Term)
+(define $sm_exists ((s $native_String) (T $smt_Type) (F $smt_Term)) ($emb_sm.exists s T F))
+
+; forall
+(declare-parameterized-const $emb_sm.forall
+  ((s $native_String :opaque) (T $smt_Type :opaque) (F $smt_Term :opaque)) 
+  $smt_Term)
+(define $sm_forall ((s $native_String) (T $smt_Type) (F $smt_Term)) ($emb_sm.forall s T F))
+
+; choice
+; A Hilbert choice binder: choice s:T. F denotes a value of type T that makes
+; F true, if such a value exists.
+(declare-parameterized-const $emb_sm.choice
+  ((s $native_String :opaque) (T $smt_Type :opaque) (F $smt_Term :opaque))
+  $smt_Term)
+(define $sm_choice ((s $native_String) (T $smt_Type) (F $smt_Term))
+  ($emb_sm.choice s T F))
+
+; bind
+; ($sm_bind s T t1 t2) binds the variable s of type T to the result of
+; evaluating t1, then evaluates t2 under that binding. Together with choice,
+; this is used to express (skolemized) nested quantifiers.
+(declare-parameterized-const $emb_sm.bind
+  ((s $native_String :opaque) (T $smt_Type :opaque)
+   (t1 $smt_Term :opaque) (t2 $smt_Term :opaque))
+  $smt_Term)
+(define $sm_bind ((s $native_String) (T $smt_Type) (t1 $smt_Term) (t2 $smt_Term))
+  ($emb_sm.bind s T t1 t2))
+  
+; the ci^th constructor of datatype ($tsm_Datatype s dd).
+(declare-parameterized-const $emb_sm.DtCons
+  ((s $native_String :opaque) (d $smt_DatatypeDecl :opaque)
+   (ci $native_Nat :opaque))
+  $smt_Term)
+(define $sm_DtCons
+  ((s $native_String) (d $smt_DatatypeDecl) (ci $native_Nat))
+  ($emb_sm.DtCons s d ci))
+
+; The selector of the ai^th argument of the ci^th constructor of datatype
+; ($tsm_Datatype s dd).
+(declare-parameterized-const $emb_sm.DtSel
+  ((s $native_String :opaque) (d $smt_DatatypeDecl :opaque)
+   (ci $native_Nat :opaque) (ai $native_Nat :opaque))
+  $smt_Term)
+(define $sm_DtSel
+  ((s $native_String) (d $smt_DatatypeDecl)
+   (ci $native_Nat) (ai $native_Nat))
+  ($emb_sm.DtSel s d ci ai))
+
+; the tester of the ci^th constructor of datatype ($tsm_Datatype s dd).
+(declare-parameterized-const $emb_sm.DtTester
+  ((s $native_String :opaque) (d $smt_DatatypeDecl :opaque) (ci $native_Nat :opaque))
+  $smt_Term)
+(define $sm_DtTester ((s $native_String) (d $smt_DatatypeDecl) (ci $native_Nat))
+  ($emb_sm.DtTester s d ci))
+
+; uninterpreted constants
+(declare-parameterized-const $emb_sm.UConst
+  ((s $native_String :opaque) (T $smt_Type :opaque))
+  $smt_Term)
+(define $sm_UConst ((s $native_String) (T $smt_Type)) ($emb_sm.UConst s T))
+
+; all other ordinary term definitions
+;$SMT_TERM_CONSTRUCTORS$
+
+;;;;;; SMT type constructors
+
+(declare-const $emb_tsm.None $smt_Type)
+(define $tsm_none () $emb_tsm.None)
+
+; The Boolean type
+(declare-const $emb_tsm.Bool $smt_Type)
+(define $tsm_Bool () $emb_tsm.Bool)
+
+; The Integer type
+(declare-const $emb_tsm.Int $smt_Type)
+(define $tsm_Int () $emb_tsm.Int)
+
+; The Real type
+(declare-const $emb_tsm.Real $smt_Type)
+(define $tsm_Real () $emb_tsm.Real)
+
+; The RegLan type
+(declare-const $emb_tsm.RegLan $smt_Type)
+(define $tsm_RegLan () $emb_tsm.RegLan)
+
+; The Bitvector type
+(declare-parameterized-const $emb_tsm.BitVec ((w $native_Nat :opaque)) $smt_Type)
+(define $tsm_BitVec ((w $native_Nat)) ($emb_tsm.BitVec w))
+
+; The Map type (for values)
+(declare-parameterized-const $emb_tsm.Map
+  ((Ti $smt_Type :opaque) (Te $smt_Type :opaque)) $smt_Type)
+(define $tsm_Map ((Ti $smt_Type) (Te $smt_Type)) ($emb_tsm.Map Ti Te))
+
+; The Array type (for terms)
+(define $tsm_Array ((Ti $smt_Type) (Te $smt_Type)) ($emb_tsm.Map Ti Te))
+
+; The Set type
+(declare-parameterized-const $emb_tsm.Set ((T $smt_Type :opaque)) $smt_Type)
+(define $tsm_Set ((T $smt_Type)) ($emb_tsm.Set T))
+
+; The Sequence type
+(declare-parameterized-const $emb_tsm.Seq ((T $smt_Type :opaque)) $smt_Type)
+(define $tsm_Seq ((T $smt_Type)) ($emb_tsm.Seq T))
+
+; The Char type
+(declare-const $emb_tsm.Char $smt_Type)
+(define $tsm_Char () $emb_tsm.Char)
+
+; The String, type a sequence of chars
+(define $tsm_String () ($tsm_Seq $tsm_Char))
+
+; A datatype is a type containing (1) its name, and (2) its structure.
+; Its name can be understood as a binder under which ($tsm_TypeRef <name>) is
+; a recursive reference to the (most recently bound) instance of a datatype
+; with the given name.
+; For example, the recursive datatype for a list of integers:
+; (declare-datatype List ((cons (head Int) (tail List)) (nil)))
+; Would have the following syntax:
+; ($tsm_Datatype "List" d)
+; Where d is the datatype spec:
+; ($dt_sum
+;   ($dtc_cons $tsm_Int ($dtc_cons ($tsm_TypeRef "List") $dtc_unit)) ; cons
+;   ($dt_sum
+;      $dtc_unit ; nil
+;      $dt_null))
+; Note that names of constructors and selectors are not represented in the AST.
+; To express constructor terms, we give an index, such that cons/nil are terms:
+;   ($sm_DtCons "List" d 0), ($sm_DtCons "List" d 1).
+; The types of these constructors are:
+;   ($sm_DtCons "List" d 0) : (-> $tsm_Int ($tsm_Datatype "List" d) ($tsm_Datatype "List" d))
+;   ($sm_DtCons "List" d 1) : ($tsm_Datatype "List" d)
+; The list (1,2) is the term:
+; ($sm_apply
+;    ($sm_apply ($sm_DtCons "List" d 0) ($sm_numeral 1))
+;    ($sm_apply
+;       ($sm_apply ($sm_DtCons "List" d 0) ($sm_numeral 2))
+;       ($sm_DtCons "List" d 1)))
+; The selectors head/tail for this datatype give indices to the constructor
+; and argument position they refer to:
+;   ($sm_DtSel "List" d 0 0) ($sm_DtSel "List" d 0 1).
+; Note this also permits mutual recursion, e.g. for SMT datatype:
+; (declare-datatypes ((List 0) (Tree 0))
+;   (((cons (head Tree) (tail List)) (nil))
+;    ((node (children List)) (leaf))))
+; this is represented as:
+; (eo::define ((Tree
+;    ($tsm_Datatype "Tree"
+;      ($dt_sum
+;        ($dtc_cons ($tsm_TypeRef "List") $dtc_unit) ; node
+;        ($dt_sum
+;          $dtc_unit ; leaf
+;          $dt_null)))))
+;   ($tsm_Datatype "List"
+;      ($dt_sum
+;        ($dtc_cons Tree ($dtc_cons ($tsm_TypeRef "List") $dtc_unit)) ; cons
+;        ($dt_sum
+;           $dtc_unit ; nil
+;           $dt_null))))
+(declare-parameterized-const $emb_tsm.Datatype
+  ((s $native_String :opaque) (d $smt_DatatypeDecl :opaque)) $smt_Type)
+(define $tsm_Datatype ((s $native_String) (d $smt_DatatypeDecl))
+  ($emb_tsm.Datatype s d))
+
+(declare-parameterized-const $emb_tsm.TypeRef
+  ((s $native_String :opaque)) $smt_Type)
+(define $tsm_TypeRef ((s $native_String)) ($emb_tsm.TypeRef s))
+
+; uninterpreted sorts
+(declare-parameterized-const $emb_tsm.USort ((n $native_Nat :opaque)) $smt_Type)
+(define $tsm_USort ((n $native_Nat)) ($emb_tsm.USort n))
+
+; functions
+; intensional function types
+(declare-parameterized-const $emb_tsm.FunType
+  ((Ti $smt_Type :opaque) (Te $smt_Type :opaque)) $smt_Type)
+(define $tsm_FunType ((Ti $smt_Type) (Te $smt_Type)) ($emb_tsm.FunType Ti Te))
+
+; The type of partially applied datatype constructors
+(declare-parameterized-const $emb_tsm.DtcAppType
+  ((Ti $smt_Type :opaque) (Te $smt_Type :opaque)) $smt_Type)
+(define $tsm_DtcAppType ((Ti $smt_Type) (Te $smt_Type)) ($emb_tsm.DtcAppType Ti Te))
+
+
+;;;;;; SMT values
+
+; The type used to define values for functions, arrays and sets in SMT-LIB.
+(declare-const $smt_Map Type)
+
+; The type used to define values for sequences in SMT-LIB.
+(declare-const $smt_Seq Type)
+
+; The type used to define values for regular languages in SMT-LIB. Its base
+; elements are $smt_Value, so that the regular expression operators can be
+; defined over the same (unpacked) sequence representation used by the
+; sequence operators.
+(define $smt_RegLan () ($native_embed_smt "SmtRegLan"))
+
+;;; SMT value datatype constructors
+
+; Denotes a failure case for values.
+(declare-const $emb_vsm.NotValue $smt_Value)
+(define $vsm_not_value () $emb_vsm.NotValue)
+
+; the literal types
+(declare-parameterized-const $emb_vsm.Boolean
+  ((b $native_Bool :opaque)) $smt_Value)
+(define $vsm_bool ((b $native_Bool)) ($emb_vsm.Boolean b))
+; helpers
+(define $vsm_true () ($vsm_bool $native_true))
+(define $vsm_false () ($vsm_bool $native_false))
+
+(declare-parameterized-const $emb_vsm.Numeral
+  ((n $native_Int :opaque)) $smt_Value)
+(define $vsm_numeral ((n $native_Int)) ($emb_vsm.Numeral n))
+; helpers
+(define $vsm_z_zero () ($vsm_numeral $native_z_zero))
+(define $vsm_z_one () ($vsm_numeral $native_z_one))
+
+(declare-parameterized-const $emb_vsm.Rational
+  ((r $native_Rat :opaque)) $smt_Value)
+(define $vsm_rational ((r $native_Rat)) ($emb_vsm.Rational r))
+; helpers
+(define $vsm_q_zero () ($vsm_rational $native_q_zero))
+
+(declare-parameterized-const $emb_vsm.Binary
+  ((w $native_Int :opaque) (v $native_Int :opaque)) $smt_Value)
+(define $vsm_binary ((w $native_Int) (v $native_Int))
+  ($emb_vsm.Binary w v))
+; utilities
+(define $vsm_binary_empty () ($vsm_binary $native_z_zero $native_z_zero))
+(define $vsm_binary_bit_false () ($vsm_binary $native_z_one $native_z_zero))
+(define $vsm_binary_bit_true () ($vsm_binary $native_z_one $native_z_one))
+
+; A value denoting a map.
+(declare-parameterized-const $emb_vsm.Map ((m $smt_Map :opaque)) $smt_Value)
+(define $vsm_map ((m $smt_Map)) ($emb_vsm.Map m))
+
+; A value denoting an intensional function.
+(declare-parameterized-const $emb_vsm.Fun
+  ((s $native_String :opaque) (T $smt_Type :opaque) (U $smt_Type :opaque))
+  $smt_Value)
+(define $vsm_fun ((s $native_String) (T $smt_Type) (U $smt_Type ))
+  ($emb_vsm.Fun s T U))
+
+; A value denoting a set. This also uses the map data structure internally.
+(declare-parameterized-const $emb_vsm.Set ((m $smt_Map :opaque)) $smt_Value)
+(define $vsm_set ((m $smt_Map)) ($emb_vsm.Set m))
+
+; A value denoting a sequence.
+(declare-parameterized-const $emb_vsm.Seq ((s $smt_Seq :opaque)) $smt_Value)
+(define $vsm_seq ((s $smt_Seq)) ($emb_vsm.Seq s))
+
+; A char (for strings)
+(declare-parameterized-const $emb_vsm.Char
+  ((c $native_Char :opaque)) $smt_Value)
+(define $vsm_char ((c $native_Char)) ($emb_vsm.Char c))
+
+; A value denoting an uninterpreted sort
+(declare-parameterized-const $emb_vsm.UValue 
+  ((i $native_Nat :opaque) (e $native_Nat :opaque)) $smt_Value)
+(define $vsm_uvalue ((i $native_Nat) (e $native_Nat)) ($emb_vsm.UValue i e))
+
+; A value denoting a regular language.
+(declare-parameterized-const $emb_vsm.RegLan ((r $smt_RegLan :opaque)) $smt_Value)
+(define $vsm_re ((r $smt_RegLan)) ($emb_vsm.RegLan r))
+
+; A constructor value
+(declare-parameterized-const $emb_vsm.DtCons
+  ((s $native_String :opaque) (d $smt_DatatypeDecl :opaque) (ci $native_Nat :opaque))
+  $smt_Value)
+(define $vsm_DtCons ((s $native_String) (d $smt_DatatypeDecl) (ci $native_Nat))
+  ($emb_vsm.DtCons s d ci))
+
+; Apply values (for Herbrand interpretations).
+(declare-parameterized-const $emb_vsm.Apply
+  ((f $smt_Value :opaque) (a $smt_Value :opaque))
+  $smt_Value)
+(define $vsm_apply ((f $smt_Value) (a $smt_Value))
+  ($emb_vsm.Apply f a))
+; utilities
+(program $vsm_apply_head ((f $smt_Value) (a $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($vsm_apply_head ($vsm_apply f a)) ($vsm_apply_head f))
+  (($vsm_apply_head a)                a)
+  )
+)
+
+; ($vsm_apply_arg_nth v n npos), where we are getting the n^th argument,
+; npos is the current position we are at + 1.
+(program $vsm_apply_arg_nth
+  ((f $smt_Value) (a $smt_Value) (n $native_Nat) (npos $native_Nat))
+  :signature ($smt_Value $native_Nat $native_Nat) $smt_Value
+  (
+  (($vsm_apply_arg_nth ($vsm_apply f a) n ($native_n_succ npos))
+    ($native_ite ($native_n_= n npos) a
+      ($vsm_apply_arg_nth f n npos)))
+  (($vsm_apply_arg_nth a n npos) $vsm_not_value)
+  )
+)
+
+;;; SMT map value datatype constructors
+
+; Constructs a map value where i is mapped to e.
+(declare-parameterized-const $emb_msm.cons
+  ((i $smt_Value :opaque) (e $smt_Value :opaque) (m $smt_Map :opaque))
+  $smt_Map)
+(define $msm_cons ((i $smt_Value) (e $smt_Value) (m $smt_Map))
+  ($emb_msm.cons i e m))
+
+; Constructs a map value where all indices are mapped to e.
+(declare-parameterized-const $emb_msm.default
+  ((T $smt_Type :opaque) (e $smt_Value :opaque))
+  $smt_Map)
+(define $msm_default ((T $smt_Type) (e $smt_Value)) ($emb_msm.default T e))
+
+;;; SMT sequence value datatype constructors
+
+(declare-parameterized-const $emb_ssm.cons
+  ((i $smt_Value :opaque) (s $smt_Seq :opaque))
+  $smt_Seq)
+(define $ssm_cons ((i $smt_Value) (s $smt_Seq)) ($emb_ssm.cons i s))
+
+(declare-parameterized-const $emb_ssm.empty ((T $smt_Type :opaque)) $smt_Seq)
+(define $ssm_empty ((T $smt_Type)) ($emb_ssm.empty T))
+
+(define $vsm_string_empty () ($vsm_seq ($ssm_empty $tsm_Char)))
+
+;;; Constructors for SMT-LIB datatypes and datatype constructors
+
+; A constructor having no arguments
+(declare-const $emb_dtc.unit $smt_DatatypeCons)
+(define $dtc_unit () $emb_dtc.unit)
+
+; A constructor having at least one argument
+; It takes the type of that argument and a constructor specifying the remaining
+; arguments.
+(declare-parameterized-const $emb_dtc.cons
+  ((T $smt_Type :opaque) (c $smt_DatatypeCons :opaque))
+  $smt_DatatypeCons)
+(define $dtc_cons ((T $smt_Type) (c $smt_DatatypeCons))
+  ($emb_dtc.cons T c))
+
+; A datatype having no constructors
+(declare-const $emb_dt.null $smt_Datatype)
+(define $dt_null () $emb_dt.null)
+
+; A datatype having at least one constructor
+(declare-parameterized-const $emb_dt.sum
+  ((c $smt_DatatypeCons :opaque) (d $smt_Datatype :opaque))
+  $smt_Datatype)
+(define $dt_sum ((c $smt_DatatypeCons) (d $smt_Datatype))
+  ($emb_dt.sum c d))
+
+; A datatype declaration having no datatypes
+(declare-const $emb_dd.nil $smt_DatatypeDecl)
+(define $dd_nil () $emb_dd.nil)
+
+; A datatype having at least one constructor
+(declare-parameterized-const $emb_dd.cons
+  ((s $native_String :opaque) (d $smt_Datatype :opaque) (dd $smt_DatatypeDecl :opaque))
+  $smt_DatatypeDecl)
+(define $dd_cons ((s $native_String) (d $smt_Datatype) (dd $smt_DatatypeDecl))
+  ($emb_dd.cons s d dd))
+  
+;;; forward declarations
+
+(program $smtx_typeof_value () :signature ($smt_Value) $smt_Type)
+(program $smtx_typeof () :signature ($smt_Term) $smt_Type)
+(program $smtx_model_eval () :signature ($smt_Model $smt_Term) $smt_Value)
+
+;;; dt resolve
+
+(program $smtx_dtc_resolve
+  ((s $native_String) (T $smt_Type) (c $smt_DatatypeCons) (dd $smt_DatatypeDecl))
+  :signature ($smt_DatatypeCons $smt_DatatypeDecl) $smt_DatatypeCons
+  (
+  (($smtx_dtc_resolve ($dtc_cons ($tsm_TypeRef s) c) dd)
+    ($dtc_cons ($tsm_Datatype s dd) ($smtx_dtc_resolve c dd)))
+  (($smtx_dtc_resolve ($dtc_cons T c) dd)
+    ($dtc_cons T ($smtx_dtc_resolve c dd)))
+  (($smtx_dtc_resolve $dtc_unit dd) $dtc_unit)
+  )
+)
+
+(program $smtx_dt_resolve
+  ((d $smt_Datatype) (c $smt_DatatypeCons) (dd $smt_DatatypeDecl))
+  :signature ($smt_Datatype $smt_DatatypeDecl) $smt_Datatype
+  (
+  (($smtx_dt_resolve ($dt_sum c d) dd)
+    ($dt_sum ($smtx_dtc_resolve c dd) ($smtx_dt_resolve d dd)))
+  (($smtx_dt_resolve $dt_null dd) $dt_null)
+  )
+)
+
+(program $smtx_dd_lookup
+  ((s $native_String) (s2 $native_String) (d $smt_Datatype) (c $smt_DatatypeCons) 
+   (dd $smt_DatatypeDecl))
+  :signature ($native_String $smt_DatatypeDecl) $smt_Datatype
+  (
+  (($smtx_dd_lookup s ($dd_cons s2 d dd))
+    ($native_ite ($native_str_= s s2) d ($smtx_dd_lookup s dd)))
+  (($smtx_dd_lookup s $dd_nil) $dt_null)
+  )
+)
+
+(program $smtx_dd_has_dt
+  ((s $native_String) (s2 $native_String) (d $smt_Datatype) (c $smt_DatatypeCons)
+   (dd $smt_DatatypeDecl))
+  :signature ($native_String $smt_DatatypeDecl) $native_Bool
+  (
+  (($smtx_dd_has_dt s ($dd_cons s2 d dd))
+    ($native_or ($native_str_= s s2) ($smtx_dd_has_dt s dd)))
+  (($smtx_dd_has_dt s $dd_nil) $native_false)
+  )
+)
+
+(define $smtx_dd_resolve ((s $native_String) (dd $smt_DatatypeDecl))
+  ($smtx_dt_resolve ($smtx_dd_lookup s dd) dd))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Well-foundedness for types
+
+(program $smtx_type_wf_rec () :signature ($smt_Type) $native_Bool)
+
+(define $smtx_type_wf_component_rec ((T $smt_Type))
+  ($native_and ($native_inhabited_type T) ($smtx_type_wf_rec T)))
+
+(program $smtx_dt_cons_wf_rec
+  ((c $smt_DatatypeCons) (T $smt_Type) (s $native_String) (dd $smt_DatatypeDecl))
+  :signature ($smt_DatatypeDecl $smt_DatatypeCons) $native_Bool
+  (
+  (($smtx_dt_cons_wf_rec dd ($dtc_cons ($tsm_TypeRef s) c))
+    ($native_and ($smtx_dd_has_dt s dd) ($smtx_dt_cons_wf_rec dd c)))
+  (($smtx_dt_cons_wf_rec dd ($dtc_cons T c))
+    ($native_and ($smtx_type_wf_component_rec T)
+      ($smtx_dt_cons_wf_rec dd c)))
+  (($smtx_dt_cons_wf_rec dd $dtc_unit) $native_true)
+  )
+)
+
+(program $smtx_dt_wf_rec
+  ((dd $smt_DatatypeDecl) (dF $smt_Datatype) (cF $smt_DatatypeCons))
+  :signature ($smt_DatatypeDecl $smt_Datatype) $native_Bool
+  (
+  (($smtx_dt_wf_rec dd ($dt_sum cF dF))
+    ($native_and ($smtx_dt_cons_wf_rec dd cF) ($smtx_dt_wf_rec dd dF)))
+  (($smtx_dt_wf_rec dd $dt_null)  $native_true)
+  )
+)
+
+(program $smtx_decl_wf_rec
+  ((s $native_String) (dd $smt_DatatypeDecl) (d $smt_Datatype) (ddF $smt_DatatypeDecl))
+  :signature ($smt_DatatypeDecl $smt_DatatypeDecl) $native_Bool
+  (
+  (($smtx_decl_wf_rec dd ($dd_cons s d ddF))
+    ($native_and ($smtx_dt_wf_rec dd d) ; this must be a well formed datatype
+    ($native_and ($native_inhabited_type ($tsm_Datatype s dd)) ; must be inhabited
+    ($native_and ($smtx_decl_wf_rec dd ddF) ; the tail must be a well formed datatype decl
+      ($native_not ($smtx_dd_has_dt s ddF)))))) ; must be a unique reference
+  (($smtx_decl_wf_rec dd $dd_nil)  $native_true)
+  )
+)
+  
+(program $smtx_type_wf_rec
+  ((T $smt_Type) (U Type) (s $native_String) (dd $smt_DatatypeDecl)
+   (x1 Type) (x2 Type))
+  :signature ($smt_Type) $native_Bool
+  (
+  (($smtx_type_wf_rec ($tsm_Datatype s dd))
+    ($native_and ($smtx_dd_has_dt s dd) ($smtx_decl_wf_rec dd dd)))
+  (($smtx_type_wf_rec ($tsm_TypeRef s)) $native_false)
+  (($smtx_type_wf_rec ($tsm_Seq x1))
+    ($smtx_type_wf_component_rec x1))
+  (($smtx_type_wf_rec ($tsm_Array x1 x2))
+    ($native_and ($smtx_type_wf_component_rec x1) ($smtx_type_wf_component_rec x2)))
+  (($smtx_type_wf_rec ($tsm_FunType x1 x2)) $native_false)
+  (($smtx_type_wf_rec ($tsm_Set x1))
+    ($smtx_type_wf_component_rec x1))
+  ; partially applied datatype constructors is not a first class type
+  (($smtx_type_wf_rec ($tsm_DtcAppType x1 x2)) $native_false)
+  (($smtx_type_wf_rec $tsm_none) $native_false)
+  (($smtx_type_wf_rec $tsm_RegLan) $native_false)
+  (($smtx_type_wf_rec U) $native_true)
+  )
+)
+
+(program $smtx_type_wf_component ((T $smt_Type))
+  :signature ($smt_Type) $native_Bool
+  (
+  (($smtx_type_wf_component T) ($smtx_type_wf_component_rec T))
+  )
+)
+
+(program $smtx_type_wf ((T $smt_Type) (U $smt_Type))
+  :signature ($smt_Type) $native_Bool
+  (
+  ; reglan only allowed at top-level
+  (($smtx_type_wf $tsm_RegLan) $native_true)
+  (($smtx_type_wf ($tsm_FunType T U))
+    ($native_and ($smtx_type_wf_component T) ($smtx_type_wf U)))
+  (($smtx_type_wf T) ($smtx_type_wf_component T))
+  )
+)
+
+;;; utilities
+
+; returns U if T is not none
+(program $smtx_typeof_guard ((T $smt_Type) (U $smt_Type))
+  :signature ($smt_Type $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_guard T U) ($native_ite ($native_Teq T $tsm_none) $tsm_none U))
+  )
+)
+
+; returns U if T is well-formed and inhabited
+(program $smtx_typeof_guard_wf ((T $smt_Type) (U $smt_Type))
+  :signature ($smt_Type $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_guard_wf T U) ($native_ite ($smtx_type_wf T) U $tsm_none))
+  )
+)
+
+;;; Map utilities
+
+; Get the default for the map
+(program $smtx_msm_get_default
+  ((T $smt_Type) (i $smt_Value) (j $smt_Value) (e $smt_Value) (m $smt_Map))
+  :signature ($smt_Map) $smt_Value
+  (
+  (($smtx_msm_get_default ($msm_cons j e m))  ($smtx_msm_get_default m))
+  (($smtx_msm_get_default ($msm_default T e)) e)
+  )
+)
+
+; This program looks up the value of a term in a map.
+; This is used for function evaluation.
+(program $smtx_msm_lookup
+  ((T $smt_Type) (i $smt_Value) (j $smt_Value) (e $smt_Value) (m $smt_Map))
+  :signature ($smt_Map $smt_Value) $smt_Value
+  (
+  (($smtx_msm_lookup ($msm_cons j e m) i)  ($native_ite ($native_veq j i) e ($smtx_msm_lookup m i)))
+  (($smtx_msm_lookup ($msm_default T e) i) e)
+  )
+)
+
+(program $smtx_msm_update_aux_no_default
+  ((ed $smt_Value) (T $smt_Type) (i $smt_Value) (e $smt_Value) (m $smt_Map))
+  :signature ($smt_Value $smt_Map $smt_Value $smt_Value) $smt_Map
+  (
+  (($smtx_msm_update_aux_no_default ed m i e)
+    ; check if we are redundant wrt the default value
+    ($native_ite ($native_veq ed e) m ($msm_cons i e m)))
+  )
+)
+
+(define $native_vcmp ((x1 $smt_Value) (x2 $smt_Value)) ($native_apply_2 "vcmp" x1 x2))
+
+; updates the map with a new entry, maintaining ordered-ness
+(program $smtx_msm_update_aux
+  ((ed $smt_Value) (T $smt_Type) (i $smt_Value) (j $smt_Value) (e1 $smt_Value) (e2 $smt_Value) (m $smt_Map))
+  :signature ($smt_Value $smt_Map $smt_Value $smt_Value) $smt_Map
+  (
+  (($smtx_msm_update_aux ed ($msm_cons j e1 m) i e2)
+    ($native_ite ($native_veq j i)
+      ; we overwrite if same index
+      ($smtx_msm_update_aux_no_default ed m i e2)
+      ; otherwise, we check the hash to retain sortedness
+      ($native_ite ($native_vcmp j i)
+        ($smtx_msm_update_aux_no_default ed ($msm_cons j e1 m) i e2)
+        ($msm_cons j e1 ($smtx_msm_update_aux ed m i e2)))))
+  (($smtx_msm_update_aux ed m i e2)
+    ($smtx_msm_update_aux_no_default ed m i e2))
+  )
+)
+(define $smtx_msm_update ((m $smt_Map) (i $smt_Value) (e $smt_Value))
+  ($smtx_msm_update_aux ($smtx_msm_get_default m) m i e))
+
+; Returns the type of the map value or tsm_none
+(program $smtx_typeof_map_value
+  ((i $smt_Value) (e $smt_Value) (m $smt_Map) (T $smt_Type))
+  :signature ($smt_Map) $smt_Type
+  (
+  (($smtx_typeof_map_value ($msm_cons i e m))
+    (eo::define ((mT ($smtx_typeof_map_value m)))
+    ($native_ite ($native_Teq ($tsm_Map ($smtx_typeof_value i) ($smtx_typeof_value e)) mT)
+      mT
+      $tsm_none)))
+  (($smtx_typeof_map_value ($msm_default T e))  ($tsm_Map T ($smtx_typeof_value e)))
+  )
+)
+
+;;; Map as sets
+
+; A set is a mapping to Bool, and the empty set maps all to false.
+(define $msm_empty_set ((T $smt_Type)) ($msm_default T $vsm_false))
+
+(program $smtx_map_to_set_type ((T $smt_Type))
+  :signature ($smt_Type) $smt_Type
+  (
+  (($smtx_map_to_set_type ($tsm_Map T $tsm_Bool)) ($tsm_Set T))
+  (($smtx_map_to_set_type T) $tsm_none)
+  )
+)
+
+;;; Utilities for Function values
+
+;;; Utilities for Sequence values
+
+; Returns the type of the map value or tsm_none
+(program $smtx_typeof_seq_value
+  ((v $smt_Value) (vs $smt_Seq) (T $smt_Type))
+  :signature ($smt_Seq) $smt_Type
+  (
+  (($smtx_typeof_seq_value ($ssm_cons v vs))
+    (eo::define ((sT ($smtx_typeof_seq_value vs)))
+    ($native_ite ($native_Teq ($tsm_Seq ($smtx_typeof_value v)) sT)
+      sT
+      $tsm_none)))
+  (($smtx_typeof_seq_value ($ssm_empty T)) ($tsm_Seq T))
+  )
+)
+
+;; datatypes
+
+(program $smtx_dtc_num_sels ((U $smt_Type) (c $smt_DatatypeCons))
+  :signature ($smt_DatatypeCons) $native_Nat
+  (
+  (($smtx_dtc_num_sels ($dtc_cons U c)) ($native_n_succ ($smtx_dtc_num_sels c)))
+  (($smtx_dtc_num_sels $dtc_unit)       $native_n_zero)
+  )
+)
+
+(program $smtx_dt_num_sels ((c $smt_DatatypeCons) (d $smt_Datatype) (n $native_Nat))
+  :signature ($smt_Datatype $native_Nat) $native_Nat
+  (
+  (($smtx_dt_num_sels ($dt_sum c d) $native_n_zero) ($smtx_dtc_num_sels c))
+  (($smtx_dt_num_sels ($dt_sum c d) ($native_n_succ n))
+     ($smtx_dt_num_sels d n))
+  (($smtx_dt_num_sels $dt_null n)                        $native_n_zero)
+  )
+)
+
+(program $smtx_typeof_dt_cons_value_rec
+  ((T $smt_Type) (U $smt_Type) (n $native_Nat) (c $smt_DatatypeCons) (d $smt_Datatype))
+  :signature ($smt_Type $smt_Datatype $native_Nat) $smt_Type
+  (
+  (($smtx_typeof_dt_cons_value_rec T ($dt_sum $dtc_unit d) $native_n_zero) T)
+  (($smtx_typeof_dt_cons_value_rec T ($dt_sum ($dtc_cons U c) d) $native_n_zero)
+    ($tsm_DtcAppType U ($smtx_typeof_dt_cons_value_rec T ($dt_sum c d) $native_n_zero)))
+  (($smtx_typeof_dt_cons_value_rec T ($dt_sum c d) ($native_n_succ n))
+    ($smtx_typeof_dt_cons_value_rec T d n))
+  (($smtx_typeof_dt_cons_value_rec T d n) $tsm_none)
+  )
+)
+
+(define $smtx_typeof_dt_cons_value
+  ((s $native_String) (dd $smt_DatatypeDecl) (n $native_Int))
+  ; substitute ($tsm_TypeRef s) to ($tsm_Datatype s dd), which ensures the
+  ; datatype we are processing is closed.
+  ($smtx_typeof_dt_cons_value_rec ($tsm_Datatype s dd) ($smtx_dd_resolve s dd) n))
+
+(program $smtx_typeof_dt_cons_rec
+  ((T $smt_Type) (U $smt_Type) (d $smt_Datatype) (c $smt_DatatypeCons) (n $native_Nat))
+  :signature ($smt_Type $smt_Datatype $native_Nat) $smt_Type
+  (
+  (($smtx_typeof_dt_cons_rec T ($dt_sum $dtc_unit d) $native_n_zero) T)
+  (($smtx_typeof_dt_cons_rec T ($dt_sum ($dtc_cons U c) d) $native_n_zero)
+    ($tsm_DtcAppType U ($smtx_typeof_dt_cons_rec T ($dt_sum c d) $native_n_zero)))
+  (($smtx_typeof_dt_cons_rec T ($dt_sum c d) ($native_n_succ n))
+    ($smtx_typeof_dt_cons_rec T d n))
+  (($smtx_typeof_dt_cons_rec T d n) $tsm_none)
+  )
+)
+
+; returns the return type of the selector n,m of datatype d.
+(program $smtx_ret_typeof_sel_rec
+  ((T $smt_Type) (n $native_Nat) (m $native_Nat) (c $smt_DatatypeCons) (d $smt_Datatype))
+  :signature ($smt_Datatype $native_Nat $native_Nat) $smt_Type
+  (
+  (($smtx_ret_typeof_sel_rec ($dt_sum ($dtc_cons T c) d) $native_n_zero $native_n_zero) T)
+  (($smtx_ret_typeof_sel_rec ($dt_sum ($dtc_cons T c) d) $native_n_zero ($native_n_succ m))
+    ($smtx_ret_typeof_sel_rec ($dt_sum c d) $native_n_zero m))
+  (($smtx_ret_typeof_sel_rec ($dt_sum c d) ($native_n_succ n) m)
+    ($smtx_ret_typeof_sel_rec d n m))
+  (($smtx_ret_typeof_sel_rec d n m) $tsm_none)
+  )
+)
+
+(program $smtx_ret_typeof_sel
+  ((s $native_String) (n $native_Nat) (m $native_Nat) (dd $smt_DatatypeDecl))
+  :signature ($native_String $smt_DatatypeDecl $native_Nat $native_Nat) $smt_Type
+  (
+  (($smtx_ret_typeof_sel s dd n m) ($smtx_ret_typeof_sel_rec ($smtx_dd_resolve s dd) n m))
+  )
+)
+
+; program: $smtx_typeof_apply_value
+(program $smtx_typeof_apply_value ((T $smt_Type) (U $smt_Type) (V $smt_Type))
+  :signature ($smt_Type $smt_Type) $smt_Type
+  (
+  ; Can partially apply datatype constructors but *not* functions or maps.
+  ; Datatype constructor applications are allowed, as they are Herbrand
+  ; interpretations.
+  (($smtx_typeof_apply_value ($tsm_DtcAppType T U) V)
+    ($smtx_typeof_guard T ($native_ite ($native_Teq T V) U $tsm_none)))
+  (($smtx_typeof_apply_value T U) $tsm_none)
+  )
+)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Type rules for values
+
+(program $smtx_typeof_value
+  ((v $smt_Value) (f $smt_Value) (dd $smt_DatatypeDecl)
+   (b $native_Bool) (w $native_Nat) (n $native_Int) (i $native_Nat) (e $native_Nat)
+   (q $native_Real) (s $native_String) (r $smt_RegLan) (c $native_Char)
+   (m $smt_Map) (ss $smt_Seq) (T $smt_Type) (U $smt_Type) (t $smt_Term))
+  :signature ($smt_Value) $smt_Type
+  (
+  (($smtx_typeof_value ($vsm_bool b))       $tsm_Bool)
+  (($smtx_typeof_value ($vsm_numeral n))    $tsm_Int)
+  (($smtx_typeof_value ($vsm_rational q))   $tsm_Real)
+  (($smtx_typeof_value ($vsm_binary w n))
+    ($native_ite 
+      ($native_and ($native_z_<= $native_z_zero w) ($native_z_= n ($native_mod_total n ($native_z_pow2 w))))
+      ($tsm_BitVec ($native_z_to_n w))
+      $tsm_none))
+  (($smtx_typeof_value ($vsm_re r))         $tsm_RegLan)
+  (($smtx_typeof_value ($vsm_map m))        ($smtx_typeof_map_value m))
+  (($smtx_typeof_value ($vsm_set m))        ($smtx_map_to_set_type ($smtx_typeof_map_value m)))
+  (($smtx_typeof_value ($vsm_fun i T U))    ($tsm_FunType T U))
+  (($smtx_typeof_value ($vsm_seq ss))       ($smtx_typeof_seq_value ss))
+  (($smtx_typeof_value ($vsm_char c))       ($native_ite ($native_apply_1 "char_valid" c) $tsm_Char $tsm_none))
+  (($smtx_typeof_value ($vsm_uvalue i e))   ($tsm_USort i))
+  ; not guarded by well-foundedness as this creates circular dependencies
+  (($smtx_typeof_value ($vsm_DtCons s dd i)) ($smtx_typeof_dt_cons_value s dd i))
+  (($smtx_typeof_value ($vsm_apply f v))
+    ($smtx_typeof_apply_value ($smtx_typeof_value f) ($smtx_typeof_value v)))
+  (($smtx_typeof_value v)                   $tsm_none)
+  )
+)
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Model semantics
+
+;;; Core
+
+; ITE branches to the appropriate child.
+; return: The evaluation of an ite application.
+(program $smtx_model_eval_ite
+  ((t1 $smt_Value) (t2 $smt_Value) (t3 $smt_Value))
+  :signature ($smt_Value $smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_ite $vsm_true t2 t3)   t2)
+  (($smtx_model_eval_ite $vsm_false t2 t3)  t3)
+  (($smtx_model_eval_ite t1 t2 t3)          $vsm_not_value)
+  )
+)
+
+; Equality insists on valueness and then reduces to an equality over datatypes
+; in the deep embedding (vsm.Value), meaning it works for all types, including
+; functions and uninterpreted sorts where values are not represented by terms.
+; Note that the valueness predicate ensures this is sound. Moreover note that
+; we do not invoke the type checker here. This means that if an ill-typed
+; equality was given as input to this method, it would always evaluate to false.
+; The caller of this method is responsible for ensuring that this behavior is
+; either avoided or admissible.
+; return: The evaluation of an equality application.
+(program $smtx_model_eval_=
+  ((v1 $smt_Value) (v2 $smt_Value) (f1 $smt_Value) (f2 $smt_Value)
+   (T1 $smt_Type) (T2 $smt_Type) (m1 $smt_Map) (m2 $smt_Map)
+   (vs1 $smt_Seq) (vs2 $smt_Seq) (r1 $smt_RegLan) (r2 $smt_RegLan))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_= ($vsm_re r1) ($vsm_re r2)) ($vsm_bool ($native_apply_2 "re_ext_eq" r1 r2)))
+  (($smtx_model_eval_= v1 v2) ($vsm_bool ($native_veq v1 v2)))
+  )
+)
+
+;;; Arithmetic
+
+;;; Functions, arrays
+
+;;; Sets
+
+; Empty set
+(define $smtx_empty_set ((T $smt_Type)) ($vsm_set ($msm_empty_set T)))
+
+;;; Sequences
+
+; Empty sequence
+(define $smtx_empty_seq ((T $smt_Type)) ($vsm_seq ($ssm_empty T)))
+
+;;; Apply
+
+; program: $smtx_model_eval_apply
+; We call ($smtx_model_eval_apply value_f value_i) when
+; evaluating (f i) whose values are value_f and value_i
+; respectively. If value_f is a map value, then we extract
+; the map and call the map lookup routine.
+(program $smtx_model_eval_apply
+  ((m $smt_Map) (i $smt_Value) (f $smt_Value) (v $smt_Value) (n $native_Nat)
+   (T $smt_Type) (U $smt_Type) (M $smt_Model)
+   (s $native_String) (dd $smt_DatatypeDecl) (T $smt_Type) (t $smt_Term))
+  :signature ($smt_Model $smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_apply M v $vsm_not_value)    $vsm_not_value)
+  ; If a Herbrand interpretation, apply it to the next value.
+  (($smtx_model_eval_apply M ($vsm_DtCons s dd n) i) ($vsm_apply ($vsm_DtCons s dd n) i))
+  (($smtx_model_eval_apply M ($vsm_apply f v) i) ($vsm_apply ($vsm_apply f v) i))
+  ; Call the native apply lookup
+  (($smtx_model_eval_apply M ($vsm_fun s T U) i)
+    ($native_apply_5 "eval_fun_apply" M s T U i))
+  ; The function did not evaluate to a map value, we fail.
+  (($smtx_model_eval_apply M v i)                 $vsm_not_value)
+  )
+)
+
+;;; Datatypes
+
+(program $smtx_model_eval_dt_sel
+  ((M $smt_Model) (n $native_Nat) (m $native_Nat) (v $smt_Value)
+   (s $native_String) (dd $smt_DatatypeDecl))
+  :signature ($smt_Model $native_String $smt_DatatypeDecl $native_Nat $native_Nat $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_dt_sel M s dd n m v)
+    ; check if the head of the apply term is ($vsm_DtCons s dd n)
+    ($native_ite ($native_veq ($vsm_apply_head v) ($vsm_DtCons s dd n))
+      ($vsm_apply_arg_nth v m ($smtx_dt_num_sels ($smtx_dd_lookup s dd) n))
+      ; wrongly applied selector
+      ; we introduce an uninterpreted function wrong_apply_sel : (-> Int Int D T)
+      ; where (wrong_apply_sel_id n m) is the uninterpreted function corresponding
+      ; to wrong applications of the m^th selector of the n^th constructor of the datatype of v.
+        ($smtx_model_eval_apply M
+          ($native_apply_3 "model_lookup" M ($native_apply_2 "wrong_apply_sel_id" n m)
+            ($tsm_FunType ($tsm_Datatype s dd) ($smtx_ret_typeof_sel s dd n m)))
+        v)))
+  )
+)
+
+(program $smtx_model_eval_dt_tester
+  ((s $native_String) (dd $smt_DatatypeDecl) (n $native_Nat) (v1 $smt_Value))
+  :signature ($native_String $smt_DatatypeDecl $native_Nat $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_dt_tester s dd n v1)
+    ; check if the head of the apply term is ($vsm_DtCons s dd n)
+    ($vsm_bool ($native_veq ($vsm_apply_head v1) ($vsm_DtCons s dd n))))
+  )
+)
+
+;;; Other model evaluation functions
+
+;$SMT_EVAL_PROGS_FWD_DECL$
+
+;$SMT_EVAL_PROGS$
+
+; An evaluator for all terms that we can reason about models.
+; This is a recursive call.
+; invariant: this must be a total function
+; invariant: unless this method returns $vsm_not_value, it must be such that
+;            it represents a unique SMT-LIB value, i.e. ($vsm_term t) is
+;            forbidden unless t denotes a value.
+(program $smtx_model_eval
+  ((M $smt_Model) (f $smt_Term) (v $smt_Value) (T $smt_Type) (dd $smt_DatatypeDecl)
+   (i $native_Nat) (j $native_Nat)
+   (b $native_Bool) (w $native_Nat) (n $native_Int)
+   (m $native_Int) (r $native_Real) (s $native_String)
+   ; generic parameters that may appear in terms to pattern match
+   (x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term) (x4 $smt_Term) (x5 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+
+  (($smtx_model_eval M ($sm_bool b))      ($vsm_bool b))
+  (($smtx_model_eval M ($sm_numeral n))   ($vsm_numeral n))
+  (($smtx_model_eval M ($sm_rational r))  ($vsm_rational r))
+  (($smtx_model_eval M ($sm_string s))    ($vsm_seq ($native_apply_1 "pack_string" s)))
+  (($smtx_model_eval M ($sm_binary w n))  ($vsm_binary w n))
+  ; evaluation of standard SMT symbols
+  ; These calls will reference helper methods above, e.g. of the form
+  ; $smtx_model_eval_*, or call builtin methods e.g. $smtx_eval_exists_rec.
+;$SMT_EVAL_CASES$
+  (($smtx_model_eval M ($sm_ite x1 x2 x3))
+    ($smtx_model_eval_ite ($smtx_model_eval M x1) ($smtx_model_eval M x2) ($smtx_model_eval M x3)))
+  (($smtx_model_eval M ($sm_= x1 x2))
+    ($smtx_model_eval_= ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  ; quantifiers
+  (($smtx_model_eval M ($sm_exists s T x1))
+    ($native_apply_4 "eval_texists" M s T x1))
+  (($smtx_model_eval M ($sm_forall s T x1))
+    ($native_apply_4 "eval_tforall" M s T x1))
+  (($smtx_model_eval M ($sm_choice s T x1))
+    ($native_apply_4 "eval_tchoice" M s T x1))
+  ; bind evaluates its body in the model extended with s bound to the value of
+  ; the first term.
+  (($smtx_model_eval M ($sm_bind s T x1 x2))
+    ($smtx_model_eval ($native_apply_4 "model_push" M s T ($smtx_model_eval M x1)) x2))
+  ; datatypes
+  (($smtx_model_eval M ($sm_DtCons s dd i)) ($vsm_DtCons s dd i))
+  (($smtx_model_eval M ($sm_apply ($sm_DtSel s dd i j) x1))
+    ($smtx_model_eval_dt_sel M s dd i j ($smtx_model_eval M x1)))
+  (($smtx_model_eval M ($sm_apply ($sm_DtTester s dd i) x1))
+    ($smtx_model_eval_dt_tester s dd i ($smtx_model_eval M x1)))
+  ; Apply case. We evaluate f and x1 separately and then call the
+  ; $smtx_model_eval_apply above. We expect f to be an uninterpreted
+  ; function whose model evaluation is an SMT-LIB map in this case.
+  ; All interpreted f should be handled in the evaluation cases above.
+  (($smtx_model_eval M ($sm_apply f x1))
+    ($smtx_model_eval_apply M ($smtx_model_eval M f) ($smtx_model_eval M x1)))
+  (($smtx_model_eval M ($sm_Var s T))     ($native_apply_3 "model_var_lookup" M s T))
+  (($smtx_model_eval M ($sm_UConst s T))  ($native_apply_3 "model_lookup" M s T))
+  (($smtx_model_eval M x1)   $vsm_not_value)
+  )
+)
+
+;;;;;;;;;;;;;;;;;;;;;;
+
+(program $smtx_typeof_ite ((T $smt_Type) (U $smt_Type) (V $smt_Type))
+  :signature ($smt_Type $smt_Type $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_ite $tsm_Bool U V) ($native_ite ($native_Teq U V) U $tsm_none))
+  (($smtx_typeof_ite T U V)         $tsm_none)
+  )
+)
+
+(program $smtx_typeof_= ((T $smt_Type) (U $smt_Type))
+  :signature ($smt_Type $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_= T U) ($smtx_typeof_guard T ($native_ite ($native_Teq T U) $tsm_Bool $tsm_none)))
+  )
+)
+
+(program $smtx_typeof_apply ((T $smt_Type) (U $smt_Type) (V $smt_Type))
+  :signature ($smt_Type $smt_Type) $smt_Type
+  (
+  ; only allowed to apply funs and datatype constructors
+  (($smtx_typeof_apply ($tsm_FunType T U) V)
+    ($smtx_typeof_guard T ($native_ite ($native_Teq T V) U $tsm_none)))
+  (($smtx_typeof_apply ($tsm_DtcAppType T U) V)
+    ($smtx_typeof_guard T ($native_ite ($native_Teq T V) U $tsm_none)))
+  (($smtx_typeof_apply T U)               $tsm_none)
+  )
+)
+
+;$SMT_TYPEOF_AUX$
+
+(program $smtx_typeof
+  ((M $smt_Model) (f $smt_Term) (T $smt_Type) (dd $smt_DatatypeDecl)
+   (i $native_Nat) (j $native_Nat)
+   (b $native_Bool) (w $native_Int) (n $native_Int)
+   (m $native_Int) (r $native_Real) (s $native_String)
+   ; generic parameters that may appear in terms to pattern match
+   (x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term) (x4 $smt_Term) (x5 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($smtx_typeof ($sm_bool b))      $tsm_Bool)
+  (($smtx_typeof ($sm_numeral n))   $tsm_Int)
+  (($smtx_typeof ($sm_rational r))  $tsm_Real)
+  (($smtx_typeof ($sm_string s))
+    ($native_ite ($native_apply_1 "string_valid" s) $tsm_String $tsm_none))
+  (($smtx_typeof ($sm_binary w n))
+    ; must be legal width and value
+    ($native_ite
+      ($native_and
+        ($native_z_<= $native_z_zero w)
+        ($native_z_= n ($native_mod_total n ($native_z_pow2 w))))
+      ($tsm_BitVec ($native_z_to_n w))
+      $tsm_none))
+;$SMT_TYPEOF_CASES$
+  (($smtx_typeof ($sm_ite x1 x2 x3))
+    ($smtx_typeof_ite ($smtx_typeof x1) ($smtx_typeof x2) ($smtx_typeof x3)))
+  (($smtx_typeof ($sm_= x1 x2))
+    ($smtx_typeof_= ($smtx_typeof x1) ($smtx_typeof x2)))
+  ; quantifiers
+  (($smtx_typeof ($sm_exists s T x1))
+    ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_Bool) ($smtx_typeof_guard_wf T $tsm_Bool) $tsm_none))
+  (($smtx_typeof ($sm_forall s T x1))
+    ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_Bool) ($smtx_typeof_guard_wf T $tsm_Bool) $tsm_none))
+  ; choice s:T. F has type T when F is Boolean and T is well-formed/inhabited.
+  (($smtx_typeof ($sm_choice s T x1))
+    ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_Bool) ($smtx_typeof_guard_wf T T) $tsm_none))
+  ; bind s:T := t1 in t2 has the type of t2, provided t1 has type T (so that
+  ; the binding is well-typed) and T is well-formed/inhabited.
+  (($smtx_typeof ($sm_bind s T x1 x2))
+    ($native_ite ($native_Teq ($smtx_typeof x1) T) ($smtx_typeof_guard_wf T ($smtx_typeof x2)) $tsm_none))
+  ; datatypes
+  (($smtx_typeof ($sm_DtCons s dd i))
+    ($smtx_typeof_guard_wf ($tsm_Datatype s dd)
+      ($smtx_typeof_dt_cons_rec ($tsm_Datatype s dd) ($smtx_dd_resolve s dd) i)))
+  (($smtx_typeof ($sm_apply ($sm_DtSel s dd i j) x1))
+    (eo::define ((ret ($smtx_ret_typeof_sel s dd i j)))
+    ($smtx_typeof_guard_wf ret
+      ($smtx_typeof_apply
+        ($tsm_FunType ($tsm_Datatype s dd) ret)
+        ($smtx_typeof x1)))))
+  (($smtx_typeof ($sm_apply ($sm_DtTester s dd i) x1))
+    ($smtx_typeof_guard
+      ; must be a valid constructor
+      ($smtx_typeof_dt_cons_rec ($tsm_Datatype s dd) ($smtx_dd_resolve s dd) i)
+      ($smtx_typeof_apply
+        ($tsm_FunType ($tsm_Datatype s dd) $tsm_Bool)
+        ($smtx_typeof x1))))
+  ; other
+  (($smtx_typeof ($sm_apply f x1))  ($smtx_typeof_apply ($smtx_typeof f) ($smtx_typeof x1)))
+  (($smtx_typeof ($sm_Var s T))     ($smtx_typeof_guard_wf T T))
+  (($smtx_typeof ($sm_UConst s T))  ($smtx_typeof_guard_wf T T))
+  (($smtx_typeof x1)   $tsm_none)
+  )
+)
+
+;;;;;;;;;;;;;;;;;;;;;;
+
+
+; The two aggregates are forward declared, since what a signature says about a
+; symbol may name either, and both are defined below.
+(program $eo_to_smt ((T Type)) :signature (T) $smt_Term)
+(program $eo_to_smt_type () :signature (Type) $smt_Type)
+
+; auxiliary definitions for defining $eo_to_smt / $eo_to_smt_type
+;$EO_TO_SMT_AUX$
+
+
+(program $eo_to_smt_datatype_cons ((U $eo_Term) (c $eo_DatatypeCons))
+  :signature ($eo_DatatypeCons) $smt_DatatypeCons
+  (
+  (($eo_to_smt_datatype_cons $edtc_unit) $dtc_unit)
+  (($eo_to_smt_datatype_cons ($edtc_cons U c))
+    ($dtc_cons ($eo_to_smt_type U) ($eo_to_smt_datatype_cons c)))
+  )
+)
+
+(program $eo_to_smt_datatype ((c $eo_DatatypeCons) (d $eo_Datatype))
+  :signature ($eo_Datatype) $smt_Datatype
+  (
+  (($eo_to_smt_datatype ($edt_sum c d))
+    ($dt_sum ($eo_to_smt_datatype_cons c) ($eo_to_smt_datatype d)))
+  (($eo_to_smt_datatype $edt_null) $dt_null)
+  )
+)
+
+(program $eo_to_smt_datatype_decl ((s $native_String) (d $eo_Datatype) (dd $eo_DatatypeDecl))
+  :signature ($eo_DatatypeDecl) $smt_DatatypeDecl
+  (
+  (($eo_to_smt_datatype_decl ($edd_cons s d dd))
+    ($dd_cons s ($eo_to_smt_datatype d) ($eo_to_smt_datatype_decl dd)))
+  (($eo_to_smt_datatype_decl $edd_nil) $dd_nil)
+  )
+)
+
+(program $eo_to_smt_type
+  ((T Type) (n1 $native_Int) (i $native_Nat) (s $native_String) (dd $eo_DatatypeDecl)
+  (T1 Type) (T2 Type) (T3 Type) (T4 Type) (T5 Type)
+  (x1 T1) (x2 T2) (x3 T3) (x4 T4) (x5 T5))
+  :signature (Type) $smt_Type
+  (
+  (($eo_to_smt_type Bool)                     $tsm_Bool)
+  (($eo_to_smt_type ($eot_DatatypeType s dd))
+    ($native_ite ($native_reserved_datatype_name s) $tsm_none
+      ($tsm_Datatype s ($eo_to_smt_datatype_decl dd))))
+  (($eo_to_smt_type ($eot_DatatypeTypeRef s))
+    ($native_ite ($native_reserved_datatype_name s) $tsm_none
+      ($tsm_TypeRef s)))
+  (($eo_to_smt_type ($eot_DtcAppType T1 T2))
+    (eo::define ((S1 ($eo_to_smt_type T1)))
+    (eo::define ((S2 ($eo_to_smt_type T2)))
+      ($smtx_typeof_guard S1 ($smtx_typeof_guard S2 ($tsm_DtcAppType S1 S2))))))
+  (($eo_to_smt_type ($eot_USort i))           ($tsm_USort i))
+  (($eo_to_smt_type (-> T1 T2))
+    (eo::define ((S1 ($eo_to_smt_type T1)))
+    (eo::define ((S2 ($eo_to_smt_type T2)))
+      ($smtx_typeof_guard S1 ($smtx_typeof_guard S2 ($tsm_FunType S1 S2))))))
+;$EO_TO_SMT_TYPE_CASES$
+  (($eo_to_smt_type T)                      $tsm_none)
+  )
+)
+
+(program $eo_to_smt
+  ((b $native_Bool) (n $native_Int) (m $native_Int) (r $native_Rat)
+   (s $native_String) (w $native_Int) (dd $eo_DatatypeDecl)
+   (T Type) (U Type) (T1 Type) (T2 Type) (T3 Type) (T4 Type) (T5 Type)
+   (f (-> U T)) (y U) (x1 T1) (x2 T2) (x3 T3) (x4 T4) (x5 T5)
+   (i $native_Nat) (j $native_Nat))
+  :signature (T) $smt_Term
+  (
+  (($eo_to_smt ($eot_bool b))        ($sm_bool b))
+  (($eo_to_smt ($eot_numeral n))     ($sm_numeral n))
+  (($eo_to_smt ($eot_rational r))    ($sm_rational r))
+  (($eo_to_smt ($eot_string s))      ($sm_string s))
+  (($eo_to_smt ($eot_binary w n))    ($sm_binary w n))
+  (($eo_to_smt ($eot_Var ($eot_string s) T))
+                                     ($sm_Var s ($eo_to_smt_type T)))
+  (($eo_to_smt ($eot_DtCons s dd i))
+    ($native_ite ($native_reserved_datatype_name s) $sm_none
+      ($sm_DtCons s ($eo_to_smt_datatype_decl dd) i)))
+  (($eo_to_smt ($eot_DtSel s dd i j))
+    ($native_ite ($native_reserved_datatype_name s) $sm_none
+      ($sm_DtSel s ($eo_to_smt_datatype_decl dd) i j)))
+  (($eo_to_smt ($eot_UConst i T))    ($sm_UConst ($native_to_uconst_id i) ($eo_to_smt_type T)))
+;$EO_TO_SMT_CASES$
+  (($eo_to_smt (f y))               ($sm_apply ($eo_to_smt f) ($eo_to_smt y)))
+  (($eo_to_smt y)                   $sm_none)
+  )
+)
+
+
+;;; Finiteness
+
+; The following computes whether a type has a bounded number of elements,
+; where the bound is determined by the flag u: if u is true, the type must
+; have exactly one element ("unit"), otherwise it must be finite.
+; For a datatype in declaration dd, we compute the set of bounded datatypes
+; of dd as a fixpoint: a declaration ddB (a sub-declaration of dd) is grown
+; by adding datatypes all of whose fields are bounded, where a reference
+; ($tsm_TypeRef s) is bounded iff s already occurs in ddB. The fixpoint is
+; reached after (at most) one pass per datatype in dd. Datatypes on reference
+; cycles never enter ddB, hence are correctly deemed infinite, while acyclic
+; references are resolved regardless of their order in the declaration.
+(program $smtx_type_bounded () :signature ($native_Bool $smt_Type) $native_Bool)
+
+
+(program $smtx_is_unit_type ((T $smt_Type))
+  :signature ($smt_Type) $native_Bool
+  (
+  (($smtx_is_unit_type T) ($smtx_type_bounded $native_true T))
+  )
+)
+
+(program $smtx_is_finite_type ((T $smt_Type))
+  :signature ($smt_Type) $native_Bool
+  (
+  (($smtx_is_finite_type T) ($smtx_type_bounded $native_false T))
+  )
+)
+
+(program $smtx_field_type_bounded
+  ((u $native_Bool) (s $native_String) (T $smt_Type) (ddB $smt_DatatypeDecl))
+  :signature ($native_Bool $smt_Type $smt_DatatypeDecl) $native_Bool
+  (
+  (($smtx_field_type_bounded u ($tsm_TypeRef s) ddB) ($smtx_dd_has_dt s ddB))
+  (($smtx_field_type_bounded u T ddB)                ($smtx_type_bounded u T))
+  )
+)
+
+(program $smtx_datatype_cons_bounded
+  ((u $native_Bool) (T $smt_Type) (c $smt_DatatypeCons) (ddB $smt_DatatypeDecl))
+  :signature ($native_Bool $smt_DatatypeCons $smt_DatatypeDecl) $native_Bool
+  (
+  (($smtx_datatype_cons_bounded u $dtc_unit ddB) $native_true)
+  (($smtx_datatype_cons_bounded u ($dtc_cons T c) ddB)
+    ($native_and ($smtx_field_type_bounded u T ddB)
+      ($smtx_datatype_cons_bounded u c ddB)))
+  )
+)
+
+; A unit datatype must have exactly one constructor, a finite datatype may
+; have any number of constructors.
+(program $smtx_datatype_bounded
+  ((u $native_Bool) (c $smt_DatatypeCons) (dF $smt_Datatype) (ddB $smt_DatatypeDecl))
+  :signature ($native_Bool $smt_Datatype $smt_DatatypeDecl) $native_Bool
+  (
+  (($smtx_datatype_bounded u ($dt_sum c $dt_null) ddB) ($smtx_datatype_cons_bounded u c ddB))
+  (($smtx_datatype_bounded u ($dt_sum c dF) ddB)
+    ($native_and ($native_not u)
+      ($native_and ($smtx_datatype_cons_bounded u c ddB) ($smtx_datatype_bounded u dF ddB))))
+  (($smtx_datatype_bounded u dF ddB) ($native_not u))
+  )
+)
+
+; One pass over the datatypes in the declaration being scanned, extending the
+; bounded set ddB with those datatypes that are bounded relative to ddB.
+(program $smtx_datatype_decl_bounded_step
+  ((u $native_Bool) (sF $native_String) (dF $smt_Datatype)
+   (ddR $smt_DatatypeDecl) (ddB $smt_DatatypeDecl))
+  :signature ($native_Bool $smt_DatatypeDecl $smt_DatatypeDecl) $smt_DatatypeDecl
+  (
+  (($smtx_datatype_decl_bounded_step u ($dd_cons sF dF ddR) ddB)
+    ($smtx_datatype_decl_bounded_step u ddR
+      ($native_ite
+        ($native_and ($native_not ($smtx_dd_has_dt sF ddB))
+          ($smtx_datatype_bounded u dF ddB))
+        ($dd_cons sF dF ddB) ddB)))
+  (($smtx_datatype_decl_bounded_step u $dd_nil ddB) ddB)
+  )
+)
+
+; Computes the set of bounded datatypes in dd, where ddC is the countdown of
+; remaining passes, initially dd itself.
+(program $smtx_datatype_decl_bounded
+  ((u $native_Bool) (sC $native_String) (dC $smt_Datatype) (ddC $smt_DatatypeDecl)
+   (dd $smt_DatatypeDecl) (ddB $smt_DatatypeDecl))
+  :signature ($native_Bool $smt_DatatypeDecl $smt_DatatypeDecl $smt_DatatypeDecl) $smt_DatatypeDecl
+  (
+  (($smtx_datatype_decl_bounded u ($dd_cons sC dC ddC) dd ddB)
+    ($smtx_datatype_decl_bounded u ddC dd ($smtx_datatype_decl_bounded_step u dd ddB)))
+  (($smtx_datatype_decl_bounded u $dd_nil dd ddB) ddB)
+  )
+)
+
+(program $smtx_type_bounded
+  ((u $native_Bool) (w $native_Nat) (T $smt_Type) (U $smt_Type)
+   (s $native_String) (dd $smt_DatatypeDecl))
+  :signature ($native_Bool $smt_Type) $native_Bool
+  (
+  (($smtx_type_bounded u $tsm_Bool)            ($native_not u))
+  (($smtx_type_bounded u ($tsm_BitVec w))      ($native_or ($native_not u) ($native_n_= w $native_n_zero)))
+  (($smtx_type_bounded u $tsm_Char)            ($native_not u))
+  (($smtx_type_bounded u ($tsm_Datatype s dd))
+    ($smtx_dd_has_dt s ($smtx_datatype_decl_bounded u dd dd $dd_nil)))
+  ; a map is unit iff its range is unit; it is also finite if both its domain
+  ; and range are finite
+  (($smtx_type_bounded u ($tsm_Map T U))
+    ($native_or ($smtx_type_bounded $native_true U)
+      ($native_and ($native_not u)
+        ($native_and ($smtx_type_bounded u T) ($smtx_type_bounded u U)))))
+  (($smtx_type_bounded u ($tsm_Set T))         ($native_and ($native_not u) ($smtx_type_bounded u T)))
+  ; note FunType is not extensional, thus assumed to be infinite
+  (($smtx_type_bounded u T)                    $native_false)
+  )
+)
+
+(program $smtx_type_default () :signature ($smt_Type) $smt_Value)
+(program $smtx_datatype_decl_default () :signature ($native_String $smt_DatatypeDecl $smt_DatatypeDecl) $smt_Value)
+
+(program $smtx_field_type_default
+  ((s $native_String) (T $smt_Type) (dd $smt_DatatypeDecl) (ddF $smt_DatatypeDecl))
+  :signature ($smt_DatatypeDecl $smt_Type $smt_DatatypeDecl) $smt_Value
+  (
+  (($smtx_field_type_default dd ($tsm_TypeRef s) ddF) ($smtx_datatype_decl_default s dd ddF))
+  (($smtx_field_type_default dd T ddF) ($smtx_type_default T))
+  )
+)
+
+(program $smtx_datatype_cons_default
+  ((v $smt_Value) (T $smt_Type) (c $smt_DatatypeCons) (dd $smt_DatatypeDecl) (ddF $smt_DatatypeDecl))
+  :signature ($smt_Value $smt_DatatypeDecl $smt_DatatypeCons $smt_DatatypeDecl) $smt_Value
+  (
+  (($smtx_datatype_cons_default v dd $dtc_unit ddF) v)
+  (($smtx_datatype_cons_default v dd ($dtc_cons T c) ddF)
+    (eo::define ((va ($smtx_field_type_default dd T ddF)))
+      ($native_ite ($native_veq va $vsm_not_value) $vsm_not_value
+        ($smtx_datatype_cons_default ($vsm_apply v va) dd c ddF))))
+  )
+)
+
+(program $smtx_datatype_default
+  ((s $native_String) (dd $smt_DatatypeDecl) (ddF $smt_DatatypeDecl) (dF $smt_Datatype)
+   (cF $smt_DatatypeCons) (n $native_Nat))
+  :signature ($native_String $smt_DatatypeDecl $native_Nat $smt_Datatype $smt_DatatypeDecl) $smt_Value
+  (
+  (($smtx_datatype_default s dd n ($dt_sum cF dF) ddF)
+    (eo::define ((v1 ($smtx_datatype_cons_default ($vsm_DtCons s dd n) dd cF ddF)))
+      ($native_ite ($native_not ($native_veq v1 $vsm_not_value))
+        v1
+        ($smtx_datatype_default s dd ($native_n_succ n) dF ddF))))
+  (($smtx_datatype_default s dd n dF ddF) $vsm_not_value)
+  )
+)
+
+(program $smtx_datatype_decl_default
+  ((s $native_String) (sF $native_String) (sU $native_String)
+   (dd $smt_DatatypeDecl) (ddF $smt_DatatypeDecl) (dF $smt_Datatype))
+  :signature ($native_String $smt_DatatypeDecl $smt_DatatypeDecl) $smt_Value
+  (
+  (($smtx_datatype_decl_default s dd ($dd_cons sF dF ddF))
+    ($native_ite ($native_str_= s sF)
+      ($smtx_datatype_default s dd $native_n_zero dF ddF)
+      ($smtx_datatype_decl_default s dd ddF)))
+  (($smtx_datatype_decl_default s dd ddF) $vsm_not_value)
+  )
+)
+
+; Returns the first term in an enumeration, assumes the type is finite.
+; Datatype constructors return the first that does not involve recursion.
+; Bool must return false to be compatible with sets
+(program $smtx_type_default
+  ((w $native_Nat) (V $smt_Type) (T $smt_Type) (U $smt_Type)
+   (s $native_String) (dd $smt_DatatypeDecl) (i $native_Nat))
+  :signature ($smt_Type) $smt_Value
+  (
+  (($smtx_type_default ($tsm_Datatype s dd))
+    ($smtx_datatype_decl_default s dd dd))
+  (($smtx_type_default $tsm_Bool)           $vsm_false)
+  (($smtx_type_default $tsm_Int)            ($vsm_numeral $native_z_zero))
+  (($smtx_type_default $tsm_Real)           ($vsm_rational $native_q_zero))
+  (($smtx_type_default $tsm_RegLan)         ($vsm_re ($native_apply_0 "re.none")))
+  (($smtx_type_default ($tsm_BitVec w))     ($vsm_binary ($native_n_to_z w) $native_z_zero))
+  (($smtx_type_default $tsm_Char)           ($vsm_char ($native_n_to_char $native_n_zero)))
+  (($smtx_type_default ($tsm_Map T U))
+    (eo::define ((u ($smtx_type_default U)))
+      ($native_ite ($native_veq u $vsm_not_value) $vsm_not_value ($vsm_map ($msm_default T u)))))
+  (($smtx_type_default ($tsm_Set T))        ($smtx_empty_set T))
+  (($smtx_type_default ($tsm_Seq T))        ($smtx_empty_seq T))
+  (($smtx_type_default ($tsm_USort i))      ($vsm_uvalue i $native_n_zero))
+  (($smtx_type_default ($tsm_FunType T U))  ($vsm_fun ($native_apply_0 "default_fun_id") T U))
+  (($smtx_type_default T) $vsm_not_value)
+  )
+)  
+
+;;; Canonicity of values
+
+(program $smtx_value_canonical_bool () :signature ($smt_Value) $native_Bool)
+
+(program $smtx_map_entries_ordered_after
+  ((i $smt_Value) (j $smt_Value) (e $smt_Value) (m $smt_Map))
+  :signature ($smt_Value $smt_Map) $native_Bool
+  (
+  (($smtx_map_entries_ordered_after i ($msm_cons j e m)) ($native_vcmp j i))
+  (($smtx_map_entries_ordered_after i m) $native_true)
+  )
+)
+
+(program $smtx_map_default_canonical ((T $smt_Type) (e $smt_Value))
+  :signature ($smt_Type $smt_Value) $native_Bool
+  (
+  (($smtx_map_default_canonical T e)
+    (eo::define ((U ($smtx_typeof_value e)))
+    ; if a finite type, it must have the canonical finite type default
+    ($native_ite ($smtx_is_finite_type T)
+      ($native_veq e ($smtx_type_default U))
+      $native_true)))
+  )
+)
+
+(program $smtx_map_canonical
+  ((T $smt_Type) (i $smt_Value) (e $smt_Value) (m $smt_Map))
+  :signature ($smt_Map) $native_Bool
+  (
+  (($smtx_map_canonical ($msm_default T e))
+    ($native_and ($smtx_map_default_canonical T e) ($smtx_value_canonical_bool e)))
+  (($smtx_map_canonical ($msm_cons i e m))
+    ($native_and
+      ($native_and
+        ($native_and
+          ($native_and
+            ($smtx_value_canonical_bool i)
+            ($smtx_value_canonical_bool e))
+          ($smtx_map_canonical m))
+        ($smtx_map_entries_ordered_after i m))
+      ($native_not ($native_veq e ($smtx_msm_get_default m)))))
+  )
+)
+
+(program $smtx_seq_canonical
+  ((T $smt_Type) (v $smt_Value) (s $smt_Seq))
+  :signature ($smt_Seq) $native_Bool
+  (
+  (($smtx_seq_canonical ($ssm_empty T)) $native_true)
+  (($smtx_seq_canonical ($ssm_cons v s))
+    ($native_and ($smtx_value_canonical_bool v) ($smtx_seq_canonical s)))
+  )
+)
+
+(program $smtx_value_canonical_bool
+  ((m $smt_Map) (s $smt_Seq) (f $smt_Value) (v $smt_Value) (w $native_Int)
+   (n $native_Int) (r $smt_RegLan) (c $native_Char))
+  :signature ($smt_Value) $native_Bool
+  (
+  (($smtx_value_canonical_bool ($vsm_binary w n))
+    ($native_ite ($native_z_<= $native_z_zero w)
+      ($native_z_= n ($native_mod_total n ($native_z_pow2 w)))
+      $native_true))
+  (($smtx_value_canonical_bool ($vsm_char c)) ($native_apply_1 "char_valid" c))
+  (($smtx_value_canonical_bool ($vsm_map m)) ($smtx_map_canonical m))
+  (($smtx_value_canonical_bool ($vsm_set m)) 
+    ($native_and ($smtx_map_canonical m) ($native_veq ($smtx_msm_get_default m) $vsm_false)))
+  (($smtx_value_canonical_bool ($vsm_seq s)) ($smtx_seq_canonical s))
+  (($smtx_value_canonical_bool ($vsm_re r)) ($native_apply_1 "re_canonical" r))
+  (($smtx_value_canonical_bool ($vsm_apply f v))
+    ($native_and
+      ($smtx_value_canonical_bool f)
+      ($smtx_value_canonical_bool v)))
+  (($smtx_value_canonical_bool v) $native_true)
+  )
+)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; model_end

--- a/plugins/model_smt/model_smt.h
+++ b/plugins/model_smt/model_smt.h
@@ -22,8 +22,6 @@
 
 namespace ethos {
 
-
-
 /**
  * Plugin that generates the EO layer for SMT-LIB model semantics.
  *
@@ -36,13 +34,12 @@ namespace ethos {
  * two signatures written directly in the deep embedding: the SMT-LIB one,
  * plugins/model_smt/smt_defs.eo, which is the target and so is fixed, and the
  * one of the input, which --defs names, e.g. plugins/model_smt/cpc_defs.eo for
- * CPC. Each is a
- * sequence of blocks, one per symbol, giving the constructor of the embedding
- * for it, the cases it contributes to `$smtx_typeof`, `$smtx_model_eval`,
- * `$eo_to_smt` and `$eo_to_smt_type`, and the programs those cases call. This
- * plugin names no symbol of any theory: it takes the blocks the input needs,
- * puts what each says where it belongs in the template, and checks that
- * nothing was left without a meaning.
+ * CPC. Each is a sequence of blocks, one per symbol, giving the constructor of
+ * the embedding for it, the cases it contributes to `$smtx_typeof`,
+ * `$smtx_model_eval`, `$eo_to_smt` and `$eo_to_smt_type`, and the programs
+ * those cases call. This plugin names no symbol of any theory: it takes the
+ * blocks the input needs, puts what each says where it belongs in the template,
+ * and checks that nothing was left without a meaning.
  *
  * So the work is:
  * - bind records what the input declares, in the order it declares it;
@@ -62,11 +59,14 @@ namespace ethos {
 class ModelSmt : public StdPlugin
 {
  public:
+  /** Construct the plugin with the bundled CPC input signature. */
+  ModelSmt(State& s);
   /**
-   * Construct the plugin. defsFile names the signature of the *input* written
-   * in the deep embedding, which says what each of its symbols means to the
-   * model; the SMT-LIB signature it is written against is fixed, being the
-   * target rather than a matter of the input. See loadDefs.
+   * Construct the plugin. defsFile is an absolute or working-directory-relative
+   * path to the signature of the *input* written in the deep embedding, which
+   * says what each of its symbols means to the model; the SMT-LIB signature it
+   * is written against is fixed, being the target rather than a matter of the
+   * input. See loadDefs.
    */
   ModelSmt(State& s, const std::string& defsFile);
   /** Destroy the model_smt plugin. */
@@ -77,7 +77,6 @@ class ModelSmt : public StdPlugin
   void finalize() override;
 
  private:
-
   /**
    * Read the signatures written directly in the deep embedding, take the
    * blocks the input needs, and put what each says where it belongs. A symbol
@@ -96,7 +95,7 @@ class ModelSmt : public StdPlugin
    * signatures cover or one no model needs; a symbol that is neither is an
    * error rather than a term the model would say nothing about.
    */
-  void finalizeDecl(const std::string& name, const Expr& e);
+  void finalizeDecl(const std::string& name);
   /** Forward declarations for SMT-LIB model-evaluation helper programs. */
   std::stringstream d_modelEvalProgsFwd;
   /** Auxiliary programs for SMT-LIB model evaluation. */

--- a/plugins/model_smt/model_smt.h
+++ b/plugins/model_smt/model_smt.h
@@ -33,13 +33,14 @@ namespace ethos {
  * What every symbol *means* to the model is not stated here. It is stated by
  * two signatures written directly in the deep embedding: the SMT-LIB one,
  * plugins/model_smt/smt_defs.eo, which is the target and so is fixed, and the
- * one of the input, which --defs names, e.g. plugins/model_smt/cpc_defs.eo for
- * CPC. Each is a sequence of blocks, one per symbol, giving the constructor of
- * the embedding for it, the cases it contributes to `$smtx_typeof`,
- * `$smtx_model_eval`, `$eo_to_smt` and `$eo_to_smt_type`, and the programs
- * those cases call. This plugin names no symbol of any theory: it takes the
- * blocks the input needs, puts what each says where it belongs in the template,
- * and checks that nothing was left without a meaning.
+ * one of the input, which is supplied at construction (the bundled CPC
+ * signature by default). Each is a sequence of blocks, one per symbol, giving
+ * the constructor of the embedding for it, the cases it contributes to
+ * `$smtx_typeof`, `$smtx_model_eval`, `$eo_to_smt` and `$eo_to_smt_type`, and
+ * the programs those cases call. The plugin algorithms contain no per-symbol
+ * model semantics: they take the blocks the input needs, put what each says
+ * where it belongs in the template, and check that nothing was left without a
+ * meaning.
  *
  * So the work is:
  * - bind records what the input declares, in the order it declares it;

--- a/plugins/model_smt/model_smt.h
+++ b/plugins/model_smt/model_smt.h
@@ -1,0 +1,126 @@
+/******************************************************************************
+ * This file is part of the ethos project.
+ *
+ * Copyright (c) 2023-2024 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ ******************************************************************************/
+#ifndef PLUGIN_MODEL_SMT_H
+#define PLUGIN_MODEL_SMT_H
+
+#include <map>
+#include <set>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <unordered_set>
+#include <vector>
+
+#include "../std_plugin.h"
+#include "defs_reader.h"
+
+namespace ethos {
+
+
+
+/**
+ * Plugin that generates the EO layer for SMT-LIB model semantics.
+ *
+ * It consumes the desugared EO signature and emits `model_smt_gen.eo`, which
+ * defines the model-evaluation machinery the SMT and Lean meta encoders use:
+ * the type language, the value language, and what each symbol of the input
+ * denotes in them.
+ *
+ * What every symbol *means* to the model is not stated here. It is stated by
+ * two signatures written directly in the deep embedding: the SMT-LIB one,
+ * plugins/model_smt/smt_defs.eo, which is the target and so is fixed, and the
+ * one of the input, which --defs names, e.g. plugins/model_smt/cpc_defs.eo for
+ * CPC. Each is a
+ * sequence of blocks, one per symbol, giving the constructor of the embedding
+ * for it, the cases it contributes to `$smtx_typeof`, `$smtx_model_eval`,
+ * `$eo_to_smt` and `$eo_to_smt_type`, and the programs those cases call. This
+ * plugin names no symbol of any theory: it takes the blocks the input needs,
+ * puts what each says where it belongs in the template, and checks that
+ * nothing was left without a meaning.
+ *
+ * So the work is:
+ * - bind records what the input declares, in the order it declares it;
+ * - loadDefs reads the two signatures, selects the blocks of the symbols the
+ *   input declares together with every block those name, and fills the streams
+ *   below from them;
+ * - finalizeDecl checks each declared symbol is covered, is internal, or is an
+ *   error, which is what keeps a verification condition from claiming to model
+ *   a symbol it says nothing about;
+ * - finalize substitutes the streams into plugins/model_smt/model_smt.eo.
+ *
+ * A constructor and a case are emitted in the order the input declares its
+ * symbols, since a case matches a head of its own and a constructor names
+ * nothing of another symbol. A program is emitted in that order as well, which
+ * it may because each evaluator is forward declared.
+ */
+class ModelSmt : public StdPlugin
+{
+ public:
+  /**
+   * Construct the plugin. defsFile names the signature of the *input* written
+   * in the deep embedding, which says what each of its symbols means to the
+   * model; the SMT-LIB signature it is written against is fixed, being the
+   * target rather than a matter of the input. See loadDefs.
+   */
+  ModelSmt(State& s, const std::string& defsFile);
+  /** Destroy the model_smt plugin. */
+  ~ModelSmt();
+  /** Remember constant declarations for model-semantics generation. */
+  void bind(const std::string& name, const Expr& e) override;
+  /** Emit the generated EO file containing SMT-LIB model semantics. */
+  void finalize() override;
+
+ private:
+
+  /**
+   * Read the signatures written directly in the deep embedding, take the
+   * blocks the input needs, and put what each says where it belongs. A symbol
+   * a block is of is one this plugin then says nothing about itself.
+   */
+  void loadDefs();
+  /** The signature of the input written in the deep embedding. */
+  std::string d_defsFile;
+  /** The blocks of each file, and the symbols they cover. */
+  DefsFile d_smtDefs;
+  DefsFile d_inputDefs;
+  std::set<std::string> d_defsCovered;
+
+  /**
+   * Check that the symbol named name, which the input declares, is one the
+   * signatures cover or one no model needs; a symbol that is neither is an
+   * error rather than a term the model would say nothing about.
+   */
+  void finalizeDecl(const std::string& name, const Expr& e);
+  /** Forward declarations for SMT-LIB model-evaluation helper programs. */
+  std::stringstream d_modelEvalProgsFwd;
+  /** Auxiliary programs for SMT-LIB model evaluation. */
+  std::stringstream d_modelEvalProgs;
+  /** SMT-LIB model evaluation cases */
+  std::stringstream d_eval;
+  /** Generated `$eo_to_smt` conversion cases. */
+  std::stringstream d_eoToSmt;
+  /** Generated `$eo_to_smt_type` conversion cases. */
+  std::stringstream d_eoToSmtType;
+  /** Auxiliary definitions used by EO-to-SMT conversion. */
+  std::stringstream d_eoToSmtAux;
+  /** Generated SMT term constructor declarations. */
+  std::stringstream d_smtTerms;
+  /** Generated SMT type rules for terms. */
+  std::stringstream d_smtTypeof;
+  /** Auxiliary definitions used by SMT type rules. */
+  std::stringstream d_smtTypeofAux;
+  /** Extra desugar helper definitions required by model_smt. */
+  std::stringstream d_desugarAux;
+  /** Constant declarations in parser order. */
+  std::vector<std::pair<std::string, Expr>> d_declSeen;
+};
+
+}  // namespace ethos
+
+#endif

--- a/plugins/model_smt/smt_defs.eo
+++ b/plugins/model_smt/smt_defs.eo
@@ -1,7 +1,7 @@
 ; The SMT-LIB signature written *directly* in the deep embedding.
 ;
 ; This is what the model-smt stage compiles the SMT-LIB half of a model from.
-; For each of the 128 symbols it covers it gives:
+; For each of the 130 symbols it covers it gives:
 ;
 ;   1. $emb_sm.X       the constructor of the embedding for X, together with
 ;                      the macro $sm_X that applies it;

--- a/plugins/model_smt/smt_defs.eo
+++ b/plugins/model_smt/smt_defs.eo
@@ -1,0 +1,3818 @@
+; The SMT-LIB signature written *directly* in the deep embedding.
+;
+; This is what the model-smt stage compiles the SMT-LIB half of a model from.
+; For each of the 128 symbols it covers it gives:
+;
+;   1. $emb_sm.X       the constructor of the embedding for X, together with
+;                      the macro $sm_X that applies it;
+;   2. $eoc_typeof_X  the cases X contributes to $smtx_typeof, i.e.
+;                        $smt_Term -> $smt_Type;
+;   3. $eoc_eval_X    the cases X contributes to $smtx_model_eval, i.e.
+;                        $smt_Model x $smt_Term -> $smt_Value;
+;   4. the auxiliary programs those cases call, $smtx_typeof_X,
+;      $smtx_model_eval_X and, where the answer is reached by counting down,
+;      $smtx_model_eval_X_rec. A case matches the *term*, so anything that
+;      inspects what an argument evaluates to is a program of its own.
+;
+; The stage that reads this file has only to concatenate the cases of every
+; $eoc_typeof_X into $smtx_typeof and of every $eoc_eval_X into
+; $smtx_model_eval, and to copy everything else through; it needs to know
+; nothing about any symbol here. A symbol comes after the ones its cases name,
+; e.g. div after div_total, whose value it is away from zero, so that nothing
+; here has to be declared before it is defined.
+;
+; Every case below is the one the model-smt stage generates today, copied as it
+; stands, so that what is compiled from this file is what is compiled now. Each
+; program declares the parameters its own cases name, and no others. Every name
+; here is the name the compiled output uses, so what is compiled from this file
+; is what is compiled now, bar the order the declarations come in.
+;
+; What stays in plugins/model_smt/model_smt.eo is the embedding itself, i.e.
+; every constructor that is not a symbol of the signature. Those are the
+; literals ($sm_bool, $sm_numeral, $sm_rational, $sm_string, $sm_binary), the
+; ones that bind a variable ($sm_forall, $sm_exists, $sm_choice, $sm_bind,
+; $sm_Var), the application and datatype constructors ($sm_apply, $sm_DtCons,
+; $sm_UConst), the two the stage treats as builtin ($sm_=, $sm_ite), the
+; operations the embedding has of its own ($sm_map_diff, $sm_seq_diff), and the
+; default case of each aggregate. Together they are the 20 cases of
+; $smtx_model_eval and of $smtx_typeof that this file does not give.
+;
+; This file is not included by anything yet.
+
+; -- not
+(declare-parameterized-const $emb_sm.not ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_not ((x1 $smt_Term)) ($emb_sm.not x1))
+(program $smtx_model_eval_not
+  ((x1 $native_Bool) (t1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_not ($vsm_bool x1)) ($vsm_bool ($native_apply_1 "not" x1)))
+  (($smtx_model_eval_not t1) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_not
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_not ($sm_not x1)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_Bool) $tsm_Bool $tsm_none))
+  )
+)
+(program $eoc_eval_not
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_not M ($sm_not x1)) ($smtx_model_eval_not ($smtx_model_eval M x1)))
+  )
+)
+
+; -- or
+(declare-parameterized-const $emb_sm.or ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_or ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.or x1 x2))
+(program $smtx_model_eval_or
+  ((x1 $native_Bool)(x2 $native_Bool) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_or ($vsm_bool x1) ($vsm_bool x2)) ($vsm_bool ($native_apply_2 "or" x1 x2)))
+  (($smtx_model_eval_or t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_or
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_or ($sm_or x1 x2)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_Bool) ($native_ite ($native_Teq ($smtx_typeof x2) $tsm_Bool) $tsm_Bool $tsm_none) $tsm_none))
+  )
+)
+(program $eoc_eval_or
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_or M ($sm_or x1 x2)) ($smtx_model_eval_or ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- and
+(declare-parameterized-const $emb_sm.and ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_and ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.and x1 x2))
+(program $smtx_model_eval_and
+  ((x1 $native_Bool)(x2 $native_Bool) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_and ($vsm_bool x1) ($vsm_bool x2)) ($vsm_bool ($native_apply_2 "and" x1 x2)))
+  (($smtx_model_eval_and t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_and
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_and ($sm_and x1 x2)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_Bool) ($native_ite ($native_Teq ($smtx_typeof x2) $tsm_Bool) $tsm_Bool $tsm_none) $tsm_none))
+  )
+)
+(program $eoc_eval_and
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_and M ($sm_and x1 x2)) ($smtx_model_eval_and ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- =>
+(declare-parameterized-const $emb_sm.=> ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_=> ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.=> x1 x2))
+(program $smtx_model_eval_=>
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_=> x1 x2) ($smtx_model_eval_or ($smtx_model_eval_not x1) x2))
+  )
+)
+(program $eoc_typeof_=>
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_=> ($sm_=> x1 x2)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_Bool) ($native_ite ($native_Teq ($smtx_typeof x2) $tsm_Bool) $tsm_Bool $tsm_none) $tsm_none))
+  )
+)
+(program $eoc_eval_=>
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_=> M ($sm_=> x1 x2)) ($smtx_model_eval_=> ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- xor
+(declare-parameterized-const $emb_sm.xor ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_xor ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.xor x1 x2))
+(program $smtx_model_eval_xor
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_xor x1 x2) ($smtx_model_eval_not ($smtx_model_eval_= x1 x2)))
+  )
+)
+(program $eoc_typeof_xor
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_xor ($sm_xor x1 x2)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_Bool) ($native_ite ($native_Teq ($smtx_typeof x2) $tsm_Bool) $tsm_Bool $tsm_none) $tsm_none))
+  )
+)
+(program $eoc_eval_xor
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_xor M ($sm_xor x1 x2)) ($smtx_model_eval_xor ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- @purify
+(declare-parameterized-const $emb_sm.@purify ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_@purify ((x1 $smt_Term)) ($emb_sm.@purify x1))
+(program $smtx_model_eval_@purify
+  ((x1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_@purify x1) x1)
+  )
+)
+(program $eoc_typeof_@purify
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_@purify ($sm_@purify x1)) ($smtx_typeof x1))
+  )
+)
+(program $eoc_eval_@purify
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_@purify M ($sm_@purify x1)) ($smtx_model_eval_@purify ($smtx_model_eval M x1)))
+  )
+)
+
+; -- $smtx_typeof_arith_overload_op_2
+; The same, for two arguments, which must be of one of those types.
+(program $smtx_typeof_arith_overload_op_2
+  ((T $smt_Type) (U $smt_Type))
+  :signature ($smt_Type $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_arith_overload_op_2 $tsm_Int $tsm_Int) $tsm_Int)
+  (($smtx_typeof_arith_overload_op_2 $tsm_Real $tsm_Real) $tsm_Real)
+  (($smtx_typeof_arith_overload_op_2 T U) $tsm_none)
+  )
+)
+
+; -- +
+(declare-parameterized-const $emb_sm.+ ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_+ ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.+ x1 x2))
+(program $smtx_model_eval_+
+  ((x1 $native_Int)(x2 $native_Int) (x3 $native_Real) (x4 $native_Real) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_+ ($vsm_numeral x1) ($vsm_numeral x2)) ($vsm_numeral ($native_z_+ x1 x2)))
+  (($smtx_model_eval_+ ($vsm_rational x3) ($vsm_rational x4)) ($vsm_rational ($native_q_+ x3 x4)))
+  (($smtx_model_eval_+ t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_+
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_+ ($sm_+ x1 x2)) ($smtx_typeof_arith_overload_op_2 ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_+
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_+ M ($sm_+ x1 x2)) ($smtx_model_eval_+ ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- -
+(declare-parameterized-const $emb_sm.- ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_- ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.- x1 x2))
+(program $smtx_model_eval_-
+  ((x1 $native_Int)(x2 $native_Int) (x3 $native_Real) (x4 $native_Real) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_- ($vsm_numeral x1) ($vsm_numeral x2)) ($vsm_numeral ($native_z_- x1 x2)))
+  (($smtx_model_eval_- ($vsm_rational x3) ($vsm_rational x4)) ($vsm_rational ($native_q_- x3 x4)))
+  (($smtx_model_eval_- t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_-
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_- ($sm_- x1 x2)) ($smtx_typeof_arith_overload_op_2 ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_-
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_- M ($sm_- x1 x2)) ($smtx_model_eval_- ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- *
+(declare-parameterized-const $emb_sm.* ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_* ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.* x1 x2))
+(program $smtx_model_eval_*
+  ((x1 $native_Int)(x2 $native_Int) (x3 $native_Real) (x4 $native_Real) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_* ($vsm_numeral x1) ($vsm_numeral x2)) ($vsm_numeral ($native_z_* x1 x2)))
+  (($smtx_model_eval_* ($vsm_rational x3) ($vsm_rational x4)) ($vsm_rational ($native_q_* x3 x4)))
+  (($smtx_model_eval_* t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_*
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_* ($sm_* x1 x2)) ($smtx_typeof_arith_overload_op_2 ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_*
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_* M ($sm_* x1 x2)) ($smtx_model_eval_* ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- $smtx_typeof_arith_overload_op_2_ret
+; The same, for one that returns a type given rather than its arguments'.
+(program $smtx_typeof_arith_overload_op_2_ret
+  ((T $smt_Type) (U $smt_Type) (V $smt_Type))
+  :signature ($smt_Type $smt_Type $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_arith_overload_op_2_ret $tsm_Int $tsm_Int T) T)
+  (($smtx_typeof_arith_overload_op_2_ret $tsm_Real $tsm_Real T) T)
+  (($smtx_typeof_arith_overload_op_2_ret T U V) $tsm_none)
+  )
+)
+
+; -- <
+(declare-parameterized-const $emb_sm.< ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_< ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.< x1 x2))
+(program $smtx_model_eval_<
+  ((x1 $native_Int)(x2 $native_Int) (x3 $native_Real) (x4 $native_Real) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_< ($vsm_numeral x1) ($vsm_numeral x2)) ($vsm_bool ($native_z_< x1 x2)))
+  (($smtx_model_eval_< ($vsm_rational x3) ($vsm_rational x4)) ($vsm_bool ($native_q_< x3 x4)))
+  (($smtx_model_eval_< t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_<
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_< ($sm_< x1 x2)) ($smtx_typeof_arith_overload_op_2_ret ($smtx_typeof x1) ($smtx_typeof x2) $tsm_Bool))
+  )
+)
+(program $eoc_eval_<
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_< M ($sm_< x1 x2)) ($smtx_model_eval_< ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- <=
+(declare-parameterized-const $emb_sm.<= ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_<= ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.<= x1 x2))
+(program $smtx_model_eval_<=
+  ((x1 $native_Int)(x2 $native_Int) (x3 $native_Real) (x4 $native_Real) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_<= ($vsm_numeral x1) ($vsm_numeral x2)) ($vsm_bool ($native_z_<= x1 x2)))
+  (($smtx_model_eval_<= ($vsm_rational x3) ($vsm_rational x4)) ($vsm_bool ($native_q_<= x3 x4)))
+  (($smtx_model_eval_<= t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_<=
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_<= ($sm_<= x1 x2)) ($smtx_typeof_arith_overload_op_2_ret ($smtx_typeof x1) ($smtx_typeof x2) $tsm_Bool))
+  )
+)
+(program $eoc_eval_<=
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_<= M ($sm_<= x1 x2)) ($smtx_model_eval_<= ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- >
+(declare-parameterized-const $emb_sm.> ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_> ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.> x1 x2))
+(program $smtx_model_eval_>
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_> x1 x2) ($smtx_model_eval_< x2 x1))
+  )
+)
+(program $eoc_typeof_>
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_> ($sm_> x1 x2)) ($smtx_typeof_arith_overload_op_2_ret ($smtx_typeof x1) ($smtx_typeof x2) $tsm_Bool))
+  )
+)
+(program $eoc_eval_>
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_> M ($sm_> x1 x2)) ($smtx_model_eval_> ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- >=
+(declare-parameterized-const $emb_sm.>= ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_>= ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.>= x1 x2))
+(program $smtx_model_eval_>=
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_>= x1 x2) ($smtx_model_eval_<= x2 x1))
+  )
+)
+(program $eoc_typeof_>=
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_>= ($sm_>= x1 x2)) ($smtx_typeof_arith_overload_op_2_ret ($smtx_typeof x1) ($smtx_typeof x2) $tsm_Bool))
+  )
+)
+(program $eoc_eval_>=
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_>= M ($sm_>= x1 x2)) ($smtx_model_eval_>= ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- to_real
+(declare-parameterized-const $emb_sm.to_real ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_to_real ((x1 $smt_Term)) ($emb_sm.to_real x1))
+(program $smtx_model_eval_to_real
+  ((x1 $native_Int) (t1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_to_real ($vsm_numeral x1)) ($vsm_rational ($native_apply_1 "to_real" x1)))
+  (($smtx_model_eval_to_real t1) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_to_real
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_to_real ($sm_to_real x1)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_Int) $tsm_Real $tsm_none))
+  )
+)
+(program $eoc_eval_to_real
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_to_real M ($sm_to_real x1)) ($smtx_model_eval_to_real ($smtx_model_eval M x1)))
+  )
+)
+
+; -- to_int
+(declare-parameterized-const $emb_sm.to_int ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_to_int ((x1 $smt_Term)) ($emb_sm.to_int x1))
+(program $smtx_model_eval_to_int
+  ((x1 $native_Real) (t1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_to_int ($vsm_rational x1)) ($vsm_numeral ($native_apply_1 "to_int" x1)))
+  (($smtx_model_eval_to_int t1) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_to_int
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_to_int ($sm_to_int x1)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_Real) $tsm_Int $tsm_none))
+  )
+)
+(program $eoc_eval_to_int
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_to_int M ($sm_to_int x1)) ($smtx_model_eval_to_int ($smtx_model_eval M x1)))
+  )
+)
+
+; -- is_int
+(declare-parameterized-const $emb_sm.is_int ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_is_int ((x1 $smt_Term)) ($emb_sm.is_int x1))
+(program $smtx_model_eval_is_int
+  ((x1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_is_int x1) ($smtx_model_eval_= ($smtx_model_eval_to_real ($smtx_model_eval_to_int x1)) x1))
+  )
+)
+(program $eoc_typeof_is_int
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_is_int ($sm_is_int x1)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_Real) $tsm_Bool $tsm_none))
+  )
+)
+(program $eoc_eval_is_int
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_is_int M ($sm_is_int x1)) ($smtx_model_eval_is_int ($smtx_model_eval M x1)))
+  )
+)
+
+; -- $smtx_typeof_arith_overload_op_1
+; The type of an arithmetic operator that returns what its argument is, which is Int or Real.
+(program $smtx_typeof_arith_overload_op_1 ((T $smt_Type))
+  :signature ($smt_Type) $smt_Type
+  (
+  (($smtx_typeof_arith_overload_op_1 $tsm_Int) $tsm_Int)
+  (($smtx_typeof_arith_overload_op_1 $tsm_Real) $tsm_Real)
+  (($smtx_typeof_arith_overload_op_1 T) $tsm_none)
+  )
+)
+
+; -- abs
+(declare-parameterized-const $emb_sm.abs ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_abs ((x1 $smt_Term)) ($emb_sm.abs x1))
+(program $smtx_model_eval_abs
+  ((x1 $native_Int)(x2 $native_Real) (t1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_abs ($vsm_numeral x1)) ($vsm_numeral ($native_z_abs x1)))
+  (($smtx_model_eval_abs ($vsm_rational x2)) ($vsm_rational ($native_q_abs x2)))
+  (($smtx_model_eval_abs t1) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_abs
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_abs ($sm_abs x1)) ($smtx_typeof_arith_overload_op_1 ($smtx_typeof x1)))
+  )
+)
+(program $eoc_eval_abs
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_abs M ($sm_abs x1)) ($smtx_model_eval_abs ($smtx_model_eval M x1)))
+  )
+)
+
+; -- uneg
+(declare-parameterized-const $emb_sm.uneg ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_uneg ((x1 $smt_Term)) ($emb_sm.uneg x1))
+(program $smtx_model_eval_uneg
+  ((x1 $native_Int)(x2 $native_Real) (t1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_uneg ($vsm_numeral x1)) ($vsm_numeral ($native_z_uneg x1)))
+  (($smtx_model_eval_uneg ($vsm_rational x2)) ($vsm_rational ($native_q_uneg x2)))
+  (($smtx_model_eval_uneg t1) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_uneg
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_uneg ($sm_uneg x1)) ($smtx_typeof_arith_overload_op_1 ($smtx_typeof x1)))
+  )
+)
+(program $eoc_eval_uneg
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_uneg M ($sm_uneg x1)) ($smtx_model_eval_uneg ($smtx_model_eval M x1)))
+  )
+)
+
+; -- div_total
+(declare-parameterized-const $emb_sm.div_total ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_div_total ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.div_total x1 x2))
+(program $smtx_model_eval_div_total
+  ((x1 $native_Int)(x2 $native_Int) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_div_total ($vsm_numeral x1) ($vsm_numeral x2)) ($vsm_numeral ($native_apply_2 "div_total" x1 x2)))
+  (($smtx_model_eval_div_total t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_div_total
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_div_total ($sm_div_total x1 x2)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_Int) ($native_ite ($native_Teq ($smtx_typeof x2) $tsm_Int) $tsm_Int $tsm_none) $tsm_none))
+  )
+)
+(program $eoc_eval_div_total
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_div_total M ($sm_div_total x1 x2)) ($smtx_model_eval_div_total ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- div
+(declare-parameterized-const $emb_sm.div ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_div ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.div x1 x2))
+(program $eoc_typeof_div
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_div ($sm_div x1 x2)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_Int) ($native_ite ($native_Teq ($smtx_typeof x2) $tsm_Int) $tsm_Int $tsm_none) $tsm_none))
+  )
+)
+(program $eoc_eval_div
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_div M ($sm_div x1 x2)) (eo::define ((e1 ($smtx_model_eval M x1))) (eo::define ((e2 ($smtx_model_eval M x2))) ($smtx_model_eval_ite ($smtx_model_eval_= e2 $vsm_z_zero) ($smtx_model_eval_apply M ($native_apply_3 "model_lookup" M ($native_apply_0 "div_by_zero_id") ($emb_tsm.FunType $emb_tsm.Int $emb_tsm.Int)) e1) ($smtx_model_eval_div_total e1 e2)))))
+  )
+)
+
+; -- mod_total
+(declare-parameterized-const $emb_sm.mod_total ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_mod_total ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.mod_total x1 x2))
+(program $smtx_model_eval_mod_total
+  ((x1 $native_Int)(x2 $native_Int) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_mod_total ($vsm_numeral x1) ($vsm_numeral x2)) ($vsm_numeral ($native_apply_2 "mod_total" x1 x2)))
+  (($smtx_model_eval_mod_total t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_mod_total
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_mod_total ($sm_mod_total x1 x2)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_Int) ($native_ite ($native_Teq ($smtx_typeof x2) $tsm_Int) $tsm_Int $tsm_none) $tsm_none))
+  )
+)
+(program $eoc_eval_mod_total
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_mod_total M ($sm_mod_total x1 x2)) ($smtx_model_eval_mod_total ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- mod
+(declare-parameterized-const $emb_sm.mod ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_mod ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.mod x1 x2))
+(program $eoc_typeof_mod
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_mod ($sm_mod x1 x2)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_Int) ($native_ite ($native_Teq ($smtx_typeof x2) $tsm_Int) $tsm_Int $tsm_none) $tsm_none))
+  )
+)
+(program $eoc_eval_mod
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_mod M ($sm_mod x1 x2)) (eo::define ((e1 ($smtx_model_eval M x1))) (eo::define ((e2 ($smtx_model_eval M x2))) ($smtx_model_eval_ite ($smtx_model_eval_= e2 $vsm_z_zero) ($smtx_model_eval_apply M ($native_apply_3 "model_lookup" M ($native_apply_0 "mod_by_zero_id") ($emb_tsm.FunType $emb_tsm.Int $emb_tsm.Int)) e1) ($smtx_model_eval_mod_total e1 e2)))))
+  )
+)
+
+; -- divisible
+(declare-parameterized-const $emb_sm.divisible ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_divisible ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.divisible x1 x2))
+(program $smtx_model_eval_divisible
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_divisible x1 x2) ($smtx_model_eval_= ($smtx_model_eval_mod_total x2 x1) $vsm_z_zero))
+  )
+)
+(program $eoc_typeof_divisible
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_divisible ($sm_divisible x1 x2)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_Int) ($native_ite ($native_Teq ($smtx_typeof x2) $tsm_Int) $tsm_Bool $tsm_none) $tsm_none))
+  )
+)
+(program $eoc_eval_divisible
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_divisible M ($sm_divisible x1 x2)) ($smtx_model_eval_divisible ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- int.pow2
+(declare-parameterized-const $emb_sm.int.pow2 ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_int.pow2 ((x1 $smt_Term)) ($emb_sm.int.pow2 x1))
+(program $smtx_model_eval_int.pow2
+  ((x1 $native_Int) (t1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_int.pow2 ($vsm_numeral x1)) ($vsm_numeral ($native_apply_1 "int.pow2" x1)))
+  (($smtx_model_eval_int.pow2 t1) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_int.pow2
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_int.pow2 ($sm_int.pow2 x1)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_Int) $tsm_Int $tsm_none))
+  )
+)
+(program $eoc_eval_int.pow2
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_int.pow2 M ($sm_int.pow2 x1)) ($smtx_model_eval_int.pow2 ($smtx_model_eval M x1)))
+  )
+)
+
+; -- int.log2
+(declare-parameterized-const $emb_sm.int.log2 ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_int.log2 ((x1 $smt_Term)) ($emb_sm.int.log2 x1))
+(program $smtx_model_eval_int.log2
+  ((x1 $native_Int) (t1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_int.log2 ($vsm_numeral x1)) ($vsm_numeral ($native_apply_1 "int.log2" x1)))
+  (($smtx_model_eval_int.log2 t1) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_int.log2
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_int.log2 ($sm_int.log2 x1)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_Int) $tsm_Int $tsm_none))
+  )
+)
+(program $eoc_eval_int.log2
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_int.log2 M ($sm_int.log2 x1)) ($smtx_model_eval_int.log2 ($smtx_model_eval M x1)))
+  )
+)
+
+; -- $smtx_map_select
+; Reading a map, a set or a sequence at an index, which are all maps.
+(program $smtx_map_select
+  ((v $smt_Value) (i $smt_Value) (m $smt_Map))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_map_select ($vsm_map m) i) ($smtx_msm_lookup m i))
+  (($smtx_map_select ($vsm_set m) i) ($smtx_msm_lookup m i))
+  (($smtx_map_select v i)            $vsm_not_value)
+  )
+)
+
+; -- select
+(declare-parameterized-const $emb_sm.select ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_select ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.select x1 x2))
+(program $smtx_typeof_select ( (x1 $smt_Type) (x2 $smt_Type)  (x3 $smt_Type)  (x4 $smt_Type)  (x5 $smt_Type))
+  :signature ($smt_Type $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_select ($tsm_Array x1 x2) x3) ($native_ite ($native_Teq x1 x3) x2 $tsm_none))
+  (($smtx_typeof_select x4 x5) $tsm_none)
+  )
+)
+(program $smtx_model_eval_select
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_select x1 x2) ($smtx_map_select x1 x2))
+  )
+)
+(program $eoc_typeof_select
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_select ($sm_select x1 x2))  ($smtx_typeof_select ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_select
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_select M ($sm_select x1 x2)) ($smtx_model_eval_select ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- store
+; Array store
+(program $smtx_map_store
+  ((v $smt_Value) (i $smt_Value) (e $smt_Value) (m $smt_Map))
+  :signature ($smt_Value $smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_map_store ($vsm_map m) i e) ($vsm_map ($smtx_msm_update m i e)))
+  (($smtx_map_store ($vsm_set m) i e) ($vsm_set ($smtx_msm_update m i e)))
+  (($smtx_map_store v i e)            $vsm_not_value)
+  )
+)
+
+(declare-parameterized-const $emb_sm.store ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque) (x3 $smt_Term :opaque)) $smt_Term)
+(define $sm_store ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term)) ($emb_sm.store x1 x2 x3))
+(program $smtx_typeof_store ( (x1 $smt_Type) (x2 $smt_Type)  (x3 $smt_Type)  (x4 $smt_Type)  (x5 $smt_Type)  (x6 $smt_Type)  (x7 $smt_Type))
+  :signature ($smt_Type $smt_Type $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_store ($tsm_Array x1 x2) x3 x4) ($native_ite ($native_Teq x1 x3) ($native_ite ($native_Teq x2 x4) ($tsm_Array x1 x2) $tsm_none) $tsm_none))
+  (($smtx_typeof_store x5 x6 x7) $tsm_none)
+  )
+)
+(program $smtx_model_eval_store
+  ((x1 $smt_Value)(x2 $smt_Value) (x3 $smt_Value))
+  :signature ($smt_Value $smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_store x1 x2 x3) ($smtx_map_store x1 x2 x3))
+  )
+)
+(program $eoc_typeof_store
+  ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_store ($sm_store x1 x2 x3))  ($smtx_typeof_store ($smtx_typeof x1) ($smtx_typeof x2) ($smtx_typeof x3)))
+  )
+)
+(program $eoc_eval_store
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_store M ($sm_store x1 x2 x3)) ($smtx_model_eval_store ($smtx_model_eval M x1) ($smtx_model_eval M x2) ($smtx_model_eval M x3)))
+  )
+)
+
+; -- concat
+(declare-parameterized-const $emb_sm.concat ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_concat ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.concat x1 x2))
+(program $smtx_typeof_concat ( (x1 $native_Int) (x2 $native_Int)  (x3 $smt_Type)  (x4 $smt_Type))
+  :signature ($smt_Type $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_concat ($tsm_BitVec x1) ($tsm_BitVec x2)) ($tsm_BitVec ($native_apply_1 "int.to_nat" ($native_apply_2 "zplus" ($native_apply_1 "nat.to_int" x1) ($native_apply_1 "nat.to_int" x2)))))
+  (($smtx_typeof_concat x3 x4) $tsm_none)
+  )
+)
+(program $smtx_model_eval_concat
+  ((x1 $native_Int) (x2 $native_Int) (x3 $native_Int) (x4 $native_Int) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_concat ($vsm_binary x1 x2) ($vsm_binary x3 x4)) ($emb_vsm.Binary ($native_apply_2 "zplus" x1 x3) ($native_apply_2 "mod_total" ($native_apply_4 "binary_concat" x1 x2 x3 x4) ($native_apply_1 "int.pow2" ($native_apply_2 "zplus" x1 x3)))))
+  (($smtx_model_eval_concat t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_concat
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_concat ($sm_concat x1 x2))  ($smtx_typeof_concat ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_concat
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_concat M ($sm_concat x1 x2)) ($smtx_model_eval_concat ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- extract
+(declare-parameterized-const $emb_sm.extract ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque) (x3 $smt_Term :opaque)) $smt_Term)
+(define $sm_extract ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term)) ($emb_sm.extract x1 x2 x3))
+(program $smtx_typeof_extract ( (x1 $native_Int) (x2 $native_Int)  (x3 $native_Int)  (x4 $smt_Type)  (x5 $smt_Type)  (x6 $smt_Type))
+  :signature ($smt_Term $smt_Term $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_extract ($sm_numeral x1) ($sm_numeral x2) ($tsm_BitVec x3)) ($native_ite ($native_apply_2 "zleq" ($native_apply_0 "0") x2) ($native_ite ($native_apply_2 "zlt" x1 ($native_apply_1 "nat.to_int" x3)) ($native_ite ($native_apply_2 "zlt" ($native_apply_0 "0") ($native_apply_2 "zplus" ($native_apply_2 "zplus" x1 ($native_apply_0 "1")) ($native_apply_1 "zneg" x2))) ($tsm_BitVec ($native_apply_1 "int.to_nat" ($native_apply_2 "zplus" ($native_apply_2 "zplus" x1 ($native_apply_0 "1")) ($native_apply_1 "zneg" x2)))) $tsm_none) $tsm_none) $tsm_none))
+  (($smtx_typeof_extract x4 x5 x6) $tsm_none)
+  )
+)
+(program $smtx_model_eval_extract
+  ((x1 $native_Int)(x2 $native_Int) (x3 $native_Int) (x4 $native_Int) (t1 $smt_Value) (t2 $smt_Value) (t3 $smt_Value))
+  :signature ($smt_Value $smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_extract ($vsm_numeral x1) ($vsm_numeral x2) ($vsm_binary x3 x4)) ($emb_vsm.Binary ($native_apply_2 "zplus" ($native_apply_2 "zplus" x1 ($native_apply_0 "1")) ($native_apply_1 "zneg" x2)) ($native_apply_2 "mod_total" ($native_apply_4 "binary_extract" x3 x4 x1 x2) ($native_apply_1 "int.pow2" ($native_apply_2 "zplus" ($native_apply_2 "zplus" x1 ($native_apply_0 "1")) ($native_apply_1 "zneg" x2))))))
+  (($smtx_model_eval_extract t1 t2 t3) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_extract
+  ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_extract ($sm_extract x1 x2 x3))  ($smtx_typeof_extract x1 x2 ($smtx_typeof x3)))
+  )
+)
+(program $eoc_eval_extract
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_extract M ($sm_extract x1 x2 x3)) ($smtx_model_eval_extract ($smtx_model_eval M x1) ($smtx_model_eval M x2) ($smtx_model_eval M x3)))
+  )
+)
+
+; -- repeat
+(declare-parameterized-const $emb_sm.repeat ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_repeat ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.repeat x1 x2))
+(program $smtx_typeof_repeat ( (x1 $native_Int) (x2 $native_Int)  (x3 $smt_Type)  (x4 $smt_Type))
+  :signature ($smt_Term $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_repeat ($sm_numeral x1) ($tsm_BitVec x2)) ($native_ite ($native_apply_2 "zleq" ($native_apply_0 "1") x1) ($tsm_BitVec ($native_apply_1 "int.to_nat" ($native_apply_2 "zmult" x1 ($native_apply_1 "nat.to_int" x2)))) $tsm_none))
+  (($smtx_typeof_repeat x3 x4) $tsm_none)
+  )
+)
+(program $smtx_model_eval_repeat_rec ((n $native_Nat)(x1 $smt_Value)(x1 $smt_Value))
+  :signature ($native_Nat $smt_Value) $smt_Value
+(
+  (($smtx_model_eval_repeat_rec $native_n_zero x1) $vsm_binary_empty)
+  (($smtx_model_eval_repeat_rec ($native_n_succ n) x1) ($smtx_model_eval_concat x1 ($smtx_model_eval_repeat_rec n x1)))
+  )
+)
+(program $smtx_model_eval_repeat
+  ((x1 $native_Int)(x2 $native_Int) (x3 $native_Int) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_repeat ($vsm_numeral x1) ($vsm_binary x2 x3)) ($smtx_model_eval_repeat_rec ($native_z_to_n x1) ($vsm_binary x2 x3)))
+  (($smtx_model_eval_repeat t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_repeat
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_repeat ($sm_repeat x1 x2))  ($smtx_typeof_repeat x1 ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_repeat
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_repeat M ($sm_repeat x1 x2)) ($smtx_model_eval_repeat ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- $smtx_typeof_bv_op_1
+; The type of a bit-vector operator that returns what its argument is.
+(program $smtx_typeof_bv_op_1 ((T $smt_Type) (n $native_Int))
+  :signature ($smt_Type) $smt_Type
+  (
+  (($smtx_typeof_bv_op_1 ($tsm_BitVec n)) ($tsm_BitVec n))
+  (($smtx_typeof_bv_op_1 T)               $tsm_none)
+  )
+)
+
+; -- bvnot
+(declare-parameterized-const $emb_sm.bvnot ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvnot ((x1 $smt_Term)) ($emb_sm.bvnot x1))
+(program $smtx_model_eval_bvnot
+  ((x1 $native_Int) (x2 $native_Int) (t1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvnot ($vsm_binary x1 x2)) ($emb_vsm.Binary x1 ($native_apply_2 "mod_total" ($native_apply_2 "binary_not" x1 x2) ($native_apply_1 "int.pow2" x1))))
+  (($smtx_model_eval_bvnot t1) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_bvnot
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvnot ($sm_bvnot x1)) ($smtx_typeof_bv_op_1 ($smtx_typeof x1)))
+  )
+)
+(program $eoc_eval_bvnot
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvnot M ($sm_bvnot x1)) ($smtx_model_eval_bvnot ($smtx_model_eval M x1)))
+  )
+)
+
+; -- $smtx_typeof_bv_op_2
+; The type of a bit-vector operator whose two arguments must be of one width.
+(program $smtx_typeof_bv_op_2
+  ((T $smt_Type) (U $smt_Type) (n1 $native_Nat) (n2 $native_Nat))
+  :signature ($smt_Type $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_bv_op_2 ($tsm_BitVec n1) ($tsm_BitVec n2))
+    ($native_ite ($native_n_= n1 n2) ($tsm_BitVec n1) $tsm_none))
+  (($smtx_typeof_bv_op_2 T U) $tsm_none)
+  )
+)
+
+; -- bvand
+(declare-parameterized-const $emb_sm.bvand ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvand ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvand x1 x2))
+(program $smtx_model_eval_bvand
+  ((x1 $native_Int) (x2 $native_Int) (x3 $native_Int) (x4 $native_Int) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvand ($vsm_binary x1 x2) ($vsm_binary x3 x4)) ($emb_vsm.Binary x1 ($native_apply_2 "mod_total" ($native_apply_3 "binary_and" x1 x2 x4) ($native_apply_1 "int.pow2" x1))))
+  (($smtx_model_eval_bvand t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_bvand
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvand ($sm_bvand x1 x2)) ($smtx_typeof_bv_op_2 ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_bvand
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvand M ($sm_bvand x1 x2)) ($smtx_model_eval_bvand ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvor
+(declare-parameterized-const $emb_sm.bvor ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvor ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvor x1 x2))
+(program $smtx_model_eval_bvor
+  ((x1 $native_Int) (x2 $native_Int) (x3 $native_Int) (x4 $native_Int) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvor ($vsm_binary x1 x2) ($vsm_binary x3 x4)) ($emb_vsm.Binary x1 ($native_apply_2 "mod_total" ($native_apply_3 "binary_or" x1 x2 x4) ($native_apply_1 "int.pow2" x1))))
+  (($smtx_model_eval_bvor t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_bvor
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvor ($sm_bvor x1 x2)) ($smtx_typeof_bv_op_2 ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_bvor
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvor M ($sm_bvor x1 x2)) ($smtx_model_eval_bvor ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvnand
+(declare-parameterized-const $emb_sm.bvnand ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvnand ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvnand x1 x2))
+(program $smtx_model_eval_bvnand
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvnand x1 x2) ($smtx_model_eval_bvnot ($smtx_model_eval_bvand x1 x2)))
+  )
+)
+(program $eoc_typeof_bvnand
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvnand ($sm_bvnand x1 x2)) ($smtx_typeof_bv_op_2 ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_bvnand
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvnand M ($sm_bvnand x1 x2)) ($smtx_model_eval_bvnand ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvnor
+(declare-parameterized-const $emb_sm.bvnor ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvnor ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvnor x1 x2))
+(program $smtx_model_eval_bvnor
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvnor x1 x2) ($smtx_model_eval_bvnot ($smtx_model_eval_bvor x1 x2)))
+  )
+)
+(program $eoc_typeof_bvnor
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvnor ($sm_bvnor x1 x2)) ($smtx_typeof_bv_op_2 ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_bvnor
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvnor M ($sm_bvnor x1 x2)) ($smtx_model_eval_bvnor ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvxor
+(declare-parameterized-const $emb_sm.bvxor ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvxor ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvxor x1 x2))
+(program $smtx_model_eval_bvxor
+  ((x1 $native_Int) (x2 $native_Int) (x3 $native_Int) (x4 $native_Int) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvxor ($vsm_binary x1 x2) ($vsm_binary x3 x4)) ($emb_vsm.Binary x1 ($native_apply_2 "mod_total" ($native_apply_3 "binary_xor" x1 x2 x4) ($native_apply_1 "int.pow2" x1))))
+  (($smtx_model_eval_bvxor t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_bvxor
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvxor ($sm_bvxor x1 x2)) ($smtx_typeof_bv_op_2 ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_bvxor
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvxor M ($sm_bvxor x1 x2)) ($smtx_model_eval_bvxor ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvxnor
+(declare-parameterized-const $emb_sm.bvxnor ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvxnor ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvxnor x1 x2))
+(program $smtx_model_eval_bvxnor
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvxnor x1 x2) ($smtx_model_eval_bvnot ($smtx_model_eval_bvxor x1 x2)))
+  )
+)
+(program $eoc_typeof_bvxnor
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvxnor ($sm_bvxnor x1 x2)) ($smtx_typeof_bv_op_2 ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_bvxnor
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvxnor M ($sm_bvxnor x1 x2)) ($smtx_model_eval_bvxnor ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- $smtx_typeof_bv_op_2_ret
+; The same, for one that returns a type given rather than its arguments'.
+(program $smtx_typeof_bv_op_2_ret
+  ((T $smt_Type) (U $smt_Type) (V $smt_Type) (n1 $native_Nat) (n2 $native_Nat))
+  :signature ($smt_Type $smt_Type $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_bv_op_2_ret ($tsm_BitVec n1) ($tsm_BitVec n2) U)
+    ($native_ite ($native_n_= n1 n2) U $tsm_none))
+  (($smtx_typeof_bv_op_2_ret T U V) $tsm_none)
+  )
+)
+
+; -- bvcomp
+(declare-parameterized-const $emb_sm.bvcomp ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvcomp ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvcomp x1 x2))
+(program $smtx_model_eval_bvcomp
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvcomp x1 x2) ($smtx_model_eval_ite ($smtx_model_eval_= x1 x2) $vsm_binary_bit_true $vsm_binary_bit_false))
+  )
+)
+(program $eoc_typeof_bvcomp
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvcomp ($sm_bvcomp x1 x2)) ($smtx_typeof_bv_op_2_ret ($smtx_typeof x1) ($smtx_typeof x2) ($emb_tsm.BitVec ($native_apply_1 "nat.succ" ($native_apply_0 "nat.zero")))))
+  )
+)
+(program $eoc_eval_bvcomp
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvcomp M ($sm_bvcomp x1 x2)) ($smtx_model_eval_bvcomp ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvneg
+(declare-parameterized-const $emb_sm.bvneg ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvneg ((x1 $smt_Term)) ($emb_sm.bvneg x1))
+(program $smtx_model_eval_bvneg
+  ((x1 $native_Int) (x2 $native_Int) (t1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvneg ($vsm_binary x1 x2)) ($emb_vsm.Binary x1 ($native_apply_2 "mod_total" ($native_apply_1 "zneg" x2) ($native_apply_1 "int.pow2" x1))))
+  (($smtx_model_eval_bvneg t1) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_bvneg
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvneg ($sm_bvneg x1)) ($smtx_typeof_bv_op_1 ($smtx_typeof x1)))
+  )
+)
+(program $eoc_eval_bvneg
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvneg M ($sm_bvneg x1)) ($smtx_model_eval_bvneg ($smtx_model_eval M x1)))
+  )
+)
+
+; -- bvadd
+(declare-parameterized-const $emb_sm.bvadd ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvadd ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvadd x1 x2))
+(program $smtx_model_eval_bvadd
+  ((x1 $native_Int) (x2 $native_Int) (x3 $native_Int) (x4 $native_Int) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvadd ($vsm_binary x1 x2) ($vsm_binary x3 x4)) ($emb_vsm.Binary x1 ($native_apply_2 "mod_total" ($native_apply_2 "zplus" x2 x4) ($native_apply_1 "int.pow2" x1))))
+  (($smtx_model_eval_bvadd t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_bvadd
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvadd ($sm_bvadd x1 x2)) ($smtx_typeof_bv_op_2 ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_bvadd
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvadd M ($sm_bvadd x1 x2)) ($smtx_model_eval_bvadd ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvmul
+(declare-parameterized-const $emb_sm.bvmul ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvmul ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvmul x1 x2))
+(program $smtx_model_eval_bvmul
+  ((x1 $native_Int) (x2 $native_Int) (x3 $native_Int) (x4 $native_Int) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvmul ($vsm_binary x1 x2) ($vsm_binary x3 x4)) ($emb_vsm.Binary x1 ($native_apply_2 "mod_total" ($native_apply_2 "zmult" x2 x4) ($native_apply_1 "int.pow2" x1))))
+  (($smtx_model_eval_bvmul t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_bvmul
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvmul ($sm_bvmul x1 x2)) ($smtx_typeof_bv_op_2 ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_bvmul
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvmul M ($sm_bvmul x1 x2)) ($smtx_model_eval_bvmul ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvudiv
+(declare-parameterized-const $emb_sm.bvudiv ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvudiv ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvudiv x1 x2))
+(program $smtx_model_eval_bvudiv
+  ((x1 $native_Int) (x2 $native_Int) (x3 $native_Int) (x4 $native_Int) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvudiv ($vsm_binary x1 x2) ($vsm_binary x3 x4)) ($emb_vsm.Binary x1 ($native_apply_2 "mod_total" ($native_apply_3 "ite" ($native_apply_2 "zeq" x4 ($native_apply_0 "0")) ($native_apply_1 "binary_max" x1) ($native_apply_2 "div_total" x2 x4)) ($native_apply_1 "int.pow2" x1))))
+  (($smtx_model_eval_bvudiv t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_bvudiv
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvudiv ($sm_bvudiv x1 x2)) ($smtx_typeof_bv_op_2 ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_bvudiv
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvudiv M ($sm_bvudiv x1 x2)) ($smtx_model_eval_bvudiv ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvurem
+(declare-parameterized-const $emb_sm.bvurem ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvurem ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvurem x1 x2))
+(program $smtx_model_eval_bvurem
+  ((x1 $native_Int) (x2 $native_Int) (x3 $native_Int) (x4 $native_Int) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvurem ($vsm_binary x1 x2) ($vsm_binary x3 x4)) ($emb_vsm.Binary x1 ($native_apply_2 "mod_total" ($native_apply_3 "ite" ($native_apply_2 "zeq" x4 ($native_apply_0 "0")) x2 ($native_apply_2 "mod_total" x2 x4)) ($native_apply_1 "int.pow2" x1))))
+  (($smtx_model_eval_bvurem t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_bvurem
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvurem ($sm_bvurem x1 x2)) ($smtx_typeof_bv_op_2 ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_bvurem
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvurem M ($sm_bvurem x1 x2)) ($smtx_model_eval_bvurem ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvsub
+(declare-parameterized-const $emb_sm.bvsub ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvsub ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvsub x1 x2))
+(program $smtx_model_eval_bvsub
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvsub x1 x2) ($smtx_model_eval_bvadd x1 ($smtx_model_eval_bvneg x2)))
+  )
+)
+(program $eoc_typeof_bvsub
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvsub ($sm_bvsub x1 x2)) ($smtx_typeof_bv_op_2 ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_bvsub
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvsub M ($sm_bvsub x1 x2)) ($smtx_model_eval_bvsub ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- $smtx_bv_sizeof_value
+; The width a bit-vector value is of, or minus one if the value is not one.
+(program $smtx_bv_sizeof_value
+  ((x1 $native_Int) (x2 $native_Int) (t1 $smt_Value))
+  :signature ($smt_Value) $native_Int
+  (
+  (($smtx_bv_sizeof_value ($vsm_binary x1 x2)) x1)
+  (($smtx_bv_sizeof_value t1) $native_z_neg_one)
+  )
+)
+
+; -- bvsdiv
+(declare-parameterized-const $emb_sm.bvsdiv ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvsdiv ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvsdiv x1 x2))
+(program $smtx_model_eval_bvsdiv
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvsdiv x1 x2) ($smtx_model_eval_ite ($smtx_model_eval_and ($smtx_model_eval_not ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x1) $vsm_binary_bit_true)) ($smtx_model_eval_not ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x2) $vsm_binary_bit_true))) ($smtx_model_eval_bvudiv x1 x2) ($smtx_model_eval_ite ($smtx_model_eval_and ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x1) $vsm_binary_bit_true) ($smtx_model_eval_not ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x2) $vsm_binary_bit_true))) ($smtx_model_eval_bvneg ($smtx_model_eval_bvudiv ($smtx_model_eval_bvneg x1) x2)) ($smtx_model_eval_ite ($smtx_model_eval_and ($smtx_model_eval_not ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x1) $vsm_binary_bit_true)) ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x2) $vsm_binary_bit_true)) ($smtx_model_eval_bvneg ($smtx_model_eval_bvudiv x1 ($smtx_model_eval_bvneg x2))) ($smtx_model_eval_bvudiv ($smtx_model_eval_bvneg x1) ($smtx_model_eval_bvneg x2))))))
+  )
+)
+(program $eoc_typeof_bvsdiv
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvsdiv ($sm_bvsdiv x1 x2)) ($smtx_typeof_bv_op_2 ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_bvsdiv
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvsdiv M ($sm_bvsdiv x1 x2)) ($smtx_model_eval_bvsdiv ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvsrem
+(declare-parameterized-const $emb_sm.bvsrem ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvsrem ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvsrem x1 x2))
+(program $smtx_model_eval_bvsrem
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvsrem x1 x2) ($smtx_model_eval_ite ($smtx_model_eval_and ($smtx_model_eval_not ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x1) $vsm_binary_bit_true)) ($smtx_model_eval_not ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x2) $vsm_binary_bit_true))) ($smtx_model_eval_bvurem x1 x2) ($smtx_model_eval_ite ($smtx_model_eval_and ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x1) $vsm_binary_bit_true) ($smtx_model_eval_not ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x2) $vsm_binary_bit_true))) ($smtx_model_eval_bvneg ($smtx_model_eval_bvurem ($smtx_model_eval_bvneg x1) x2)) ($smtx_model_eval_ite ($smtx_model_eval_and ($smtx_model_eval_not ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x1) $vsm_binary_bit_true)) ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x2) $vsm_binary_bit_true)) ($smtx_model_eval_bvurem x1 ($smtx_model_eval_bvneg x2)) ($smtx_model_eval_bvneg ($smtx_model_eval_bvurem ($smtx_model_eval_bvneg x1) ($smtx_model_eval_bvneg x2)))))))
+  )
+)
+(program $eoc_typeof_bvsrem
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvsrem ($sm_bvsrem x1 x2)) ($smtx_typeof_bv_op_2 ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_bvsrem
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvsrem M ($sm_bvsrem x1 x2)) ($smtx_model_eval_bvsrem ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvsmod
+(declare-parameterized-const $emb_sm.bvsmod ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvsmod ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvsmod x1 x2))
+(program $smtx_model_eval_bvsmod
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvsmod x1 x2) ($smtx_model_eval_ite ($smtx_model_eval_= ($smtx_model_eval_bvurem ($smtx_model_eval_ite ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x1) $vsm_binary_bit_true) ($smtx_model_eval_bvneg x1) x1) ($smtx_model_eval_ite ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x2) $vsm_binary_bit_true) ($smtx_model_eval_bvneg x2) x2)) ($emb_vsm.Binary ($smtx_bv_sizeof_value x1) ($native_apply_0 "0"))) ($smtx_model_eval_bvurem ($smtx_model_eval_ite ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x1) $vsm_binary_bit_true) ($smtx_model_eval_bvneg x1) x1) ($smtx_model_eval_ite ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x2) $vsm_binary_bit_true) ($smtx_model_eval_bvneg x2) x2)) ($smtx_model_eval_ite ($smtx_model_eval_and ($smtx_model_eval_not ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x1) $vsm_binary_bit_true)) ($smtx_model_eval_not ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x2) $vsm_binary_bit_true))) ($smtx_model_eval_bvurem ($smtx_model_eval_ite ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x1) $vsm_binary_bit_true) ($smtx_model_eval_bvneg x1) x1) ($smtx_model_eval_ite ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x2) $vsm_binary_bit_true) ($smtx_model_eval_bvneg x2) x2)) ($smtx_model_eval_ite ($smtx_model_eval_and ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x1) $vsm_binary_bit_true) ($smtx_model_eval_not ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x2) $vsm_binary_bit_true))) ($smtx_model_eval_bvadd ($smtx_model_eval_bvneg ($smtx_model_eval_bvurem ($smtx_model_eval_ite ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x1) $vsm_binary_bit_true) ($smtx_model_eval_bvneg x1) x1) ($smtx_model_eval_ite ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x2) $vsm_binary_bit_true) ($smtx_model_eval_bvneg x2) x2))) x2) ($smtx_model_eval_ite ($smtx_model_eval_and ($smtx_model_eval_not ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x1) $vsm_binary_bit_true)) ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x2) $vsm_binary_bit_true)) ($smtx_model_eval_bvadd ($smtx_model_eval_bvurem ($smtx_model_eval_ite ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x1) $vsm_binary_bit_true) ($smtx_model_eval_bvneg x1) x1) ($smtx_model_eval_ite ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x2) $vsm_binary_bit_true) ($smtx_model_eval_bvneg x2) x2)) x2) ($smtx_model_eval_bvneg ($smtx_model_eval_bvurem ($smtx_model_eval_ite ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x1) $vsm_binary_bit_true) ($smtx_model_eval_bvneg x1) x1) ($smtx_model_eval_ite ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x2) $vsm_binary_bit_true) ($smtx_model_eval_bvneg x2) x2))))))))
+  )
+)
+(program $eoc_typeof_bvsmod
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvsmod ($sm_bvsmod x1 x2)) ($smtx_typeof_bv_op_2 ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_bvsmod
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvsmod M ($sm_bvsmod x1 x2)) ($smtx_model_eval_bvsmod ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvugt
+(declare-parameterized-const $emb_sm.bvugt ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvugt ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvugt x1 x2))
+(program $smtx_model_eval_bvugt
+  ((x1 $native_Int) (x2 $native_Int) (x3 $native_Int) (x4 $native_Int) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvugt ($vsm_binary x1 x2) ($vsm_binary x3 x4)) ($emb_vsm.Boolean ($native_apply_2 "zlt" x4 x2)))
+  (($smtx_model_eval_bvugt t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_bvugt
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvugt ($sm_bvugt x1 x2)) ($smtx_typeof_bv_op_2_ret ($smtx_typeof x1) ($smtx_typeof x2) $tsm_Bool))
+  )
+)
+(program $eoc_eval_bvugt
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvugt M ($sm_bvugt x1 x2)) ($smtx_model_eval_bvugt ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvult
+(declare-parameterized-const $emb_sm.bvult ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvult ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvult x1 x2))
+(program $smtx_model_eval_bvult
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvult x1 x2) ($smtx_model_eval_bvugt x2 x1))
+  )
+)
+(program $eoc_typeof_bvult
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvult ($sm_bvult x1 x2)) ($smtx_typeof_bv_op_2_ret ($smtx_typeof x1) ($smtx_typeof x2) $tsm_Bool))
+  )
+)
+(program $eoc_eval_bvult
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvult M ($sm_bvult x1 x2)) ($smtx_model_eval_bvult ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvuge
+(declare-parameterized-const $emb_sm.bvuge ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvuge ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvuge x1 x2))
+(program $smtx_model_eval_bvuge
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvuge x1 x2) ($smtx_model_eval_or ($smtx_model_eval_bvugt x1 x2) ($smtx_model_eval_= x1 x2)))
+  )
+)
+(program $eoc_typeof_bvuge
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvuge ($sm_bvuge x1 x2)) ($smtx_typeof_bv_op_2_ret ($smtx_typeof x1) ($smtx_typeof x2) $tsm_Bool))
+  )
+)
+(program $eoc_eval_bvuge
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvuge M ($sm_bvuge x1 x2)) ($smtx_model_eval_bvuge ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvule
+(declare-parameterized-const $emb_sm.bvule ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvule ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvule x1 x2))
+(program $smtx_model_eval_bvule
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvule x1 x2) ($smtx_model_eval_bvuge x2 x1))
+  )
+)
+(program $eoc_typeof_bvule
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvule ($sm_bvule x1 x2)) ($smtx_typeof_bv_op_2_ret ($smtx_typeof x1) ($smtx_typeof x2) $tsm_Bool))
+  )
+)
+(program $eoc_eval_bvule
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvule M ($sm_bvule x1 x2)) ($smtx_model_eval_bvule ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvsgt
+(declare-parameterized-const $emb_sm.bvsgt ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvsgt ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvsgt x1 x2))
+(program $smtx_model_eval_bvsgt
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvsgt x1 x2) ($smtx_model_eval_or ($smtx_model_eval_and ($smtx_model_eval_not ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x1) $vsm_binary_bit_true)) ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x2)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x2)) $vsm_z_one) x2) $vsm_binary_bit_true)) ($smtx_model_eval_and ($smtx_model_eval_= ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x1) $vsm_binary_bit_true) ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x2)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x2)) $vsm_z_one) x2) $vsm_binary_bit_true)) ($smtx_model_eval_bvugt x1 x2))))
+  )
+)
+(program $eoc_typeof_bvsgt
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvsgt ($sm_bvsgt x1 x2)) ($smtx_typeof_bv_op_2_ret ($smtx_typeof x1) ($smtx_typeof x2) $tsm_Bool))
+  )
+)
+(program $eoc_eval_bvsgt
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvsgt M ($sm_bvsgt x1 x2)) ($smtx_model_eval_bvsgt ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvslt
+(declare-parameterized-const $emb_sm.bvslt ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvslt ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvslt x1 x2))
+(program $smtx_model_eval_bvslt
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvslt x1 x2) ($smtx_model_eval_bvsgt x2 x1))
+  )
+)
+(program $eoc_typeof_bvslt
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvslt ($sm_bvslt x1 x2)) ($smtx_typeof_bv_op_2_ret ($smtx_typeof x1) ($smtx_typeof x2) $tsm_Bool))
+  )
+)
+(program $eoc_eval_bvslt
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvslt M ($sm_bvslt x1 x2)) ($smtx_model_eval_bvslt ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvsge
+(declare-parameterized-const $emb_sm.bvsge ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvsge ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvsge x1 x2))
+(program $smtx_model_eval_bvsge
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvsge x1 x2) ($smtx_model_eval_or ($smtx_model_eval_bvsgt x1 x2) ($smtx_model_eval_= x1 x2)))
+  )
+)
+(program $eoc_typeof_bvsge
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvsge ($sm_bvsge x1 x2)) ($smtx_typeof_bv_op_2_ret ($smtx_typeof x1) ($smtx_typeof x2) $tsm_Bool))
+  )
+)
+(program $eoc_eval_bvsge
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvsge M ($sm_bvsge x1 x2)) ($smtx_model_eval_bvsge ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvsle
+(declare-parameterized-const $emb_sm.bvsle ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvsle ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvsle x1 x2))
+(program $smtx_model_eval_bvsle
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvsle x1 x2) ($smtx_model_eval_bvsge x2 x1))
+  )
+)
+(program $eoc_typeof_bvsle
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvsle ($sm_bvsle x1 x2)) ($smtx_typeof_bv_op_2_ret ($smtx_typeof x1) ($smtx_typeof x2) $tsm_Bool))
+  )
+)
+(program $eoc_eval_bvsle
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvsle M ($sm_bvsle x1 x2)) ($smtx_model_eval_bvsle ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvshl
+(declare-parameterized-const $emb_sm.bvshl ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvshl ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvshl x1 x2))
+(program $smtx_model_eval_bvshl
+  ((x1 $native_Int) (x2 $native_Int) (x3 $native_Int) (x4 $native_Int) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvshl ($vsm_binary x1 x2) ($vsm_binary x3 x4)) ($emb_vsm.Binary x1 ($native_apply_2 "mod_total" ($native_apply_2 "zmult" x2 ($native_apply_1 "int.pow2" x4)) ($native_apply_1 "int.pow2" x1))))
+  (($smtx_model_eval_bvshl t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_bvshl
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvshl ($sm_bvshl x1 x2)) ($smtx_typeof_bv_op_2 ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_bvshl
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvshl M ($sm_bvshl x1 x2)) ($smtx_model_eval_bvshl ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvlshr
+(declare-parameterized-const $emb_sm.bvlshr ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvlshr ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvlshr x1 x2))
+(program $smtx_model_eval_bvlshr
+  ((x1 $native_Int) (x2 $native_Int) (x3 $native_Int) (x4 $native_Int) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvlshr ($vsm_binary x1 x2) ($vsm_binary x3 x4)) ($emb_vsm.Binary x1 ($native_apply_2 "mod_total" ($native_apply_2 "div_total" x2 ($native_apply_1 "int.pow2" x4)) ($native_apply_1 "int.pow2" x1))))
+  (($smtx_model_eval_bvlshr t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_bvlshr
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvlshr ($sm_bvlshr x1 x2)) ($smtx_typeof_bv_op_2 ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_bvlshr
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvlshr M ($sm_bvlshr x1 x2)) ($smtx_model_eval_bvlshr ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvashr
+(declare-parameterized-const $emb_sm.bvashr ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvashr ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvashr x1 x2))
+(program $smtx_model_eval_bvashr
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvashr x1 x2) ($smtx_model_eval_ite ($smtx_model_eval_= ($smtx_model_eval_extract ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) ($smtx_model_eval_- ($emb_vsm.Numeral ($smtx_bv_sizeof_value x1)) $vsm_z_one) x1) $vsm_binary_bit_false) ($smtx_model_eval_bvlshr x1 x2) ($smtx_model_eval_bvnot ($smtx_model_eval_bvlshr ($smtx_model_eval_bvnot x1) x2))))
+  )
+)
+(program $eoc_typeof_bvashr
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvashr ($sm_bvashr x1 x2)) ($smtx_typeof_bv_op_2 ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_bvashr
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvashr M ($sm_bvashr x1 x2)) ($smtx_model_eval_bvashr ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- zero_extend
+(declare-parameterized-const $emb_sm.zero_extend ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_zero_extend ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.zero_extend x1 x2))
+(program $smtx_typeof_zero_extend ( (x1 $native_Int) (x2 $native_Int)  (x3 $smt_Type)  (x4 $smt_Type))
+  :signature ($smt_Term $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_zero_extend ($sm_numeral x1) ($tsm_BitVec x2)) ($native_ite ($native_apply_2 "zleq" ($native_apply_0 "0") x1) ($tsm_BitVec ($native_apply_1 "int.to_nat" ($native_apply_2 "zplus" x1 ($native_apply_1 "nat.to_int" x2)))) $tsm_none))
+  (($smtx_typeof_zero_extend x3 x4) $tsm_none)
+  )
+)
+(program $smtx_model_eval_zero_extend
+  ((x1 $native_Int)(x2 $native_Int) (x3 $native_Int) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_zero_extend ($vsm_numeral x1) ($vsm_binary x2 x3)) ($emb_vsm.Binary ($native_apply_2 "zplus" x1 x2) x3))
+  (($smtx_model_eval_zero_extend t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_zero_extend
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_zero_extend ($sm_zero_extend x1 x2))  ($smtx_typeof_zero_extend x1 ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_zero_extend
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_zero_extend M ($sm_zero_extend x1 x2)) ($smtx_model_eval_zero_extend ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- sign_extend
+(declare-parameterized-const $emb_sm.sign_extend ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_sign_extend ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.sign_extend x1 x2))
+(program $smtx_typeof_sign_extend ( (x1 $native_Int) (x2 $native_Int)  (x3 $smt_Type)  (x4 $smt_Type))
+  :signature ($smt_Term $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_sign_extend ($sm_numeral x1) ($tsm_BitVec x2)) ($native_ite ($native_apply_2 "zleq" ($native_apply_0 "0") x1) ($tsm_BitVec ($native_apply_1 "int.to_nat" ($native_apply_2 "zplus" x1 ($native_apply_1 "nat.to_int" x2)))) $tsm_none))
+  (($smtx_typeof_sign_extend x3 x4) $tsm_none)
+  )
+)
+(program $smtx_model_eval_sign_extend
+  ((x1 $native_Int)(x2 $native_Int) (x3 $native_Int) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_sign_extend ($vsm_numeral x1) ($vsm_binary x2 x3)) ($emb_vsm.Binary ($native_apply_2 "zplus" x1 x2) ($native_apply_2 "mod_total" ($native_apply_2 "binary_uts" x2 x3) ($native_apply_1 "int.pow2" ($native_apply_2 "zplus" x1 x2)))))
+  (($smtx_model_eval_sign_extend t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_sign_extend
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_sign_extend ($sm_sign_extend x1 x2))  ($smtx_typeof_sign_extend x1 ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_sign_extend
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_sign_extend M ($sm_sign_extend x1 x2)) ($smtx_model_eval_sign_extend ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- rotate_left
+(declare-parameterized-const $emb_sm.rotate_left ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_rotate_left ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.rotate_left x1 x2))
+(program $smtx_typeof_rotate_left ( (x1 $native_Int) (x2 $native_Int)  (x3 $smt_Type)  (x4 $smt_Type))
+  :signature ($smt_Term $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_rotate_left ($sm_numeral x1) ($tsm_BitVec x2)) ($native_ite ($native_apply_2 "zleq" ($native_apply_0 "0") x1) ($tsm_BitVec x2) $tsm_none))
+  (($smtx_typeof_rotate_left x3 x4) $tsm_none)
+  )
+)
+(program $smtx_model_eval_rotate_left_rec ((n $native_Nat)(x1 $native_Int) (x2 $native_Int)(x1 $native_Int) (x2 $native_Int) (t1 $smt_Value))
+  :signature ($native_Nat $smt_Value) $smt_Value
+(
+  (($smtx_model_eval_rotate_left_rec $native_n_zero ($vsm_binary x1 x2)) ($vsm_binary x1 x2))
+  (($smtx_model_eval_rotate_left_rec ($native_n_succ n) ($vsm_binary x1 x2)) (eo::define (($wm1 ($vsm_numeral ($native_z_dec x1)))) (eo::define (($wm2 ($vsm_numeral ($native_z_dec ($native_z_dec x1))))) ($smtx_model_eval_rotate_left_rec n ($smtx_model_eval_concat ($smtx_model_eval_extract $wm2 $vsm_z_zero ($vsm_binary x1 x2)) ($smtx_model_eval_extract $wm1 $wm1 ($vsm_binary x1 x2)))))))
+  (($smtx_model_eval_rotate_left_rec n t1) $vsm_not_value)
+  )
+)
+(program $smtx_model_eval_rotate_left
+  ((x1 $native_Int)(x2 $smt_Value) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_rotate_left ($vsm_numeral x1) x2) ($smtx_model_eval_rotate_left_rec ($native_z_to_n x1) x2))
+  (($smtx_model_eval_rotate_left t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_rotate_left
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_rotate_left ($sm_rotate_left x1 x2))  ($smtx_typeof_rotate_left x1 ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_rotate_left
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_rotate_left M ($sm_rotate_left x1 x2)) ($smtx_model_eval_rotate_left ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- rotate_right
+(declare-parameterized-const $emb_sm.rotate_right ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_rotate_right ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.rotate_right x1 x2))
+(program $smtx_typeof_rotate_right ( (x1 $native_Int) (x2 $native_Int)  (x3 $smt_Type)  (x4 $smt_Type))
+  :signature ($smt_Term $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_rotate_right ($sm_numeral x1) ($tsm_BitVec x2)) ($native_ite ($native_apply_2 "zleq" ($native_apply_0 "0") x1) ($tsm_BitVec x2) $tsm_none))
+  (($smtx_typeof_rotate_right x3 x4) $tsm_none)
+  )
+)
+(program $smtx_model_eval_rotate_right_rec ((n $native_Nat)(x1 $native_Int) (x2 $native_Int)(x1 $native_Int) (x2 $native_Int) (t1 $smt_Value))
+  :signature ($native_Nat $smt_Value) $smt_Value
+(
+  (($smtx_model_eval_rotate_right_rec $native_n_zero ($vsm_binary x1 x2)) ($vsm_binary x1 x2))
+  (($smtx_model_eval_rotate_right_rec ($native_n_succ n) ($vsm_binary x1 x2)) (eo::define (($wm1 ($vsm_numeral ($native_z_dec x1)))) ($smtx_model_eval_rotate_right_rec n ($smtx_model_eval_concat ($smtx_model_eval_extract $vsm_z_zero $vsm_z_zero ($vsm_binary x1 x2)) ($smtx_model_eval_extract $wm1 $vsm_z_one ($vsm_binary x1 x2))))))
+  (($smtx_model_eval_rotate_right_rec n t1) $vsm_not_value)
+  )
+)
+(program $smtx_model_eval_rotate_right
+  ((x1 $native_Int)(x2 $smt_Value) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_rotate_right ($vsm_numeral x1) x2) ($smtx_model_eval_rotate_right_rec ($native_z_to_n x1) x2))
+  (($smtx_model_eval_rotate_right t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_rotate_right
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_rotate_right ($sm_rotate_right x1 x2))  ($smtx_typeof_rotate_right x1 ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_rotate_right
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_rotate_right M ($sm_rotate_right x1 x2)) ($smtx_model_eval_rotate_right ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvuaddo
+(declare-parameterized-const $emb_sm.bvuaddo ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvuaddo ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvuaddo x1 x2))
+(program $smtx_model_eval_bvuaddo
+  ((x1 $native_Int) (x2 $native_Int) (x3 $native_Int) (x4 $native_Int) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvuaddo ($vsm_binary x1 x2) ($vsm_binary x3 x4)) ($emb_vsm.Boolean ($native_apply_2 "zleq" ($native_apply_1 "int.pow2" x1) ($native_apply_2 "zplus" x2 x4))))
+  (($smtx_model_eval_bvuaddo t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_bvuaddo
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvuaddo ($sm_bvuaddo x1 x2)) ($smtx_typeof_bv_op_2_ret ($smtx_typeof x1) ($smtx_typeof x2) $tsm_Bool))
+  )
+)
+(program $eoc_eval_bvuaddo
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvuaddo M ($sm_bvuaddo x1 x2)) ($smtx_model_eval_bvuaddo ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- $smtx_typeof_bv_op_1_ret
+; The same, for one that returns a type given rather than its argument's.
+(program $smtx_typeof_bv_op_1_ret ((T $smt_Type) (U $smt_Type) (n $native_Int))
+  :signature ($smt_Type $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_bv_op_1_ret ($tsm_BitVec n) T) T)
+  (($smtx_typeof_bv_op_1_ret T U)               $tsm_none)
+  )
+)
+
+; -- bvnego
+(declare-parameterized-const $emb_sm.bvnego ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvnego ((x1 $smt_Term)) ($emb_sm.bvnego x1))
+(program $smtx_model_eval_bvnego
+  ((x1 $native_Int) (x2 $native_Int) (t1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvnego ($vsm_binary x1 x2)) ($emb_vsm.Boolean ($native_apply_2 "zeq" x2 ($native_apply_1 "int.pow2" ($native_apply_2 "zplus" x1 ($native_apply_1 "zneg" ($native_apply_0 "1")))))))
+  (($smtx_model_eval_bvnego t1) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_bvnego
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvnego ($sm_bvnego x1)) ($smtx_typeof_bv_op_1_ret ($smtx_typeof x1) $tsm_Bool))
+  )
+)
+(program $eoc_eval_bvnego
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvnego M ($sm_bvnego x1)) ($smtx_model_eval_bvnego ($smtx_model_eval M x1)))
+  )
+)
+
+; -- bvsaddo
+(declare-parameterized-const $emb_sm.bvsaddo ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvsaddo ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvsaddo x1 x2))
+(program $smtx_model_eval_bvsaddo
+  ((x1 $native_Int) (x2 $native_Int) (x3 $native_Int) (x4 $native_Int) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvsaddo ($vsm_binary x1 x2) ($vsm_binary x3 x4)) ($emb_vsm.Boolean ($native_apply_2 "or" ($native_apply_2 "zleq" ($native_apply_1 "int.pow2" ($native_apply_2 "zplus" x1 ($native_apply_1 "zneg" ($native_apply_0 "1")))) ($native_apply_2 "zplus" ($native_apply_2 "binary_uts" x1 x2) ($native_apply_2 "binary_uts" x3 x4))) ($native_apply_2 "zlt" ($native_apply_2 "zplus" ($native_apply_2 "binary_uts" x1 x2) ($native_apply_2 "binary_uts" x3 x4)) ($native_apply_1 "zneg" ($native_apply_1 "int.pow2" ($native_apply_2 "zplus" x1 ($native_apply_1 "zneg" ($native_apply_0 "1")))))))))
+  (($smtx_model_eval_bvsaddo t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_bvsaddo
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvsaddo ($sm_bvsaddo x1 x2)) ($smtx_typeof_bv_op_2_ret ($smtx_typeof x1) ($smtx_typeof x2) $tsm_Bool))
+  )
+)
+(program $eoc_eval_bvsaddo
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvsaddo M ($sm_bvsaddo x1 x2)) ($smtx_model_eval_bvsaddo ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvumulo
+(declare-parameterized-const $emb_sm.bvumulo ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvumulo ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvumulo x1 x2))
+(program $smtx_model_eval_bvumulo
+  ((x1 $native_Int) (x2 $native_Int) (x3 $native_Int) (x4 $native_Int) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvumulo ($vsm_binary x1 x2) ($vsm_binary x3 x4)) ($emb_vsm.Boolean ($native_apply_2 "zleq" ($native_apply_1 "int.pow2" x1) ($native_apply_2 "zmult" x2 x4))))
+  (($smtx_model_eval_bvumulo t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_bvumulo
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvumulo ($sm_bvumulo x1 x2)) ($smtx_typeof_bv_op_2_ret ($smtx_typeof x1) ($smtx_typeof x2) $tsm_Bool))
+  )
+)
+(program $eoc_eval_bvumulo
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvumulo M ($sm_bvumulo x1 x2)) ($smtx_model_eval_bvumulo ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvsmulo
+(declare-parameterized-const $emb_sm.bvsmulo ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvsmulo ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvsmulo x1 x2))
+(program $smtx_model_eval_bvsmulo
+  ((x1 $native_Int) (x2 $native_Int) (x3 $native_Int) (x4 $native_Int) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvsmulo ($vsm_binary x1 x2) ($vsm_binary x3 x4)) ($emb_vsm.Boolean ($native_apply_2 "or" ($native_apply_2 "zleq" ($native_apply_1 "int.pow2" ($native_apply_2 "zplus" x1 ($native_apply_1 "zneg" ($native_apply_0 "1")))) ($native_apply_2 "zmult" ($native_apply_2 "binary_uts" x1 x2) ($native_apply_2 "binary_uts" x3 x4))) ($native_apply_2 "zlt" ($native_apply_2 "zmult" ($native_apply_2 "binary_uts" x1 x2) ($native_apply_2 "binary_uts" x3 x4)) ($native_apply_1 "zneg" ($native_apply_1 "int.pow2" ($native_apply_2 "zplus" x1 ($native_apply_1 "zneg" ($native_apply_0 "1")))))))))
+  (($smtx_model_eval_bvsmulo t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_bvsmulo
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvsmulo ($sm_bvsmulo x1 x2)) ($smtx_typeof_bv_op_2_ret ($smtx_typeof x1) ($smtx_typeof x2) $tsm_Bool))
+  )
+)
+(program $eoc_eval_bvsmulo
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvsmulo M ($sm_bvsmulo x1 x2)) ($smtx_model_eval_bvsmulo ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvusubo
+(declare-parameterized-const $emb_sm.bvusubo ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvusubo ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvusubo x1 x2))
+(program $smtx_model_eval_bvusubo
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvusubo x1 x2) ($smtx_model_eval_bvult x1 x2))
+  )
+)
+(program $eoc_typeof_bvusubo
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvusubo ($sm_bvusubo x1 x2)) ($smtx_typeof_bv_op_2_ret ($smtx_typeof x1) ($smtx_typeof x2) $tsm_Bool))
+  )
+)
+(program $eoc_eval_bvusubo
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvusubo M ($sm_bvusubo x1 x2)) ($smtx_model_eval_bvusubo ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvssubo
+(declare-parameterized-const $emb_sm.bvssubo ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvssubo ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvssubo x1 x2))
+(program $smtx_model_eval_bvssubo
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvssubo x1 x2) ($smtx_model_eval_ite ($smtx_model_eval_bvnego x2) ($smtx_model_eval_bvsge x1 ($emb_vsm.Binary ($smtx_bv_sizeof_value x1) ($native_apply_0 "0"))) ($smtx_model_eval_bvsaddo x1 ($smtx_model_eval_bvneg x2))))
+  )
+)
+(program $eoc_typeof_bvssubo
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvssubo ($sm_bvssubo x1 x2)) ($smtx_typeof_bv_op_2_ret ($smtx_typeof x1) ($smtx_typeof x2) $tsm_Bool))
+  )
+)
+(program $eoc_eval_bvssubo
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvssubo M ($sm_bvssubo x1 x2)) ($smtx_model_eval_bvssubo ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- bvsdivo
+(declare-parameterized-const $emb_sm.bvsdivo ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_bvsdivo ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.bvsdivo x1 x2))
+(program $smtx_model_eval_bvsdivo
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_bvsdivo x1 x2) ($smtx_model_eval_and ($smtx_model_eval_bvnego x1) ($smtx_model_eval_= x2 ($smtx_model_eval_bvnot ($emb_vsm.Binary ($smtx_bv_sizeof_value x1) ($native_apply_0 "0"))))))
+  )
+)
+(program $eoc_typeof_bvsdivo
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_bvsdivo ($sm_bvsdivo x1 x2)) ($smtx_typeof_bv_op_2_ret ($smtx_typeof x1) ($smtx_typeof x2) $tsm_Bool))
+  )
+)
+(program $eoc_eval_bvsdivo
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_bvsdivo M ($sm_bvsdivo x1 x2)) ($smtx_model_eval_bvsdivo ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- seq.empty
+(declare-parameterized-const $emb_sm.seq.empty ((x1 $smt_Type :opaque)) $smt_Term)
+(define $sm_seq.empty ((x1 $smt_Type)) ($emb_sm.seq.empty x1))
+(program $eoc_typeof_seq.empty
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_seq.empty ($sm_seq.empty x1)) ($smtx_typeof_guard_wf ($emb_tsm.Seq x1) ($emb_tsm.Seq x1)))
+  )
+)
+(program $eoc_eval_seq.empty
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_seq.empty M ($sm_seq.empty x1)) ($emb_vsm.Seq ($emb_ssm.empty x1)))
+  )
+)
+
+; -- $smtx_typeof_seq_op_1_ret
+; The same, for one that returns a type given rather than its argument's.
+(program $smtx_typeof_seq_op_1_ret ((x1 $smt_Type) (x2 $smt_Type))
+  :signature ($smt_Type $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_seq_op_1_ret ($tsm_Seq x1) x2) x2)
+  (($smtx_typeof_seq_op_1_ret x1 x2) $tsm_none)
+  )
+)
+
+; -- str.len
+(declare-parameterized-const $emb_sm.str.len ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_str.len ((x1 $smt_Term)) ($emb_sm.str.len x1))
+(program $smtx_model_eval_str.len
+  ((x1 $smt_Seq) (t1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_str.len ($vsm_seq x1)) ($vsm_numeral ($native_apply_1 "seq.len" ($native_apply_1 "unpack_seq" x1))))
+  (($smtx_model_eval_str.len t1) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_str.len
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_str.len ($sm_str.len x1)) ($smtx_typeof_seq_op_1_ret ($smtx_typeof x1) $tsm_Int))
+  )
+)
+(program $eoc_eval_str.len
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_str.len M ($sm_str.len x1)) ($smtx_model_eval_str.len ($smtx_model_eval M x1)))
+  )
+)
+
+; -- $smtx_typeof_seq_op_2
+; The type of a sequence operator whose two arguments must be of one type.
+(program $smtx_typeof_seq_op_2 ((x1 $smt_Type) (x2 $smt_Type))
+  :signature ($smt_Type $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_seq_op_2 ($tsm_Seq x1) ($tsm_Seq x2))
+    ($native_ite ($native_Teq x1 x2) ($tsm_Seq x1) $tsm_none))
+  (($smtx_typeof_seq_op_2 x1 x2) $tsm_none)
+  )
+)
+
+; -- $smtx_elem_typeof_seq_value
+; The type of the elements of a sequence value, or nothing if they disagree.
+(program $smtx_elem_typeof_seq_value
+  ((v $smt_Value) (vs $smt_Seq) (T $smt_Type))
+  :signature ($smt_Seq) $smt_Type
+  (
+  (($smtx_elem_typeof_seq_value ($ssm_cons v vs)) ($smtx_elem_typeof_seq_value vs))
+  (($smtx_elem_typeof_seq_value ($ssm_empty T)) T)
+  )
+)
+
+; -- str.++
+(declare-parameterized-const $emb_sm.str.++ ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_str.++ ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.str.++ x1 x2))
+(program $smtx_model_eval_str.++
+  ((x1 $smt_Seq)(x2 $smt_Seq) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_str.++ ($vsm_seq x1) ($vsm_seq x2)) ($vsm_seq  ($native_apply_2 "pack_seq" ($smtx_elem_typeof_seq_value x1) ($native_apply_2 "seq.++" ($native_apply_1 "unpack_seq" x1) ($native_apply_1 "unpack_seq" x2)))))
+  (($smtx_model_eval_str.++ t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_str.++
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_str.++ ($sm_str.++ x1 x2)) ($smtx_typeof_seq_op_2 ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_str.++
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_str.++ M ($sm_str.++ x1 x2)) ($smtx_model_eval_str.++ ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- str.substr
+(declare-parameterized-const $emb_sm.str.substr ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque) (x3 $smt_Term :opaque)) $smt_Term)
+(define $sm_str.substr ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term)) ($emb_sm.str.substr x1 x2 x3))
+(program $smtx_typeof_str.substr ( (x1 $smt_Type) (x2 $smt_Type)  (x3 $smt_Type)  (x4 $smt_Type))
+  :signature ($smt_Type $smt_Type $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_str.substr ($tsm_Seq x1) $tsm_Int $tsm_Int) ($tsm_Seq x1))
+  (($smtx_typeof_str.substr x2 x3 x4) $tsm_none)
+  )
+)
+(program $smtx_model_eval_str.substr
+  ((x1 $smt_Seq)(x2 $native_Int) (x3 $native_Int) (t1 $smt_Value) (t2 $smt_Value) (t3 $smt_Value))
+  :signature ($smt_Value $smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_str.substr ($vsm_seq x1) ($vsm_numeral x2) ($vsm_numeral x3)) ($vsm_seq  ($native_apply_2 "pack_seq" ($smtx_elem_typeof_seq_value x1) ($native_apply_3 "seq.extract" ($native_apply_1 "unpack_seq" x1) x2 x3))))
+  (($smtx_model_eval_str.substr t1 t2 t3) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_str.substr
+  ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_str.substr ($sm_str.substr x1 x2 x3))  ($smtx_typeof_str.substr ($smtx_typeof x1) ($smtx_typeof x2) ($smtx_typeof x3)))
+  )
+)
+(program $eoc_eval_str.substr
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_str.substr M ($sm_str.substr x1 x2 x3)) ($smtx_model_eval_str.substr ($smtx_model_eval M x1) ($smtx_model_eval M x2) ($smtx_model_eval M x3)))
+  )
+)
+
+; -- $smtx_typeof_seq_op_2_ret
+; The same, for one that returns a type given rather than its arguments'.
+(program $smtx_typeof_seq_op_2_ret
+  ((T $smt_Type) (U $smt_Type) (V $smt_Type) (x1 $smt_Type) (x2 $smt_Type))
+  :signature ($smt_Type $smt_Type $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_seq_op_2_ret ($tsm_Seq x1) ($tsm_Seq x2) T)
+    ($native_ite ($native_Teq x1 x2) T $tsm_none))
+  (($smtx_typeof_seq_op_2_ret T U V) $tsm_none)
+  )
+)
+
+; -- str.contains
+(declare-parameterized-const $emb_sm.str.contains ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_str.contains ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.str.contains x1 x2))
+(program $smtx_model_eval_str.contains
+  ((x1 $smt_Seq)(x2 $smt_Seq) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_str.contains ($vsm_seq x1) ($vsm_seq x2)) ($vsm_bool ($native_apply_2 "seq.contains" ($native_apply_1 "unpack_seq" x1) ($native_apply_1 "unpack_seq" x2))))
+  (($smtx_model_eval_str.contains t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_str.contains
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_str.contains ($sm_str.contains x1 x2)) ($smtx_typeof_seq_op_2_ret ($smtx_typeof x1) ($smtx_typeof x2) $tsm_Bool))
+  )
+)
+(program $eoc_eval_str.contains
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_str.contains M ($sm_str.contains x1 x2)) ($smtx_model_eval_str.contains ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- $smtx_typeof_seq_op_3
+; The type of a sequence operator whose three arguments must be of one type.
+(program $smtx_typeof_seq_op_3 ((x1 $smt_Type) (x2 $smt_Type) (x3 $smt_Type))
+  :signature ($smt_Type $smt_Type $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_seq_op_3 ($tsm_Seq x1) ($tsm_Seq x2) ($tsm_Seq x3))
+    ($native_ite ($native_Teq x1 x2)
+    ($native_ite ($native_Teq x2 x3) ($tsm_Seq x1) $tsm_none) $tsm_none))
+  (($smtx_typeof_seq_op_3 x1 x2 x3) $tsm_none)
+  )
+)
+
+; -- str.replace
+(declare-parameterized-const $emb_sm.str.replace ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque) (x3 $smt_Term :opaque)) $smt_Term)
+(define $sm_str.replace ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term)) ($emb_sm.str.replace x1 x2 x3))
+(program $smtx_model_eval_str.replace
+  ((x1 $smt_Seq)(x2 $smt_Seq) (x3 $smt_Seq) (t1 $smt_Value) (t2 $smt_Value) (t3 $smt_Value))
+  :signature ($smt_Value $smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_str.replace ($vsm_seq x1) ($vsm_seq x2) ($vsm_seq x3)) ($vsm_seq  ($native_apply_2 "pack_seq" ($smtx_elem_typeof_seq_value x1) ($native_apply_3 "seq.replace" ($native_apply_1 "unpack_seq" x1) ($native_apply_1 "unpack_seq" x2) ($native_apply_1 "unpack_seq" x3)))))
+  (($smtx_model_eval_str.replace t1 t2 t3) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_str.replace
+  ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_str.replace ($sm_str.replace x1 x2 x3)) ($smtx_typeof_seq_op_3 ($smtx_typeof x1) ($smtx_typeof x2) ($smtx_typeof x3)))
+  )
+)
+(program $eoc_eval_str.replace
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_str.replace M ($sm_str.replace x1 x2 x3)) ($smtx_model_eval_str.replace ($smtx_model_eval M x1) ($smtx_model_eval M x2) ($smtx_model_eval M x3)))
+  )
+)
+
+; -- str.indexof
+(declare-parameterized-const $emb_sm.str.indexof ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque) (x3 $smt_Term :opaque)) $smt_Term)
+(define $sm_str.indexof ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term)) ($emb_sm.str.indexof x1 x2 x3))
+(program $smtx_typeof_str.indexof ( (x1 $smt_Type) (x2 $smt_Type)   (x3 $smt_Type)  (x4 $smt_Type)  (x5 $smt_Type))
+  :signature ($smt_Type $smt_Type $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_str.indexof ($tsm_Seq x1) ($tsm_Seq x2) $tsm_Int) ($native_ite ($native_Teq x1 x2) $tsm_Int $tsm_none))
+  (($smtx_typeof_str.indexof x3 x4 x5) $tsm_none)
+  )
+)
+(program $smtx_model_eval_str.indexof
+  ((x1 $smt_Seq)(x2 $smt_Seq) (x3 $native_Int) (t1 $smt_Value) (t2 $smt_Value) (t3 $smt_Value))
+  :signature ($smt_Value $smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_str.indexof ($vsm_seq x1) ($vsm_seq x2) ($vsm_numeral x3)) ($vsm_numeral ($native_apply_3 "seq.indexof" ($native_apply_1 "unpack_seq" x1) ($native_apply_1 "unpack_seq" x2) x3)))
+  (($smtx_model_eval_str.indexof t1 t2 t3) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_str.indexof
+  ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_str.indexof ($sm_str.indexof x1 x2 x3))  ($smtx_typeof_str.indexof ($smtx_typeof x1) ($smtx_typeof x2) ($smtx_typeof x3)))
+  )
+)
+(program $eoc_eval_str.indexof
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_str.indexof M ($sm_str.indexof x1 x2 x3)) ($smtx_model_eval_str.indexof ($smtx_model_eval M x1) ($smtx_model_eval M x2) ($smtx_model_eval M x3)))
+  )
+)
+
+; -- str.at
+(declare-parameterized-const $emb_sm.str.at ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_str.at ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.str.at x1 x2))
+(program $smtx_typeof_str.at ( (x1 $smt_Type) (x2 $smt_Type)  (x3 $smt_Type))
+  :signature ($smt_Type $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_str.at ($tsm_Seq x1) $tsm_Int) ($tsm_Seq x1))
+  (($smtx_typeof_str.at x2 x3) $tsm_none)
+  )
+)
+(program $smtx_model_eval_str.at
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_str.at x1 x2) ($smtx_model_eval_str.substr x1 x2 $vsm_z_one))
+  )
+)
+(program $eoc_typeof_str.at
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_str.at ($sm_str.at x1 x2))  ($smtx_typeof_str.at ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_str.at
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_str.at M ($sm_str.at x1 x2)) ($smtx_model_eval_str.at ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- str.prefixof
+(declare-parameterized-const $emb_sm.str.prefixof ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_str.prefixof ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.str.prefixof x1 x2))
+(program $smtx_model_eval_str.prefixof
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_str.prefixof x1 x2) ($smtx_model_eval_= x1 ($smtx_model_eval_str.substr x2 $vsm_z_zero ($smtx_model_eval_str.len x1))))
+  )
+)
+(program $eoc_typeof_str.prefixof
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_str.prefixof ($sm_str.prefixof x1 x2)) ($smtx_typeof_seq_op_2_ret ($smtx_typeof x1) ($smtx_typeof x2) $tsm_Bool))
+  )
+)
+(program $eoc_eval_str.prefixof
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_str.prefixof M ($sm_str.prefixof x1 x2)) ($smtx_model_eval_str.prefixof ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- str.suffixof
+(declare-parameterized-const $emb_sm.str.suffixof ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_str.suffixof ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.str.suffixof x1 x2))
+(program $smtx_model_eval_str.suffixof
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_str.suffixof x1 x2) ($smtx_model_eval_= x1 ($smtx_model_eval_str.substr x2 ($smtx_model_eval_- ($smtx_model_eval_str.len x2) ($smtx_model_eval_str.len x1)) ($smtx_model_eval_str.len x1))))
+  )
+)
+(program $eoc_typeof_str.suffixof
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_str.suffixof ($sm_str.suffixof x1 x2)) ($smtx_typeof_seq_op_2_ret ($smtx_typeof x1) ($smtx_typeof x2) $tsm_Bool))
+  )
+)
+(program $eoc_eval_str.suffixof
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_str.suffixof M ($sm_str.suffixof x1 x2)) ($smtx_model_eval_str.suffixof ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- $smtx_typeof_seq_op_1
+; The type of a sequence operator that returns what its argument is.
+(program $smtx_typeof_seq_op_1 ((x1 $smt_Type))
+  :signature ($smt_Type) $smt_Type
+  (
+  (($smtx_typeof_seq_op_1 ($tsm_Seq x1)) ($tsm_Seq x1) )
+  (($smtx_typeof_seq_op_1 x1) $tsm_none)
+  )
+)
+
+; -- str.rev
+(declare-parameterized-const $emb_sm.str.rev ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_str.rev ((x1 $smt_Term)) ($emb_sm.str.rev x1))
+(program $smtx_model_eval_str.rev
+  ((x1 $smt_Seq) (t1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_str.rev ($vsm_seq x1)) ($vsm_seq  ($native_apply_2 "pack_seq" ($smtx_elem_typeof_seq_value x1) ($native_apply_1 "seq.rev" ($native_apply_1 "unpack_seq" x1)))))
+  (($smtx_model_eval_str.rev t1) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_str.rev
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_str.rev ($sm_str.rev x1)) ($smtx_typeof_seq_op_1 ($smtx_typeof x1)))
+  )
+)
+(program $eoc_eval_str.rev
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_str.rev M ($sm_str.rev x1)) ($smtx_model_eval_str.rev ($smtx_model_eval M x1)))
+  )
+)
+
+; -- str.update
+(declare-parameterized-const $emb_sm.str.update ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque) (x3 $smt_Term :opaque)) $smt_Term)
+(define $sm_str.update ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term)) ($emb_sm.str.update x1 x2 x3))
+(program $smtx_typeof_str.update ( (x1 $smt_Type) (x2 $smt_Type)  (x3 $smt_Type)  (x4 $smt_Type)  (x5 $smt_Type))
+  :signature ($smt_Type $smt_Type $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_str.update ($tsm_Seq x1) $tsm_Int ($tsm_Seq x2)) ($native_ite ($native_Teq x1 x2) ($tsm_Seq x1) $tsm_none))
+  (($smtx_typeof_str.update x3 x4 x5) $tsm_none)
+  )
+)
+(program $smtx_model_eval_str.update
+  ((x1 $smt_Seq)(x2 $native_Int) (x3 $smt_Seq) (t1 $smt_Value) (t2 $smt_Value) (t3 $smt_Value))
+  :signature ($smt_Value $smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_str.update ($vsm_seq x1) ($vsm_numeral x2) ($vsm_seq x3)) ($vsm_seq  ($native_apply_2 "pack_seq" ($smtx_elem_typeof_seq_value x1) ($native_apply_3 "seq.update" ($native_apply_1 "unpack_seq" x1) x2 ($native_apply_1 "unpack_seq" x3)))))
+  (($smtx_model_eval_str.update t1 t2 t3) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_str.update
+  ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_str.update ($sm_str.update x1 x2 x3))  ($smtx_typeof_str.update ($smtx_typeof x1) ($smtx_typeof x2) ($smtx_typeof x3)))
+  )
+)
+(program $eoc_eval_str.update
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_str.update M ($sm_str.update x1 x2 x3)) ($smtx_model_eval_str.update ($smtx_model_eval M x1) ($smtx_model_eval M x2) ($smtx_model_eval M x3)))
+  )
+)
+
+; -- str.to_lower
+(declare-parameterized-const $emb_sm.str.to_lower ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_str.to_lower ((x1 $smt_Term)) ($emb_sm.str.to_lower x1))
+(program $smtx_model_eval_str.to_lower
+  ((x1 $native_String) (t1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_str.to_lower ($vsm_seq x1)) ($vsm_seq  ($native_apply_1 "pack_string" ($native_apply_1 "str.to_lower" ($native_apply_1 "unpack_string" x1)))))
+  (($smtx_model_eval_str.to_lower t1) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_str.to_lower
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_str.to_lower ($sm_str.to_lower x1)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_String) $tsm_String $tsm_none))
+  )
+)
+(program $eoc_eval_str.to_lower
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_str.to_lower M ($sm_str.to_lower x1)) ($smtx_model_eval_str.to_lower ($smtx_model_eval M x1)))
+  )
+)
+
+; -- str.to_upper
+(declare-parameterized-const $emb_sm.str.to_upper ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_str.to_upper ((x1 $smt_Term)) ($emb_sm.str.to_upper x1))
+(program $smtx_model_eval_str.to_upper
+  ((x1 $native_String) (t1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_str.to_upper ($vsm_seq x1)) ($vsm_seq  ($native_apply_1 "pack_string" ($native_apply_1 "str.to_upper" ($native_apply_1 "unpack_string" x1)))))
+  (($smtx_model_eval_str.to_upper t1) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_str.to_upper
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_str.to_upper ($sm_str.to_upper x1)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_String) $tsm_String $tsm_none))
+  )
+)
+(program $eoc_eval_str.to_upper
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_str.to_upper M ($sm_str.to_upper x1)) ($smtx_model_eval_str.to_upper ($smtx_model_eval M x1)))
+  )
+)
+
+; -- str.to_code
+(declare-parameterized-const $emb_sm.str.to_code ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_str.to_code ((x1 $smt_Term)) ($emb_sm.str.to_code x1))
+(program $smtx_model_eval_str.to_code
+  ((x1 $native_String) (t1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_str.to_code ($vsm_seq x1)) ($vsm_numeral ($native_apply_1 "str.to_code" ($native_apply_1 "unpack_string" x1))))
+  (($smtx_model_eval_str.to_code t1) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_str.to_code
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_str.to_code ($sm_str.to_code x1)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_String) $tsm_Int $tsm_none))
+  )
+)
+(program $eoc_eval_str.to_code
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_str.to_code M ($sm_str.to_code x1)) ($smtx_model_eval_str.to_code ($smtx_model_eval M x1)))
+  )
+)
+
+; -- str.from_code
+(declare-parameterized-const $emb_sm.str.from_code ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_str.from_code ((x1 $smt_Term)) ($emb_sm.str.from_code x1))
+(program $smtx_model_eval_str.from_code
+  ((x1 $native_Int) (t1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_str.from_code ($vsm_numeral x1)) ($vsm_seq  ($native_apply_1 "pack_string" ($native_apply_1 "str.from_code" x1))))
+  (($smtx_model_eval_str.from_code t1) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_str.from_code
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_str.from_code ($sm_str.from_code x1)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_Int) $tsm_String $tsm_none))
+  )
+)
+(program $eoc_eval_str.from_code
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_str.from_code M ($sm_str.from_code x1)) ($smtx_model_eval_str.from_code ($smtx_model_eval M x1)))
+  )
+)
+
+; -- str.is_digit
+(declare-parameterized-const $emb_sm.str.is_digit ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_str.is_digit ((x1 $smt_Term)) ($emb_sm.str.is_digit x1))
+(program $smtx_model_eval_str.is_digit
+  ((x1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_str.is_digit x1) ($smtx_model_eval_and ($smtx_model_eval_<= ($vsm_numeral ($native_apply_0 "48")) ($smtx_model_eval_str.to_code x1)) ($smtx_model_eval_<= ($smtx_model_eval_str.to_code x1) ($vsm_numeral ($native_apply_0 "57")))))
+  )
+)
+(program $eoc_typeof_str.is_digit
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_str.is_digit ($sm_str.is_digit x1)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_String) $tsm_Bool $tsm_none))
+  )
+)
+(program $eoc_eval_str.is_digit
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_str.is_digit M ($sm_str.is_digit x1)) ($smtx_model_eval_str.is_digit ($smtx_model_eval M x1)))
+  )
+)
+
+; -- str.to_int
+(declare-parameterized-const $emb_sm.str.to_int ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_str.to_int ((x1 $smt_Term)) ($emb_sm.str.to_int x1))
+(program $smtx_model_eval_str.to_int
+  ((x1 $native_String) (t1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_str.to_int ($vsm_seq x1)) ($vsm_numeral ($native_apply_1 "str.to_int" ($native_apply_1 "unpack_string" x1))))
+  (($smtx_model_eval_str.to_int t1) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_str.to_int
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_str.to_int ($sm_str.to_int x1)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_String) $tsm_Int $tsm_none))
+  )
+)
+(program $eoc_eval_str.to_int
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_str.to_int M ($sm_str.to_int x1)) ($smtx_model_eval_str.to_int ($smtx_model_eval M x1)))
+  )
+)
+
+; -- str.from_int
+(declare-parameterized-const $emb_sm.str.from_int ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_str.from_int ((x1 $smt_Term)) ($emb_sm.str.from_int x1))
+(program $smtx_model_eval_str.from_int
+  ((x1 $native_Int) (t1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_str.from_int ($vsm_numeral x1)) ($vsm_seq  ($native_apply_1 "pack_string" ($native_apply_1 "str.from_int" x1))))
+  (($smtx_model_eval_str.from_int t1) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_str.from_int
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_str.from_int ($sm_str.from_int x1)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_Int) $tsm_String $tsm_none))
+  )
+)
+(program $eoc_eval_str.from_int
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_str.from_int M ($sm_str.from_int x1)) ($smtx_model_eval_str.from_int ($smtx_model_eval M x1)))
+  )
+)
+
+; -- str.<
+(declare-parameterized-const $emb_sm.str.< ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_str.< ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.str.< x1 x2))
+(program $smtx_model_eval_str.<
+  ((x1 $native_String)(x2 $native_String) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_str.< ($vsm_seq x1) ($vsm_seq x2)) ($vsm_bool ($native_apply_2 "str.<" ($native_apply_1 "unpack_string" x1) ($native_apply_1 "unpack_string" x2))))
+  (($smtx_model_eval_str.< t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_str.<
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_str.< ($sm_str.< x1 x2)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_String) ($native_ite ($native_Teq ($smtx_typeof x2) $tsm_String) $tsm_Bool $tsm_none) $tsm_none))
+  )
+)
+(program $eoc_eval_str.<
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_str.< M ($sm_str.< x1 x2)) ($smtx_model_eval_str.< ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- str.<=
+(declare-parameterized-const $emb_sm.str.<= ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_str.<= ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.str.<= x1 x2))
+(program $smtx_model_eval_str.<=
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_str.<= x1 x2) ($smtx_model_eval_or ($smtx_model_eval_= x1 x2) ($smtx_model_eval_str.< x1 x2)))
+  )
+)
+(program $eoc_typeof_str.<=
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_str.<= ($sm_str.<= x1 x2)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_String) ($native_ite ($native_Teq ($smtx_typeof x2) $tsm_String) $tsm_Bool $tsm_none) $tsm_none))
+  )
+)
+(program $eoc_eval_str.<=
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_str.<= M ($sm_str.<= x1 x2)) ($smtx_model_eval_str.<= ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- str.replace_all
+(declare-parameterized-const $emb_sm.str.replace_all ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque) (x3 $smt_Term :opaque)) $smt_Term)
+(define $sm_str.replace_all ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term)) ($emb_sm.str.replace_all x1 x2 x3))
+(program $smtx_model_eval_str.replace_all
+  ((x1 $smt_Seq)(x2 $smt_Seq) (x3 $smt_Seq) (t1 $smt_Value) (t2 $smt_Value) (t3 $smt_Value))
+  :signature ($smt_Value $smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_str.replace_all ($vsm_seq x1) ($vsm_seq x2) ($vsm_seq x3)) ($vsm_seq  ($native_apply_2 "pack_seq" ($smtx_elem_typeof_seq_value x1) ($native_apply_3 "seq.replace_all" ($native_apply_1 "unpack_seq" x1) ($native_apply_1 "unpack_seq" x2) ($native_apply_1 "unpack_seq" x3)))))
+  (($smtx_model_eval_str.replace_all t1 t2 t3) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_str.replace_all
+  ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_str.replace_all ($sm_str.replace_all x1 x2 x3)) ($smtx_typeof_seq_op_3 ($smtx_typeof x1) ($smtx_typeof x2) ($smtx_typeof x3)))
+  )
+)
+(program $eoc_eval_str.replace_all
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_str.replace_all M ($sm_str.replace_all x1 x2 x3)) ($smtx_model_eval_str.replace_all ($smtx_model_eval M x1) ($smtx_model_eval M x2) ($smtx_model_eval M x3)))
+  )
+)
+
+; -- str.replace_re
+(declare-parameterized-const $emb_sm.str.replace_re ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque) (x3 $smt_Term :opaque)) $smt_Term)
+(define $sm_str.replace_re ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term)) ($emb_sm.str.replace_re x1 x2 x3))
+(program $smtx_model_eval_str.replace_re
+  ((x1 $smt_Seq)(x2 $smt_RegLan) (x3 $smt_Seq) (t1 $smt_Value) (t2 $smt_Value) (t3 $smt_Value))
+  :signature ($smt_Value $smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_str.replace_re ($vsm_seq x1) ($vsm_re x2) ($vsm_seq x3)) ($vsm_seq  ($native_apply_2 "pack_seq" ($smtx_elem_typeof_seq_value x1) ($native_apply_3 "str_replace_re" ($native_apply_1 "unpack_seq" x1) x2 ($native_apply_1 "unpack_seq" x3)))))
+  (($smtx_model_eval_str.replace_re t1 t2 t3) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_str.replace_re
+  ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_str.replace_re ($sm_str.replace_re x1 x2 x3)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_String) ($native_ite ($native_Teq ($smtx_typeof x2) $tsm_RegLan) ($native_ite ($native_Teq ($smtx_typeof x3) $tsm_String) $tsm_String $tsm_none) $tsm_none) $tsm_none))
+  )
+)
+(program $eoc_eval_str.replace_re
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_str.replace_re M ($sm_str.replace_re x1 x2 x3)) ($smtx_model_eval_str.replace_re ($smtx_model_eval M x1) ($smtx_model_eval M x2) ($smtx_model_eval M x3)))
+  )
+)
+
+; -- str.replace_re_all
+(declare-parameterized-const $emb_sm.str.replace_re_all ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque) (x3 $smt_Term :opaque)) $smt_Term)
+(define $sm_str.replace_re_all ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term)) ($emb_sm.str.replace_re_all x1 x2 x3))
+(program $smtx_model_eval_str.replace_re_all
+  ((x1 $smt_Seq)(x2 $smt_RegLan) (x3 $smt_Seq) (t1 $smt_Value) (t2 $smt_Value) (t3 $smt_Value))
+  :signature ($smt_Value $smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_str.replace_re_all ($vsm_seq x1) ($vsm_re x2) ($vsm_seq x3)) ($vsm_seq  ($native_apply_2 "pack_seq" ($smtx_elem_typeof_seq_value x1) ($native_apply_3 "str_replace_re_all" ($native_apply_1 "unpack_seq" x1) x2 ($native_apply_1 "unpack_seq" x3)))))
+  (($smtx_model_eval_str.replace_re_all t1 t2 t3) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_str.replace_re_all
+  ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_str.replace_re_all ($sm_str.replace_re_all x1 x2 x3)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_String) ($native_ite ($native_Teq ($smtx_typeof x2) $tsm_RegLan) ($native_ite ($native_Teq ($smtx_typeof x3) $tsm_String) $tsm_String $tsm_none) $tsm_none) $tsm_none))
+  )
+)
+(program $eoc_eval_str.replace_re_all
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_str.replace_re_all M ($sm_str.replace_re_all x1 x2 x3)) ($smtx_model_eval_str.replace_re_all ($smtx_model_eval M x1) ($smtx_model_eval M x2) ($smtx_model_eval M x3)))
+  )
+)
+
+; -- str.indexof_re
+(declare-parameterized-const $emb_sm.str.indexof_re ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque) (x3 $smt_Term :opaque)) $smt_Term)
+(define $sm_str.indexof_re ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term)) ($emb_sm.str.indexof_re x1 x2 x3))
+(program $smtx_model_eval_str.indexof_re
+  ((x1 $smt_Seq)(x2 $smt_RegLan) (x3 $native_Int) (t1 $smt_Value) (t2 $smt_Value) (t3 $smt_Value))
+  :signature ($smt_Value $smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_str.indexof_re ($vsm_seq x1) ($vsm_re x2) ($vsm_numeral x3)) ($vsm_numeral ($native_apply_3 "str_indexof_re" ($native_apply_1 "unpack_seq" x1) x2 x3)))
+  (($smtx_model_eval_str.indexof_re t1 t2 t3) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_str.indexof_re
+  ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_str.indexof_re ($sm_str.indexof_re x1 x2 x3)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_String) ($native_ite ($native_Teq ($smtx_typeof x2) $tsm_RegLan) ($native_ite ($native_Teq ($smtx_typeof x3) $tsm_Int) $tsm_Int $tsm_none) $tsm_none) $tsm_none))
+  )
+)
+(program $eoc_eval_str.indexof_re
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_str.indexof_re M ($sm_str.indexof_re x1 x2 x3)) ($smtx_model_eval_str.indexof_re ($smtx_model_eval M x1) ($smtx_model_eval M x2) ($smtx_model_eval M x3)))
+  )
+)
+
+; -- re.allchar
+(declare-parameterized-const $emb_sm.re.allchar () $smt_Term)
+(define $sm_re.allchar () $emb_sm.re.allchar)
+(program $eoc_typeof_re.allchar
+  ()
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_re.allchar $sm_re.allchar) $tsm_RegLan)
+  )
+)
+(program $eoc_eval_re.allchar
+  ((M $smt_Model))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_re.allchar M $sm_re.allchar) ($vsm_re ($native_apply_0 "re.allchar")))
+  )
+)
+
+; -- re.none
+(declare-parameterized-const $emb_sm.re.none () $smt_Term)
+(define $sm_re.none () $emb_sm.re.none)
+(program $eoc_typeof_re.none
+  ()
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_re.none $sm_re.none) $tsm_RegLan)
+  )
+)
+(program $eoc_eval_re.none
+  ((M $smt_Model))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_re.none M $sm_re.none) ($vsm_re ($native_apply_0 "re.none")))
+  )
+)
+
+; -- re.all
+(declare-parameterized-const $emb_sm.re.all () $smt_Term)
+(define $sm_re.all () $emb_sm.re.all)
+(program $eoc_typeof_re.all
+  ()
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_re.all $sm_re.all) $tsm_RegLan)
+  )
+)
+(program $eoc_eval_re.all
+  ((M $smt_Model))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_re.all M $sm_re.all) ($vsm_re ($native_apply_0 "re.all")))
+  )
+)
+
+; -- str.to_re
+(declare-parameterized-const $emb_sm.str.to_re ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_str.to_re ((x1 $smt_Term)) ($emb_sm.str.to_re x1))
+(program $smtx_model_eval_str.to_re
+  ((x1 $smt_Seq) (t1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_str.to_re ($vsm_seq x1)) ($vsm_re ($native_apply_1 "str_to_re" ($native_apply_1 "unpack_seq" x1))))
+  (($smtx_model_eval_str.to_re t1) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_str.to_re
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_str.to_re ($sm_str.to_re x1)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_String) $tsm_RegLan $tsm_none))
+  )
+)
+(program $eoc_eval_str.to_re
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_str.to_re M ($sm_str.to_re x1)) ($smtx_model_eval_str.to_re ($smtx_model_eval M x1)))
+  )
+)
+
+; -- re.*
+(declare-parameterized-const $emb_sm.re.* ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_re.* ((x1 $smt_Term)) ($emb_sm.re.* x1))
+(program $smtx_model_eval_re.*
+  ((x1 $smt_RegLan) (t1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_re.* ($vsm_re x1)) ($vsm_re ($native_apply_1 "re.*" x1)))
+  (($smtx_model_eval_re.* t1) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_re.*
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_re.* ($sm_re.* x1)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_RegLan) $tsm_RegLan $tsm_none))
+  )
+)
+(program $eoc_eval_re.*
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_re.* M ($sm_re.* x1)) ($smtx_model_eval_re.* ($smtx_model_eval M x1)))
+  )
+)
+
+; -- re.++
+(declare-parameterized-const $emb_sm.re.++ ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_re.++ ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.re.++ x1 x2))
+(program $smtx_model_eval_re.++
+  ((x1 $smt_RegLan)(x2 $smt_RegLan) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_re.++ ($vsm_re x1) ($vsm_re x2)) ($vsm_re ($native_apply_2 "re.++" x1 x2)))
+  (($smtx_model_eval_re.++ t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_re.++
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_re.++ ($sm_re.++ x1 x2)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_RegLan) ($native_ite ($native_Teq ($smtx_typeof x2) $tsm_RegLan) $tsm_RegLan $tsm_none) $tsm_none))
+  )
+)
+(program $eoc_eval_re.++
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_re.++ M ($sm_re.++ x1 x2)) ($smtx_model_eval_re.++ ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- re.+
+(declare-parameterized-const $emb_sm.re.+ ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_re.+ ((x1 $smt_Term)) ($emb_sm.re.+ x1))
+(program $smtx_model_eval_re.+
+  ((x1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_re.+ x1) ($smtx_model_eval_re.++ x1 ($smtx_model_eval_re.* x1)))
+  )
+)
+(program $eoc_typeof_re.+
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_re.+ ($sm_re.+ x1)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_RegLan) $tsm_RegLan $tsm_none))
+  )
+)
+(program $eoc_eval_re.+
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_re.+ M ($sm_re.+ x1)) ($smtx_model_eval_re.+ ($smtx_model_eval M x1)))
+  )
+)
+
+; -- re.^
+(declare-parameterized-const $emb_sm.re.^ ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_re.^ ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.re.^ x1 x2))
+(program $smtx_typeof_re.^ ( (x1 $native_Int) (x2 $smt_Type)  (x3 $smt_Type))
+  :signature ($smt_Term $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_re.^ ($sm_numeral x1) $tsm_RegLan) ($native_ite ($native_apply_2 "zleq" ($native_apply_0 "0") x1) $tsm_RegLan $tsm_none))
+  (($smtx_typeof_re.^ x2 x3) $tsm_none)
+  )
+)
+(program $smtx_model_eval_re.^_rec ((n $native_Nat)(x1 $smt_Value)(x1 $smt_Value))
+  :signature ($native_Nat $smt_Value) $smt_Value
+(
+  (($smtx_model_eval_re.^_rec $native_n_zero x1) ($smtx_model_eval_str.to_re $vsm_string_empty))
+  (($smtx_model_eval_re.^_rec ($native_n_succ n) x1) ($smtx_model_eval_re.++ ($smtx_model_eval_re.^_rec n x1) x1))
+  )
+)
+(program $smtx_model_eval_re.^
+  ((x1 $native_Int)(x2 $smt_RegLan) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_re.^ ($vsm_numeral x1) ($vsm_re x2)) ($smtx_model_eval_re.^_rec ($native_z_to_n x1) ($vsm_re x2)))
+  (($smtx_model_eval_re.^ t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_re.^
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_re.^ ($sm_re.^ x1 x2))  ($smtx_typeof_re.^ x1 ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_re.^
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_re.^ M ($sm_re.^ x1 x2)) ($smtx_model_eval_re.^ ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- re.union
+(declare-parameterized-const $emb_sm.re.union ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_re.union ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.re.union x1 x2))
+(program $smtx_model_eval_re.union
+  ((x1 $smt_RegLan)(x2 $smt_RegLan) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_re.union ($vsm_re x1) ($vsm_re x2)) ($vsm_re ($native_apply_2 "re.union" x1 x2)))
+  (($smtx_model_eval_re.union t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_re.union
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_re.union ($sm_re.union x1 x2)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_RegLan) ($native_ite ($native_Teq ($smtx_typeof x2) $tsm_RegLan) $tsm_RegLan $tsm_none) $tsm_none))
+  )
+)
+(program $eoc_eval_re.union
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_re.union M ($sm_re.union x1 x2)) ($smtx_model_eval_re.union ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- re.opt
+(declare-parameterized-const $emb_sm.re.opt ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_re.opt ((x1 $smt_Term)) ($emb_sm.re.opt x1))
+(program $smtx_model_eval_re.opt
+  ((x1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_re.opt x1) ($smtx_model_eval_re.union x1 ($smtx_model_eval_str.to_re $vsm_string_empty)))
+  )
+)
+(program $eoc_typeof_re.opt
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_re.opt ($sm_re.opt x1)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_RegLan) $tsm_RegLan $tsm_none))
+  )
+)
+(program $eoc_eval_re.opt
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_re.opt M ($sm_re.opt x1)) ($smtx_model_eval_re.opt ($smtx_model_eval M x1)))
+  )
+)
+
+; -- re.comp
+(declare-parameterized-const $emb_sm.re.comp ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_re.comp ((x1 $smt_Term)) ($emb_sm.re.comp x1))
+(program $smtx_model_eval_re.comp
+  ((x1 $smt_RegLan) (t1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_re.comp ($vsm_re x1)) ($vsm_re ($native_apply_1 "re.comp" x1)))
+  (($smtx_model_eval_re.comp t1) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_re.comp
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_re.comp ($sm_re.comp x1)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_RegLan) $tsm_RegLan $tsm_none))
+  )
+)
+(program $eoc_eval_re.comp
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_re.comp M ($sm_re.comp x1)) ($smtx_model_eval_re.comp ($smtx_model_eval M x1)))
+  )
+)
+
+; -- re.range
+(declare-parameterized-const $emb_sm.re.range ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_re.range ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.re.range x1 x2))
+(program $smtx_model_eval_re.range
+  ((x1 $smt_Seq)(x2 $smt_Seq) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_re.range ($vsm_seq x1) ($vsm_seq x2)) ($vsm_re ($native_apply_2 "re_range" ($native_apply_1 "unpack_seq" x1) ($native_apply_1 "unpack_seq" x2))))
+  (($smtx_model_eval_re.range t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_re.range
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_re.range ($sm_re.range x1 x2)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_String) ($native_ite ($native_Teq ($smtx_typeof x2) $tsm_String) $tsm_RegLan $tsm_none) $tsm_none))
+  )
+)
+(program $eoc_eval_re.range
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_re.range M ($sm_re.range x1 x2)) ($smtx_model_eval_re.range ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- re.inter
+(declare-parameterized-const $emb_sm.re.inter ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_re.inter ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.re.inter x1 x2))
+(program $smtx_model_eval_re.inter
+  ((x1 $smt_RegLan)(x2 $smt_RegLan) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_re.inter ($vsm_re x1) ($vsm_re x2)) ($vsm_re ($native_apply_2 "re.inter" x1 x2)))
+  (($smtx_model_eval_re.inter t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_re.inter
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_re.inter ($sm_re.inter x1 x2)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_RegLan) ($native_ite ($native_Teq ($smtx_typeof x2) $tsm_RegLan) $tsm_RegLan $tsm_none) $tsm_none))
+  )
+)
+(program $eoc_eval_re.inter
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_re.inter M ($sm_re.inter x1 x2)) ($smtx_model_eval_re.inter ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- re.diff
+(declare-parameterized-const $emb_sm.re.diff ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_re.diff ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.re.diff x1 x2))
+(program $smtx_model_eval_re.diff
+  ((x1 $smt_RegLan)(x2 $smt_RegLan) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_re.diff ($vsm_re x1) ($vsm_re x2)) ($vsm_re ($native_apply_2 "re.diff" x1 x2)))
+  (($smtx_model_eval_re.diff t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_re.diff
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_re.diff ($sm_re.diff x1 x2)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_RegLan) ($native_ite ($native_Teq ($smtx_typeof x2) $tsm_RegLan) $tsm_RegLan $tsm_none) $tsm_none))
+  )
+)
+(program $eoc_eval_re.diff
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_re.diff M ($sm_re.diff x1 x2)) ($smtx_model_eval_re.diff ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- re.loop
+(declare-parameterized-const $emb_sm.re.loop ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque) (x3 $smt_Term :opaque)) $smt_Term)
+(define $sm_re.loop ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term)) ($emb_sm.re.loop x1 x2 x3))
+(program $smtx_typeof_re.loop ( (x1 $native_Int) (x2 $native_Int)   (x3 $smt_Type)  (x4 $smt_Type)  (x5 $smt_Type))
+  :signature ($smt_Term $smt_Term $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_re.loop ($sm_numeral x1) ($sm_numeral x2) $tsm_RegLan) ($native_ite ($native_apply_2 "zleq" ($native_apply_0 "0") x1) ($native_ite ($native_apply_2 "zleq" ($native_apply_0 "0") x2) $tsm_RegLan $tsm_none) $tsm_none))
+  (($smtx_typeof_re.loop x3 x4 x5) $tsm_none)
+  )
+)
+(program $smtx_model_eval_re.loop_rec ((n $native_Nat)(x1 $smt_Value)(x2 $native_Int) (x3 $smt_Value)(x1 $smt_Value)(x2 $native_Int) (x3 $smt_Value) (t1 $smt_Value) (t2 $smt_Value) (t3 $smt_Value))
+  :signature ($native_Nat $smt_Value $smt_Value $smt_Value) $smt_Value
+(
+  (($smtx_model_eval_re.loop_rec $native_n_zero x1 ($vsm_numeral x2) x3) ($smtx_model_eval_re.^ x1 x3))
+  (($smtx_model_eval_re.loop_rec ($native_n_succ n) x1 ($vsm_numeral x2) x3) ($smtx_model_eval_re.union ($smtx_model_eval_re.loop_rec n x1 ($vsm_numeral ($native_z_dec x2)) x3) ($smtx_model_eval_re.^ ($vsm_numeral x2) x3)))
+  (($smtx_model_eval_re.loop_rec n t1 t2 t3) $vsm_not_value)
+  )
+)
+(program $smtx_model_eval_re.loop
+  ((x1 $native_Int)(x2 $native_Int) (x3 $smt_RegLan) (t1 $smt_Value) (t2 $smt_Value) (t3 $smt_Value))
+  :signature ($smt_Value $smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_re.loop ($vsm_numeral x1) ($vsm_numeral x2) ($vsm_re x3)) ($smtx_model_eval_ite ($smtx_model_eval_> ($vsm_numeral x1) ($vsm_numeral x2)) ($vsm_re ($native_apply_0 "re.none")) ($smtx_model_eval_re.loop_rec ($native_z_to_n ($native_z_- x2 x1)) ($vsm_numeral x1) ($vsm_numeral x2) ($vsm_re x3))))
+  (($smtx_model_eval_re.loop t1 t2 t3) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_re.loop
+  ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_re.loop ($sm_re.loop x1 x2 x3))  ($smtx_typeof_re.loop x1 x2 ($smtx_typeof x3)))
+  )
+)
+(program $eoc_eval_re.loop
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_re.loop M ($sm_re.loop x1 x2 x3)) ($smtx_model_eval_re.loop ($smtx_model_eval M x1) ($smtx_model_eval M x2) ($smtx_model_eval M x3)))
+  )
+)
+
+; -- str.in_re
+(declare-parameterized-const $emb_sm.str.in_re ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_str.in_re ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.str.in_re x1 x2))
+(program $smtx_model_eval_str.in_re
+  ((x1 $smt_Seq)(x2 $smt_RegLan) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_str.in_re ($vsm_seq x1) ($vsm_re x2)) ($vsm_bool ($native_apply_2 "str_in_re" ($native_apply_1 "unpack_seq" x1) x2)))
+  (($smtx_model_eval_str.in_re t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_str.in_re
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_str.in_re ($sm_str.in_re x1 x2)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_String) ($native_ite ($native_Teq ($smtx_typeof x2) $tsm_RegLan) $tsm_Bool $tsm_none) $tsm_none))
+  )
+)
+(program $eoc_eval_str.in_re
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_str.in_re M ($sm_str.in_re x1 x2)) ($smtx_model_eval_str.in_re ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- str.indexof_re_split
+(declare-parameterized-const $emb_sm.str.indexof_re_split ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque) (x3 $smt_Term :opaque)) $smt_Term)
+(define $sm_str.indexof_re_split ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term)) ($emb_sm.str.indexof_re_split x1 x2 x3))
+(program $smtx_model_eval_str.indexof_re_split
+  ((x1 $smt_Seq)(x2 $smt_RegLan) (x3 $smt_RegLan) (t1 $smt_Value) (t2 $smt_Value) (t3 $smt_Value))
+  :signature ($smt_Value $smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_str.indexof_re_split ($vsm_seq x1) ($vsm_re x2) ($vsm_re x3)) ($vsm_numeral ($native_apply_3 "str_indexof_re_split" ($native_apply_1 "unpack_seq" x1) x2 x3)))
+  (($smtx_model_eval_str.indexof_re_split t1 t2 t3) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_str.indexof_re_split
+  ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_str.indexof_re_split ($sm_str.indexof_re_split x1 x2 x3)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_String) ($native_ite ($native_Teq ($smtx_typeof x2) $tsm_RegLan) ($native_ite ($native_Teq ($smtx_typeof x3) $tsm_RegLan) $tsm_Int $tsm_none) $tsm_none) $tsm_none))
+  )
+)
+(program $eoc_eval_str.indexof_re_split
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_str.indexof_re_split M ($sm_str.indexof_re_split x1 x2 x3)) ($smtx_model_eval_str.indexof_re_split ($smtx_model_eval M x1) ($smtx_model_eval M x2) ($smtx_model_eval M x3)))
+  )
+)
+
+; -- seq.unit
+(declare-parameterized-const $emb_sm.seq.unit ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_seq.unit ((x1 $smt_Term)) ($emb_sm.seq.unit x1))
+(program $eoc_typeof_seq.unit
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_seq.unit ($sm_seq.unit x1)) ($smtx_typeof_guard_wf ($emb_tsm.Seq ($smtx_typeof x1)) ($emb_tsm.Seq ($smtx_typeof x1))))
+  )
+)
+(program $eoc_eval_seq.unit
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_seq.unit M ($sm_seq.unit x1)) (eo::define ((e1 ($smtx_model_eval M x1))) ($emb_vsm.Seq ($emb_ssm.cons e1 ($emb_ssm.empty ($smtx_typeof_value e1))))))
+  )
+)
+
+; -- seq.nth
+(program $smtx_ssm_seq_nth
+  ((v $smt_Value) (vs $smt_Seq) (n $native_Int) (T $smt_Type) (d $smt_Value))
+  :signature ($smt_Seq $native_Int $smt_Value) $smt_Value
+  (
+  (($smtx_ssm_seq_nth ($ssm_empty T) n d)                     d)
+  (($smtx_ssm_seq_nth ($ssm_cons v vs) $native_z_zero d) v)
+  (($smtx_ssm_seq_nth ($ssm_cons v vs) n d)
+    ($smtx_ssm_seq_nth vs ($native_z_dec n) d))
+  )
+)
+
+(program $smtx_seq_nth_wrong
+  ((M $smt_Model) (s $smt_Seq) (n $native_Int) (T $smt_Type))
+  :signature ($smt_Model $smt_Seq $native_Int $smt_Type) $smt_Value
+  (
+  (($smtx_seq_nth_wrong M s n ($tsm_Seq T))
+    ($smtx_map_select
+      ($smtx_map_select
+        ($native_apply_3 "model_lookup" M ($native_apply_0 "oob_seq_nth_id")
+          ($tsm_Map ($tsm_Seq T) ($tsm_Map $tsm_Int T)))
+        ($vsm_seq s))
+      ($vsm_numeral n)))
+  (($smtx_seq_nth_wrong M s n T)  $vsm_not_value)
+  )
+)
+
+; Sequence nth
+(program $smtx_seq_nth
+  ((M $smt_Model) (s $smt_Seq) (n $native_Int) (v1 $smt_Value) (v2 $smt_Value))
+  :signature ($smt_Model $smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_seq_nth M ($vsm_seq s) ($vsm_numeral n))
+    ($smtx_ssm_seq_nth s n ($smtx_seq_nth_wrong M s n ($smtx_typeof_seq_value s))))
+  (($smtx_seq_nth M v1 v2) $vsm_not_value)
+  )
+)
+
+(declare-parameterized-const $emb_sm.seq.nth ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_seq.nth ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.seq.nth x1 x2))
+(program $smtx_typeof_seq.nth ( (x1 $smt_Type) (x2 $smt_Type)  (x3 $smt_Type))
+  :signature ($smt_Type $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_seq.nth ($tsm_Seq x1) $tsm_Int) ($smtx_typeof_guard_wf x1 x1))
+  (($smtx_typeof_seq.nth x2 x3) $tsm_none)
+  )
+)
+(program $eoc_typeof_seq.nth
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_seq.nth ($sm_seq.nth x1 x2))  ($smtx_typeof_seq.nth ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_seq.nth
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_seq.nth M ($sm_seq.nth x1 x2)) (eo::define ((e1 ($smtx_model_eval M x1))) (eo::define ((e2 ($smtx_model_eval M x2))) ($smtx_seq_nth M e1 e2))))
+  )
+)
+
+; -- @strings_occur_index
+(declare-parameterized-const $emb_sm.@strings_occur_index ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque) (x3 $smt_Term :opaque)) $smt_Term)
+(define $sm_@strings_occur_index ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term)) ($emb_sm.@strings_occur_index x1 x2 x3))
+(program $smtx_model_eval_@strings_occur_index
+  ((x1 $smt_Seq)(x2 $smt_Seq) (x3 $native_Int) (t1 $smt_Value) (t2 $smt_Value) (t3 $smt_Value))
+  :signature ($smt_Value $smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_@strings_occur_index ($vsm_seq x1) ($vsm_seq x2) ($vsm_numeral x3)) ($emb_vsm.Numeral ($native_apply_3 "seq.occur_index" ($native_apply_1 "unpack_seq" x1) ($native_apply_1 "unpack_seq" x2) x3)))
+  (($smtx_model_eval_@strings_occur_index t1 t2 t3) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_@strings_occur_index
+  ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_@strings_occur_index ($sm_@strings_occur_index x1 x2 x3)) ($smtx_typeof_str.indexof ($smtx_typeof x1) ($smtx_typeof x2) ($smtx_typeof x3)))
+  )
+)
+(program $eoc_eval_@strings_occur_index
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_@strings_occur_index M ($sm_@strings_occur_index x1 x2 x3)) ($smtx_model_eval_@strings_occur_index ($smtx_model_eval M x1) ($smtx_model_eval M x2) ($smtx_model_eval M x3)))
+  )
+)
+
+; -- @strings_occur_index_re
+(declare-parameterized-const $emb_sm.@strings_occur_index_re ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque) (x3 $smt_Term :opaque)) $smt_Term)
+(define $sm_@strings_occur_index_re ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term)) ($emb_sm.@strings_occur_index_re x1 x2 x3))
+(program $smtx_model_eval_@strings_occur_index_re
+  ((x1 $smt_Seq)(x2 $smt_RegLan) (x3 $native_Int) (t1 $smt_Value) (t2 $smt_Value) (t3 $smt_Value))
+  :signature ($smt_Value $smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_@strings_occur_index_re ($vsm_seq x1) ($vsm_re x2) ($vsm_numeral x3)) ($vsm_numeral ($native_apply_3 "str_occur_index_re" ($native_apply_1 "unpack_seq" x1) x2 x3)))
+  (($smtx_model_eval_@strings_occur_index_re t1 t2 t3) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_@strings_occur_index_re
+  ((x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_@strings_occur_index_re ($sm_@strings_occur_index_re x1 x2 x3)) ($native_ite ($native_Teq ($smtx_typeof x1) $tsm_String) ($native_ite ($native_Teq ($smtx_typeof x2) $tsm_RegLan) ($native_ite ($native_Teq ($smtx_typeof x3) $tsm_Int) $tsm_Int $tsm_none) $tsm_none) $tsm_none))
+  )
+)
+(program $eoc_eval_@strings_occur_index_re
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term) (x3 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_@strings_occur_index_re M ($sm_@strings_occur_index_re x1 x2 x3)) ($smtx_model_eval_@strings_occur_index_re ($smtx_model_eval M x1) ($smtx_model_eval M x2) ($smtx_model_eval M x3)))
+  )
+)
+
+; -- set.empty
+(declare-parameterized-const $emb_sm.set.empty ((x1 $smt_Type :opaque)) $smt_Term)
+(define $sm_set.empty ((x1 $smt_Type)) ($emb_sm.set.empty x1))
+(program $eoc_typeof_set.empty
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_set.empty ($sm_set.empty x1)) ($smtx_typeof_guard_wf ($emb_tsm.Set x1) ($emb_tsm.Set x1)))
+  )
+)
+(program $eoc_eval_set.empty
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_set.empty M ($sm_set.empty x1)) ($emb_vsm.Set ($emb_msm.default x1 ($emb_vsm.Boolean ($native_apply_0 "false")))))
+  )
+)
+
+; -- set.singleton
+(declare-parameterized-const $emb_sm.set.singleton ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_set.singleton ((x1 $smt_Term)) ($emb_sm.set.singleton x1))
+(program $smtx_model_eval_set.singleton
+  ((x1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_set.singleton x1) ($emb_vsm.Set ($emb_msm.cons x1 ($emb_vsm.Boolean ($native_apply_0 "true")) ($emb_msm.default ($smtx_typeof_value x1) ($emb_vsm.Boolean ($native_apply_0 "false"))))))
+  )
+)
+(program $eoc_typeof_set.singleton
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_set.singleton ($sm_set.singleton x1)) ($smtx_typeof_guard_wf ($emb_tsm.Set ($smtx_typeof x1)) ($emb_tsm.Set ($smtx_typeof x1))))
+  )
+)
+(program $eoc_eval_set.singleton
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_set.singleton M ($sm_set.singleton x1)) ($smtx_model_eval_set.singleton ($smtx_model_eval M x1)))
+  )
+)
+
+; -- $smtx_index_typeof_map
+; The type a map is indexed by, which for a set is the type of its elements.
+(program $smtx_index_typeof_map ((T $smt_Type) (U $smt_Type))
+  :signature ($smt_Type) $smt_Type
+  (
+  (($smtx_index_typeof_map ($tsm_Map T U)) T)
+  (($smtx_index_typeof_map T) $tsm_none)
+  )
+)
+
+; -- $smtx_typeof_sets_op_2
+; The type of a set operator whose two arguments must be sets of one type.
+(program $smtx_typeof_sets_op_2 ((x1 $smt_Type) (x2 $smt_Type))
+  :signature ($smt_Type $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_sets_op_2 ($tsm_Set x1) ($tsm_Set x2))
+    ($native_ite ($native_Teq x1 x2) ($tsm_Set x1) $tsm_none))
+  (($smtx_typeof_sets_op_2 x1 x2) $tsm_none)
+  )
+)
+
+; -- $smtx_mss_op_internal
+; Binary set operators, computed over the map a set is. It takes a flag and
+; the two maps, and accumulates into the third: with the flag it keeps what
+; lies in both, and without it what lies in the first alone.
+(program $smtx_mss_op_internal
+  ((T $smt_Type) (m1 $smt_Map) (m2 $smt_Map) (acc $smt_Map) (e $smt_Value)
+   (efalse $smt_Value) (etrue $smt_Value) (isInter $native_Bool))
+  :signature ($native_Bool $smt_Map $smt_Map $smt_Map) $smt_Map
+  (
+  ; note we don't insist on true/false here, to ensure the function is total
+  (($smtx_mss_op_internal isInter ($msm_default T efalse) m2 acc) acc)
+  (($smtx_mss_op_internal isInter ($msm_cons e etrue m1) m2 acc)
+    ($smtx_mss_op_internal isInter m1 m2
+      ($native_ite
+        ($native_iff ($native_veq ($smtx_msm_lookup m2 e) $vsm_true) isInter)
+        ($smtx_msm_update acc e $vsm_true)
+        acc)))
+  )
+)
+
+; -- set.union
+; Set union
+; return the union of two set values.
+(program $smtx_set_union
+  ((m1 $smt_Map) (m2 $smt_Map) (v1 $smt_Value) (v2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_set_union ($vsm_set m1) ($vsm_set m2))
+    ; m1 minus the empty set starting with m2.
+    ($vsm_set ($smtx_mss_op_internal $native_false m1 ($msm_empty_set ($smtx_index_typeof_map ($smtx_typeof_map_value m1))) m2)))
+  (($smtx_set_union v1 v2)  $vsm_not_value)
+  )
+)
+
+(declare-parameterized-const $emb_sm.set.union ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_set.union ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.set.union x1 x2))
+(program $smtx_model_eval_set.union
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_set.union x1 x2) ($smtx_set_union x1 x2))
+  )
+)
+(program $eoc_typeof_set.union
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_set.union ($sm_set.union x1 x2)) ($smtx_typeof_sets_op_2 ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_set.union
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_set.union M ($sm_set.union x1 x2)) ($smtx_model_eval_set.union ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- set.inter
+; Set intersection
+; return the intersection of two set values.
+(program $smtx_set_inter
+  ((m1 $smt_Map) (m2 $smt_Map) (v1 $smt_Value) (v2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_set_inter ($vsm_set m1) ($vsm_set m2))
+    ; m1 intersected m2 starting with empty set.
+    ($vsm_set ($smtx_mss_op_internal $native_true m1 m2 ($msm_empty_set ($smtx_index_typeof_map ($smtx_typeof_map_value m1))))))
+  (($smtx_set_inter v1 v2)  $vsm_not_value)
+  )
+)
+
+(declare-parameterized-const $emb_sm.set.inter ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_set.inter ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.set.inter x1 x2))
+(program $smtx_model_eval_set.inter
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_set.inter x1 x2) ($smtx_set_inter x1 x2))
+  )
+)
+(program $eoc_typeof_set.inter
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_set.inter ($sm_set.inter x1 x2)) ($smtx_typeof_sets_op_2 ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_set.inter
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_set.inter M ($sm_set.inter x1 x2)) ($smtx_model_eval_set.inter ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- set.minus
+; Set minus
+; return the set minus of two set values.
+(program $smtx_set_minus
+  ((m1 $smt_Map) (m2 $smt_Map) (v1 $smt_Value) (v2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_set_minus ($vsm_set m1) ($vsm_set m2))
+    ; m1 minus m2 starting with empty set.
+    ($vsm_set ($smtx_mss_op_internal $native_false m1 m2 ($msm_empty_set ($smtx_index_typeof_map ($smtx_typeof_map_value m1))))))
+  (($smtx_set_minus v1 v2)  $vsm_not_value)
+  )
+)
+
+(declare-parameterized-const $emb_sm.set.minus ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_set.minus ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.set.minus x1 x2))
+(program $smtx_model_eval_set.minus
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_set.minus x1 x2) ($smtx_set_minus x1 x2))
+  )
+)
+(program $eoc_typeof_set.minus
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_set.minus ($sm_set.minus x1 x2)) ($smtx_typeof_sets_op_2 ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_set.minus
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_set.minus M ($sm_set.minus x1 x2)) ($smtx_model_eval_set.minus ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- set.member
+(declare-parameterized-const $emb_sm.set.member ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_set.member ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.set.member x1 x2))
+(program $smtx_typeof_set.member ( (x1 $smt_Type) (x2 $smt_Type)  (x3 $smt_Type)  (x4 $smt_Type))
+  :signature ($smt_Type $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_set.member x1 ($tsm_Set x2)) ($native_ite ($native_Teq x1 x2) $tsm_Bool $tsm_none))
+  (($smtx_typeof_set.member x3 x4) $tsm_none)
+  )
+)
+(program $smtx_model_eval_set.member
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_set.member x1 x2) ($smtx_map_select x2 x1))
+  )
+)
+(program $eoc_typeof_set.member
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_set.member ($sm_set.member x1 x2))  ($smtx_typeof_set.member ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_set.member
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_set.member M ($sm_set.member x1 x2)) ($smtx_model_eval_set.member ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- $smtx_typeof_sets_op_2_ret
+; The same, for one that returns a type given rather than its arguments'.
+(program $smtx_typeof_sets_op_2_ret
+  ((T $smt_Type) (U $smt_Type) (V $smt_Type) (x1 $smt_Type) (x2 $smt_Type))
+  :signature ($smt_Type $smt_Type $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_sets_op_2_ret ($tsm_Set x1) ($tsm_Set x2) T)
+    ($native_ite ($native_Teq x1 x2) T $tsm_none))
+  (($smtx_typeof_sets_op_2_ret T U V) $tsm_none)
+  )
+)
+
+; -- set.subset
+(declare-parameterized-const $emb_sm.set.subset ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_set.subset ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.set.subset x1 x2))
+(program $smtx_model_eval_set.subset
+  ((x1 $smt_Value)(x2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_set.subset x1 x2) ($smtx_model_eval_= ($smtx_model_eval_set.inter x1 x2) x1))
+  )
+)
+(program $eoc_typeof_set.subset
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_set.subset ($sm_set.subset x1 x2)) ($smtx_typeof_sets_op_2_ret ($smtx_typeof x1) ($smtx_typeof x2) $tsm_Bool))
+  )
+)
+(program $eoc_eval_set.subset
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_set.subset M ($sm_set.subset x1 x2)) ($smtx_model_eval_set.subset ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- /_total
+(declare-parameterized-const $emb_sm./_total ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_/_total ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm./_total x1 x2))
+(program $smtx_model_eval_/_total
+  ((x1 $native_Int)(x2 $native_Int) (x3 $native_Real) (x4 $native_Real) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_/_total ($vsm_numeral x1) ($vsm_numeral x2)) ($vsm_rational ($native_z_/_total x1 x2)))
+  (($smtx_model_eval_/_total ($vsm_rational x3) ($vsm_rational x4)) ($vsm_rational ($native_q_/_total x3 x4)))
+  (($smtx_model_eval_/_total t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_/_total
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_/_total ($sm_/_total x1 x2)) ($smtx_typeof_arith_overload_op_2_ret ($smtx_typeof x1) ($smtx_typeof x2) $tsm_Real))
+  )
+)
+(program $eoc_eval_/_total
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_/_total M ($sm_/_total x1 x2)) ($smtx_model_eval_/_total ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- /
+(program $smtx_model_eval_to_real_coerce ((x1 $native_Int) (x2 $native_Rat) (v $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_to_real_coerce ($vsm_numeral x1)) ($vsm_rational ($native_apply_1 "to_real" x1)))
+  (($smtx_model_eval_to_real_coerce ($vsm_rational x2)) ($vsm_rational x2))
+  (($smtx_model_eval_to_real_coerce v) $vsm_not_value)
+  )
+)
+
+(declare-parameterized-const $emb_sm./ ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_/ ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm./ x1 x2))
+(program $eoc_typeof_/
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_/ ($sm_/ x1 x2)) ($smtx_typeof_arith_overload_op_2_ret ($smtx_typeof x1) ($smtx_typeof x2) $tsm_Real))
+  )
+)
+(program $eoc_eval_/
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_/ M ($sm_/ x1 x2)) (eo::define ((e1 ($smtx_model_eval M x1))) (eo::define ((e2 ($smtx_model_eval M x2))) ($smtx_model_eval_ite ($smtx_model_eval_= ($smtx_model_eval_to_real_coerce e2) $vsm_q_zero) ($smtx_model_eval_apply M ($native_apply_3 "model_lookup" M ($native_apply_0 "/_by_zero_id") ($emb_tsm.FunType $emb_tsm.Real $emb_tsm.Real)) ($smtx_model_eval_to_real_coerce e1)) ($smtx_model_eval_/_total ($smtx_model_eval_to_real_coerce e1) ($smtx_model_eval_to_real_coerce e2))))))
+  )
+)
+
+; -- int_to_bv
+(declare-parameterized-const $emb_sm.int_to_bv ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque)) $smt_Term)
+(define $sm_int_to_bv ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.int_to_bv x1 x2))
+(program $smtx_typeof_int_to_bv ( (x1 $native_Int) (x2 $smt_Type)  (x3 $smt_Type))
+  :signature ($smt_Term $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_int_to_bv ($sm_numeral x1) $tsm_Int) ($native_ite ($native_apply_2 "zleq" ($native_apply_0 "0") x1) ($tsm_BitVec ($native_apply_1 "int.to_nat" x1)) $tsm_none))
+  (($smtx_typeof_int_to_bv x2 x3) $tsm_none)
+  )
+)
+(program $smtx_model_eval_int_to_bv
+  ((x1 $native_Int)(x2 $native_Int) (t1 $smt_Value) (t2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_int_to_bv ($vsm_numeral x1) ($vsm_numeral x2)) ($emb_vsm.Binary x1 ($native_apply_2 "mod_total" x2 ($native_apply_1 "int.pow2" x1))))
+  (($smtx_model_eval_int_to_bv t1 t2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_int_to_bv
+  ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_int_to_bv ($sm_int_to_bv x1 x2))  ($smtx_typeof_int_to_bv x1 ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_int_to_bv
+  ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_int_to_bv M ($sm_int_to_bv x1 x2)) ($smtx_model_eval_int_to_bv ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- ubv_to_int
+(declare-parameterized-const $emb_sm.ubv_to_int ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_ubv_to_int ((x1 $smt_Term)) ($emb_sm.ubv_to_int x1))
+(program $smtx_model_eval_ubv_to_int
+  ((x1 $native_Int) (x2 $native_Int) (t1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_ubv_to_int ($vsm_binary x1 x2)) ($emb_vsm.Numeral x2))
+  (($smtx_model_eval_ubv_to_int t1) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_ubv_to_int
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_ubv_to_int ($sm_ubv_to_int x1)) ($smtx_typeof_bv_op_1_ret ($smtx_typeof x1) $tsm_Int))
+  )
+)
+(program $eoc_eval_ubv_to_int
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_ubv_to_int M ($sm_ubv_to_int x1)) ($smtx_model_eval_ubv_to_int ($smtx_model_eval M x1)))
+  )
+)
+
+; -- sbv_to_int
+(declare-parameterized-const $emb_sm.sbv_to_int ((x1 $smt_Term :opaque)) $smt_Term)
+(define $sm_sbv_to_int ((x1 $smt_Term)) ($emb_sm.sbv_to_int x1))
+(program $smtx_model_eval_sbv_to_int
+  ((x1 $native_Int) (x2 $native_Int) (t1 $smt_Value))
+  :signature ($smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_sbv_to_int ($vsm_binary x1 x2)) ($emb_vsm.Numeral ($native_apply_2 "binary_uts" x1 x2)))
+  (($smtx_model_eval_sbv_to_int t1) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_sbv_to_int
+  ((x1 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_sbv_to_int ($sm_sbv_to_int x1)) ($smtx_typeof_bv_op_1_ret ($smtx_typeof x1) $tsm_Int))
+  )
+)
+(program $eoc_eval_sbv_to_int
+  ((M $smt_Model) (x1 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_sbv_to_int M ($sm_sbv_to_int x1)) ($smtx_model_eval_sbv_to_int ($smtx_model_eval M x1)))
+  )
+)
+
+; -- map_diff
+; map difference
+(declare-parameterized-const $emb_sm.map_diff
+  ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque))
+  $smt_Term)
+(define $sm_map_diff ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.map_diff x1 x2))
+(program $smtx_typeof_map_diff
+  ((T1 $smt_Type) (U1 $smt_Type) (T2 $smt_Type) (U2 $smt_Type))
+  :signature ($smt_Type $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_map_diff ($tsm_Map T1 U1) ($tsm_Map T2 U2))
+    ($native_ite ($native_and ($native_Teq T1 T2) ($native_Teq U1 U2)) T1 $tsm_none))
+  (($smtx_typeof_map_diff ($tsm_Set T1) ($tsm_Set T2))
+    ($native_ite ($native_Teq T1 T2) T1 $tsm_none))
+  (($smtx_typeof_map_diff T1 T2) $tsm_none)
+  )
+)
+(program $smtx_model_eval_map_diff
+  ((m1 $smt_Map) (m2 $smt_Map) (v1 $smt_Value) (v2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_map_diff ($vsm_map m1) ($vsm_map m2)) ($native_apply_2 "eval_map_diff_msm" m1 m2))
+  (($smtx_model_eval_map_diff ($vsm_set m1) ($vsm_set m2)) ($native_apply_2 "eval_map_diff_msm" m1 m2))
+  (($smtx_model_eval_map_diff v1 v2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_map_diff ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_map_diff ($sm_map_diff x1 x2))
+    ($smtx_typeof_map_diff ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_map_diff ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_map_diff M ($sm_map_diff x1 x2))
+    ($smtx_model_eval_map_diff ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)
+
+; -- seq_diff
+; sequence difference
+; Given two sequences x1 and x2 of the same type, returns an index (of type
+; Int) at which they differ, if any. This is the sequence analogue of map
+; difference above, where the witness is an index instead of a key.
+(declare-parameterized-const $emb_sm.seq_diff
+  ((x1 $smt_Term :opaque) (x2 $smt_Term :opaque))
+  $smt_Term)
+(define $sm_seq_diff ((x1 $smt_Term) (x2 $smt_Term)) ($emb_sm.seq_diff x1 x2))
+(program $smtx_typeof_seq_diff
+  ((T1 $smt_Type) (T2 $smt_Type))
+  :signature ($smt_Type $smt_Type) $smt_Type
+  (
+  (($smtx_typeof_seq_diff ($tsm_Seq T1) ($tsm_Seq T2))
+    ($native_ite ($native_Teq T1 T2) $tsm_Int $tsm_none))
+  (($smtx_typeof_seq_diff T1 T2) $tsm_none)
+  )
+)
+(program $smtx_model_eval_seq_diff
+  ((s1 $smt_Seq) (s2 $smt_Seq) (v1 $smt_Value) (v2 $smt_Value))
+  :signature ($smt_Value $smt_Value) $smt_Value
+  (
+  (($smtx_model_eval_seq_diff ($vsm_seq s1) ($vsm_seq s2)) ($native_apply_2 "eval_seq_diff_ssm" s1 s2))
+  (($smtx_model_eval_seq_diff v1 v2) $vsm_not_value)
+  )
+)
+(program $eoc_typeof_seq_diff ((x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Term) $smt_Type
+  (
+  (($eoc_typeof_seq_diff ($sm_seq_diff x1 x2))
+    ($smtx_typeof_seq_diff ($smtx_typeof x1) ($smtx_typeof x2)))
+  )
+)
+(program $eoc_eval_seq_diff ((M $smt_Model) (x1 $smt_Term) (x2 $smt_Term))
+  :signature ($smt_Model $smt_Term) $smt_Value
+  (
+  (($eoc_eval_seq_diff M ($sm_seq_diff x1 x2))
+    ($smtx_model_eval_seq_diff ($smtx_model_eval M x1) ($smtx_model_eval M x2)))
+  )
+)


### PR DESCRIPTION
This plugin defines the official semantics for SMT-LIB and the correspondence between CPC terms and SMT-LIB terms.

It contains two Eunoia signatures which currently are hardcoded (they will be compiled from a higher-level source and abstracted further in followup PRs).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>