### PR TITLE
Add core Eunoia compiler infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 build
+build-eoc
+tools/eoc/out
+tools/eoc/__pycache__
 .vscode
 .DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,12 +71,9 @@ add_subdirectory(tests)
 # which additionally links them; see plugins/CMakeLists.txt.
 #
 # cpp_compiler is skipped: it is a snapshot from an earlier version of ethos
-# and is known not to compile (see plugins/cpp_compiler/README.md). scratch
-# directories are skipped as well: they hold code fragments kept for reference,
-# which are not standalone translation units.
+# and is known not to compile (see plugins/cpp_compiler/README.md).
 file(GLOB_RECURSE plugins_SRC CONFIGURE_DEPENDS "plugins/*.cpp")
 list(FILTER plugins_SRC EXCLUDE REGEX "/plugins/cpp_compiler/")
-list(FILTER plugins_SRC EXCLUDE REGEX "/scratch/")
 if(plugins_SRC)
   add_library(plugins-compile-check OBJECT EXCLUDE_FROM_ALL ${plugins_SRC})
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,16 +60,23 @@ add_subdirectory(src)
 add_subdirectory(tests)
 
 # Compile-only check for the experimental extensions in plugins/. Those are
-# not part of ethos and produce nothing here; this target exists so that CI
-# can catch them bitrotting against src/. It is EXCLUDE_FROM_ALL, so an
-# ordinary build never sees it. Build it explicitly with:
+# not part of ethos and produce nothing here; this target exists so that they
+# can be checked for bitrot against src/ from an ordinary build tree. It is
+# EXCLUDE_FROM_ALL, so an ordinary build never sees it. Build it explicitly
+# with:
 #
 #   make plugins-compile-check
 #
+# The standalone project in plugins/ builds the same sources into ethos-eoc,
+# which additionally links them; see plugins/CMakeLists.txt.
+#
 # cpp_compiler is skipped: it is a snapshot from an earlier version of ethos
-# and is known not to compile (see plugins/cpp_compiler/README.md).
+# and is known not to compile (see plugins/cpp_compiler/README.md). scratch
+# directories are skipped as well: they hold code fragments kept for reference,
+# which are not standalone translation units.
 file(GLOB_RECURSE plugins_SRC CONFIGURE_DEPENDS "plugins/*.cpp")
 list(FILTER plugins_SRC EXCLUDE REGEX "/plugins/cpp_compiler/")
+list(FILTER plugins_SRC EXCLUDE REGEX "/scratch/")
 if(plugins_SRC)
   add_library(plugins-compile-check OBJECT EXCLUDE_FROM_ALL ${plugins_SRC})
 else()

--- a/README.md
+++ b/README.md
@@ -53,16 +53,3 @@ You can also filter tests using regular expressions for example:
 ```
 ctest -R arith
 ```
-
-## Optional `ethos-eoc` pipeline
-
-The experimental Eunoia compiler workflow is built as a separate standalone
-project in [`plugins/`](plugins/), leaving the core ethos build untouched:
-
-```bash
-cmake -S plugins -B build-eoc
-cmake --build build-eoc --target ethos-eoc -j4
-```
-
-The workflow is driven by [`tools/eoc/driver.py`](tools/eoc/driver.py);
-detailed usage is documented in [`tools/eoc/README.md`](tools/eoc/README.md).

--- a/README.md
+++ b/README.md
@@ -53,3 +53,16 @@ You can also filter tests using regular expressions for example:
 ```
 ctest -R arith
 ```
+
+## Optional `ethos-eoc` pipeline
+
+The experimental Eunoia compiler workflow is built as a separate standalone
+project in [`plugins/`](plugins/), leaving the core ethos build untouched:
+
+```bash
+cmake -S plugins -B build-eoc
+cmake --build build-eoc --target ethos-eoc -j4
+```
+
+The workflow is driven by [`tools/eoc/driver.py`](tools/eoc/driver.py);
+detailed usage is documented in [`tools/eoc/README.md`](tools/eoc/README.md).

--- a/cmake/EthosPlugin.cmake
+++ b/cmake/EthosPlugin.cmake
@@ -1,6 +1,12 @@
-# Build an Ethos executable with a plugin selected by its header and class.
-# The generic factory in src/plugin.cpp performs the construction, so plugin
-# projects only need to provide their implementation sources.
+# Shared CMake infrastructure for the plugin projects under plugins/. These
+# are standalone projects that build against the ethos core in src/, so this
+# module holds the settings they would otherwise each duplicate: the build
+# flags (ethos_configure_target), the build type (ethos_set_default_build_type),
+# the ethos core library (ethos_add_core_library), and the single-plugin
+# executable driven by the generic factory in src/plugin.cpp
+# (add_ethos_plugin_executable).
+#
+# Callers must find_package(GMP REQUIRED) before including this module.
 
 get_filename_component(ETHOS_PLUGIN_INFRA_SOURCE_DIR
                        "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
@@ -31,4 +37,55 @@ function(add_ethos_plugin_executable target)
     ${target} PRIVATE
     ETHOS_PLUGIN_HEADER="${ETHOS_PLUGIN_PLUGIN_HEADER}"
     ETHOS_PLUGIN_CLASS=${ETHOS_PLUGIN_PLUGIN_CLASS})
+endfunction()
+
+# Apply the ethos build settings (language standard, include paths, warnings,
+# and build-type definitions) to a target of a plugin project. Include paths
+# cover the ethos core and the calling project's own source directory.
+function(ethos_configure_target target)
+  set_target_properties(${target} PROPERTIES
+                        CXX_STANDARD 17
+                        CXX_STANDARD_REQUIRED YES
+                        CXX_EXTENSIONS YES)
+  target_include_directories(${target} PRIVATE
+                             "${ETHOS_PLUGIN_INFRA_SOURCE_DIR}/src"
+                             "${CMAKE_CURRENT_SOURCE_DIR}"
+                             "${GMP_INCLUDE_DIR}")
+  if(MSVC)
+    target_compile_options(${target} PRIVATE /W4)
+  else()
+    target_compile_options(${target} PRIVATE -Wall -Wno-deprecated)
+  endif()
+  if(WIN32)
+    target_compile_definitions(${target} PRIVATE USE_CPP_FILESYSTEM)
+  endif()
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_definitions(${target} PRIVATE EO_ASSERTIONS EO_TRACING)
+  endif()
+endfunction()
+
+# Validate CMAKE_BUILD_TYPE for a plugin project, defaulting to Release.
+macro(ethos_set_default_build_type)
+  if(NOT CMAKE_BUILD_TYPE)
+    message(STATUS "Defaulting to release build.")
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "" FORCE)
+  endif()
+  if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug"
+     AND NOT CMAKE_BUILD_TYPE STREQUAL "Release")
+    message(FATAL_ERROR "Invalid build type '${CMAKE_BUILD_TYPE}'")
+  endif()
+endmacro()
+
+# Add a static library holding the ethos core: everything under src/ except
+# main.cpp and plugin.cpp. Executables bring their own entry point, and
+# add_ethos_plugin_executable compiles src/plugin.cpp into the executable
+# itself, where the plugin selection macros are defined.
+function(ethos_add_core_library target)
+  file(GLOB_RECURSE ethos_core_SRC CONFIGURE_DEPENDS
+       "${ETHOS_PLUGIN_INFRA_SOURCE_DIR}/src/*.cpp")
+  list(FILTER ethos_core_SRC EXCLUDE REGEX "/src/main\\.cpp$")
+  list(FILTER ethos_core_SRC EXCLUDE REGEX "/src/plugin\\.cpp$")
+  add_library(${target} STATIC ${ethos_core_SRC})
+  ethos_configure_target(${target})
+  target_link_libraries(${target} PUBLIC ${GMP_LIBRARIES})
 endfunction()

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,0 +1,44 @@
+# Standalone build for ethos-eoc: the ethos core plus the Eunoia compiler
+# plugins in this directory. This is deliberately a separate project so that
+# the core ethos build is unaffected by the plugins. From the repository
+# root, configure and build with:
+#
+#   cmake -S plugins -B build-eoc
+#   cmake --build build-eoc --target ethos-eoc -j4
+#
+# The tools/eoc/driver.py script configures and builds this project
+# automatically.
+cmake_minimum_required (VERSION 3.12)
+
+project (ethos_eoc LANGUAGES CXX)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+get_filename_component(ETHOS_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
+set(CMAKE_MODULE_PATH "${ETHOS_SOURCE_DIR}/cmake")
+
+find_package(GMP REQUIRED)
+include(EthosPlugin)
+
+ethos_set_default_build_type()
+
+ethos_add_core_library(ethos-eoc-core)
+
+# Every plugin source in this directory, matching the plugins-compile-check
+# target in the top-level CMakeLists.txt so that the two cannot drift: a new
+# plugin source is picked up by both. cpp_compiler is its own project (see
+# cpp_compiler/CMakeLists.txt).
+file(GLOB_RECURSE ethos_eoc_SRC CONFIGURE_DEPENDS
+     "${CMAKE_CURRENT_LIST_DIR}/*.cpp")
+list(FILTER ethos_eoc_SRC EXCLUDE REGEX "/cpp_compiler/")
+
+add_executable(ethos-eoc ${ethos_eoc_SRC})
+ethos_configure_target(ethos-eoc)
+target_link_libraries(ethos-eoc PRIVATE ethos-eoc-core)
+
+# Where the plugins read their .eo/.lean inputs from and write their outputs
+# to, see StdPlugin::getSourceDirectory and StdPlugin::getOutputDirectory.
+target_compile_definitions(
+  ethos-eoc PRIVATE
+  ETHOS_PLUGIN_SOURCE_DIR="${ETHOS_SOURCE_DIR}"
+  ETHOS_PLUGIN_OUTPUT_DIR="${PROJECT_BINARY_DIR}/out")

--- a/plugins/cpp_compiler/CMakeLists.txt
+++ b/plugins/cpp_compiler/CMakeLists.txt
@@ -11,14 +11,7 @@ set(CMAKE_MODULE_PATH "${ETHOS_SOURCE_DIR}/cmake")
 find_package(GMP REQUIRED)
 include(EthosPlugin)
 
-if(NOT CMAKE_BUILD_TYPE)
-  message(STATUS "Defaulting to release build.")
-  set(CMAKE_BUILD_TYPE Release CACHE STRING "" FORCE)
-endif()
-if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug"
-   AND NOT CMAKE_BUILD_TYPE STREQUAL "Release")
-  message(FATAL_ERROR "Invalid build type '${CMAKE_BUILD_TYPE}'")
-endif()
+ethos_set_default_build_type()
 
 set(ETHOS_CPP_COMPILER_MODE "" CACHE STRING
     "C++ auto-parser mode: compiler, executor, or test")
@@ -27,35 +20,7 @@ set_property(CACHE ETHOS_CPP_COMPILER_MODE PROPERTY STRINGS
 set(ETHOS_CPP_COMPILER_GENERATED_SOURCE "" CACHE FILEPATH
     "Generated compiled.out.cpp used in executor mode")
 
-function(configure_ethos_target target)
-  set_target_properties(${target} PROPERTIES
-                        CXX_STANDARD 17
-                        CXX_STANDARD_REQUIRED YES
-                        CXX_EXTENSIONS YES)
-  target_include_directories(${target} PRIVATE
-                             "${ETHOS_SOURCE_DIR}/src"
-                             "${CMAKE_CURRENT_LIST_DIR}"
-                             "${GMP_INCLUDE_DIR}")
-  if(MSVC)
-    target_compile_options(${target} PRIVATE /W4)
-  else()
-    target_compile_options(${target} PRIVATE -Wall -Wno-deprecated)
-  endif()
-  if(WIN32)
-    target_compile_definitions(${target} PRIVATE USE_CPP_FILESYSTEM)
-  endif()
-  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    target_compile_definitions(${target} PRIVATE EO_ASSERTIONS EO_TRACING)
-  endif()
-endfunction()
-
-file(GLOB_RECURSE ethos_core_SRC CONFIGURE_DEPENDS
-     "${ETHOS_SOURCE_DIR}/src/*.cpp")
-list(FILTER ethos_core_SRC EXCLUDE REGEX "/src/main\\.cpp$")
-list(FILTER ethos_core_SRC EXCLUDE REGEX "/src/plugin\\.cpp$")
-add_library(ethos-cpp-core STATIC ${ethos_core_SRC})
-configure_ethos_target(ethos-cpp-core)
-target_link_libraries(ethos-cpp-core PUBLIC ${GMP_LIBRARIES})
+ethos_add_core_library(ethos-cpp-core)
 
 if(ETHOS_CPP_COMPILER_MODE STREQUAL "compiler")
   add_ethos_plugin_executable(
@@ -83,7 +48,7 @@ elseif(NOT ETHOS_CPP_COMPILER_MODE STREQUAL "test")
 endif()
 
 if(TARGET ethos)
-  configure_ethos_target(ethos)
+  ethos_configure_target(ethos)
   set_target_properties(ethos PROPERTIES
                         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
   target_link_libraries(ethos PRIVATE ethos-cpp-core)
@@ -105,7 +70,7 @@ file(MAKE_DIRECTORY "${cpp_compiler_test_dir}")
 add_executable(cpp-compiler-generate EXCLUDE_FROM_ALL
                test/generate.cpp
                compiler.cpp)
-configure_ethos_target(cpp-compiler-generate)
+ethos_configure_target(cpp-compiler-generate)
 target_link_libraries(cpp-compiler-generate PRIVATE ethos-cpp-core)
 
 set(cpp_compiler_generated_source
@@ -134,7 +99,7 @@ add_executable(cpp-compiler-replay EXCLUDE_FROM_ALL
                test/replay.cpp
                executor.cpp
                "${cpp_compiler_generated_source}")
-configure_ethos_target(cpp-compiler-replay)
+ethos_configure_target(cpp-compiler-replay)
 target_compile_definitions(
   cpp-compiler-replay PRIVATE
   ETHOS_CPP_COMPILER_TEST_SIGNATURE="${cpp_compiler_relocated_signature}"

--- a/plugins/main_eoc.cpp
+++ b/plugins/main_eoc.cpp
@@ -1,0 +1,230 @@
+/******************************************************************************
+ * This file is part of the ethos project.
+ *
+ * Copyright (c) 2023-2024 by the authors listed in the file AUTHORS
+ * in the top-level source directory and their institutional affiliations.
+ * All rights reserved.  See the file COPYING in the top-level source
+ * directory for licensing information.
+ ******************************************************************************/
+
+/*
+ * Driver for ethos-eoc, the ethos core extended with the Eunoia compiler
+ * plugins in this directory. It is built as a standalone project (see
+ * plugins/CMakeLists.txt) and is typically invoked via tools/eoc/driver.py,
+ * e.g.:
+ *
+ *   ethos-eoc --plugin.desugar <file>
+ *   ethos-eoc --plugin.model-smt --defs=<file> <file>
+ *   ethos-eoc --plugin.lean-meta --lean-config=<file> <file>
+ *
+ * With no --plugin.* argument, it parses the given file like plain ethos.
+ * Unlike the plain ethos binary, it requires a file argument (no stdin mode)
+ * and does not print a proof checking verdict; a run is successful iff the
+ * exit code is 0.
+ */
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "base/check.h"
+#include "base/output.h"
+#include "state.h"
+
+#include "desugar/desugar.h"
+#include "lean_meta/lean_meta_reduce.h"
+#include "model_smt/model_smt.h"
+#include "trim_defs/trim_defs.h"
+
+using namespace ethos;
+
+namespace {
+
+std::unique_ptr<Plugin> createPlugin(const std::string& name,
+                                     State& s,
+                                     bool generateParser,
+                                     const std::string& defsFile,
+                                     const std::string& leanConfigFile)
+{
+  if (name == "desugar")
+  {
+    return std::make_unique<Desugar>(s);
+  }
+  if (name == "lean-meta")
+  {
+    return std::make_unique<LeanMetaReduce>(s, generateParser, leanConfigFile);
+  }
+  if (name == "trim-defs")
+  {
+    return std::make_unique<TrimDefs>(s);
+  }
+  if (name == "model-smt")
+  {
+    return std::make_unique<ModelSmt>(s, defsFile);
+  }
+  EO_FATAL() << "Error: unknown plugin \"" << name
+             << "\" (available: desugar, lean-meta, trim-defs, model-smt)";
+  return nullptr;
+}
+
+}  // namespace
+
+int main(int argc, char* argv[])
+{
+  Options opts;
+  std::string file;
+  bool readFile = false;
+  std::string pluginName;
+  bool generateParser = true;
+  std::string defsFile;
+  std::string leanConfigFile;
+  // the list of includes and whether they were an include or reference
+  std::vector<std::pair<std::string, bool>> includes;
+  size_t i = 1;
+  size_t nargs = static_cast<size_t>(argc);
+  while (i < nargs)
+  {
+    std::string arg(argv[i]);
+    i++;
+    if (arg.compare(0, 9, "--plugin.") == 0)
+    {
+      if (!pluginName.empty())
+      {
+        EO_FATAL() << "Error: multiple plugins specified, \"" << pluginName
+                   << "\" and \"" << arg.substr(9) << "\"";
+      }
+      pluginName = arg.substr(9);
+      continue;
+    }
+    if (arg == "--no-parser")
+    {
+      generateParser = false;
+      continue;
+    }
+    if (arg.compare(0, 7, "--defs=") == 0)
+    {
+      // The signature of the input written in the deep embedding, which says
+      // what each of its symbols means to the model. It is read by the
+      // model-smt plugin alone; no stage before that one sees it.
+      defsFile = arg.substr(7);
+      continue;
+    }
+    if (arg.compare(0, 14, "--lean-config=") == 0)
+    {
+      // What the input signature needs said about its generated Lean that the
+      // compiler cannot derive, namely why each of its recursive programs
+      // terminates. It is read by the lean-meta plugin alone.
+      leanConfigFile = arg.substr(14);
+      continue;
+    }
+    if (arg.compare(0, 5, "--no-") == 0)
+    {
+      if (opts.setOption(arg.substr(5), false))
+      {
+        continue;
+      }
+    }
+    else if (arg.compare(0, 2, "--") == 0)
+    {
+      if (opts.setOption(arg.substr(2), true))
+      {
+        continue;
+      }
+    }
+    bool isInclude = (arg.compare(0, 10, "--include=") == 0);
+    if (isInclude || arg.compare(0, 12, "--reference=") == 0)
+    {
+      // defer the inclusion until the options are finalized
+      size_t first = arg.find_first_of("=");
+      std::string ifile = arg.substr(first + 1);
+      includes.emplace_back(ifile, isInclude);
+      continue;
+    }
+    if (arg == "-t")
+    {
+      if (i >= nargs)
+      {
+        EO_FATAL() << "Error: Missing trace tag.";
+      }
+      std::string targ(argv[i]);
+      i++;
+#ifdef EO_TRACING
+      TraceChannel.on(targ);
+#else
+      EO_FATAL() << "Error: tracing not enabled in this build";
+#endif
+    }
+    else if (!readFile)
+    {
+      file = arg;
+      readFile = true;
+    }
+    else
+    {
+      // maybe one of these is a wrong option
+      for (size_t j = 0; j < 2; j++)
+      {
+        std::string oarg(j == 0 ? file : arg);
+        if (oarg.compare(0, 2, "--") == 0)
+        {
+          EO_FATAL() << "Error: unrecognized option " << oarg;
+        }
+      }
+      EO_FATAL() << "Error: multiple files specified, \"" << file << "\" and \""
+                 << arg << "\"";
+    }
+  }
+  if (!readFile)
+  {
+    EO_FATAL() << "Error: no input specified.";
+  }
+  if (!generateParser && pluginName != "lean-meta")
+  {
+    EO_FATAL() << "Error: --no-parser requires --plugin.lean-meta";
+  }
+  if (!defsFile.empty() && pluginName != "model-smt")
+  {
+    EO_FATAL() << "Error: --defs requires --plugin.model-smt";
+  }
+  if (!leanConfigFile.empty() && pluginName != "lean-meta")
+  {
+    EO_FATAL() << "Error: --lean-config requires --plugin.lean-meta";
+  }
+  // options are finalized, now initialize the state and the plugin
+  Stats stats;
+  State s(opts, stats);
+  std::unique_ptr<Plugin> plugin;
+  if (!pluginName.empty())
+  {
+    plugin =
+        createPlugin(pluginName, s, generateParser, defsFile, leanConfigFile);
+    // note the plugin must be set before any file is included, so that it
+    // receives callbacks during parsing
+    s.setPlugin(plugin.get());
+  }
+  for (size_t j = 0, nincludes = includes.size(); j < nincludes; j++)
+  {
+    const std::string& ifile = includes[j].first;
+    bool isInclude = includes[j].second;
+    // cannot provide reference
+    Expr refNf;
+    if (!s.includeFile(ifile, isInclude, !isInclude, refNf))
+    {
+      EO_FATAL() << "Error: cannot include file " << ifile;
+    }
+  }
+  // whether it is a signature is determined by file extension *.eo.
+  bool isSignature = (file.size() >= 3 && file.substr(file.size() - 3) == ".eo");
+  if (!s.includeFile(file, isSignature))
+  {
+    EO_FATAL() << "Error: cannot include file " << file;
+  }
+  if (plugin != nullptr)
+  {
+    plugin->finalize();
+  }
+  // exit immediately, which avoids deleting all expressions which can take time
+  exit(0);
+  return 0;
+}

--- a/plugins/main_eoc.cpp
+++ b/plugins/main_eoc.cpp
@@ -23,6 +23,7 @@
  * exit code is 0.
  */
 
+#include <iostream>
 #include <memory>
 #include <string>
 #include <utility>
@@ -61,6 +62,12 @@ std::unique_ptr<Plugin> createPlugin(const std::string& name,
   }
   if (name == "model-smt")
   {
+    // With no --defs the plugin reads the signature it defaults to; naming
+    // one that is empty would instead fail once the stage runs.
+    if (defsFile.empty())
+    {
+      return std::make_unique<ModelSmt>(s);
+    }
     return std::make_unique<ModelSmt>(s, defsFile);
   }
   EO_FATAL() << "Error: unknown plugin \"" << name
@@ -191,6 +198,13 @@ int main(int argc, char* argv[])
   {
     EO_FATAL() << "Error: --lean-config requires --plugin.lean-meta";
   }
+  if (opts.d_requireProofOfFalse)
+  {
+    // This binary compiles a signature; what a proof ends in is no business
+    // of its own, so the option of ethos that says so is not one it takes.
+    EO_FATAL() << "Error: --require-proof-of-false is not supported by "
+                  "ethos-eoc";
+  }
   // options are finalized, now initialize the state and the plugin
   Stats stats;
   State s(opts, stats);
@@ -223,6 +237,10 @@ int main(int argc, char* argv[])
   if (plugin != nullptr)
   {
     plugin->finalize();
+  }
+  if (opts.d_stats)
+  {
+    std::cout << stats.toString(s, opts.d_statsCompact, opts.d_statsAll);
   }
   // exit immediately, which avoids deleting all expressions which can take time
   exit(0);

--- a/tools/eoc/README.md
+++ b/tools/eoc/README.md
@@ -331,5 +331,4 @@ relative to the current shell directory, not to `--build-dir`.
 ### I want to inspect the generated artifacts directly
 
 Look in `tools/eoc/out/` for both the staged EO artifacts and the final
-published outputs. The plugin-private scratch files remain under
-`<build-dir>/out/plugins/`.
+published outputs.

--- a/tools/eoc/README.md
+++ b/tools/eoc/README.md
@@ -1,0 +1,335 @@
+# EOC Workflow
+
+`tools/eoc/driver.py` is the canonical entrypoint for the optional
+`ethos-eoc` workflow.
+
+## What `ethos-eoc` is for
+
+`ethos-eoc` is the optional Eunoia compiler target that drives the
+non-standard EOC plugins:
+
+- `desugar`
+- `trim-defs`
+- `model-smt`
+- `lean-meta`
+
+The default `ethos` build does not include these plugins. Use `ethos-eoc`
+only when you want the Eunoia-to-Lean pipeline.
+
+`model-smt` gives every symbol of the signature its SMT-LIB semantics. A symbol
+that instead has no semantics of its own is *eliminated* on the way to the
+SMT-LIB term layer, i.e. it is defined in terms of the other symbols of the
+signature. Such a reduction is written in the syntax of the signature itself,
+as an ordinary `define` whose name is `$eo_reduce_` followed by the symbol it
+reduces.
+
+## The signatures written in the deep embedding
+
+What a symbol means to the model is said by two files. The SMT-LIB one is the
+target and so is fixed; the one of the input is named with `--defs`:
+
+```text
+plugins/model_smt/smt_defs.eo   the SMT-LIB signature, written in the embedding
+--defs <file>                   how the input's symbols transform into it,
+                                e.g. plugins/model_smt/cpc_defs.eo for CPC
+```
+
+```text
+python3 tools/eoc/driver.py lean \
+  --defs plugins/model_smt/cpc_defs.eo <cvc5>/proofs/eo/cpc/Cpc.eo
+```
+
+Only the `model-smt` stage reads them; no stage before it sees either. A symbol
+the input declares that the file says nothing about is an error rather than a
+term the model would silently say nothing about.
+
+Each is a sequence of blocks, one per symbol, opened by a `; -- X` line. For a
+symbol X, `smt_defs.eo` gives the constructor `$emb_sm.X` and the macro
+`$sm_X`, the cases X contributes to `$smtx_typeof` and to `$smtx_model_eval`
+(as `$eoc_typeof_X` and `$eoc_eval_X`), and the auxiliary programs those cases
+call. `cpc_defs.eo` gives `$eoc_transform_X`, the cases X contributes to
+`$eo_to_smt`, and `$eoc_transform_type_X` for a type constructor.
+
+What a block says to the compiler is named `$eoc_`, which is what tells it
+apart from what the compiler emits: the case of an `$eoc_` program is spliced
+into the aggregate its family names, so the name itself never reaches the
+generated file. The exception is `$eoc_is_list_nil_X`, which the desugar stage
+calls by name and which is therefore emitted as `$eo_is_list_nil_X`.
+
+A block may also be of a helper rather than of a symbol, in which case the
+`; -- X` line names the helper itself, e.g. `; -- $smtx_typeof_bv_op_2` for the
+typing of a bit-vector operator whose two arguments must be of one width. Such
+a block is taken only when a block that is kept names it, so a signature with
+no bit-vectors in it compiles to a model that has never heard of them. A helper
+belongs in the signature when only theory operators call it; what remains in
+`plugins/model_smt/model_smt.eo` is the type language, the value language and
+the terms that file declares itself, together with their methods.
+
+The stage takes the blocks of the symbols the input declares, together with
+every block those name, and puts what each says where it belongs; it knows
+nothing about any symbol itself. A block is copied as *text*, which is what
+keeps the definitions of the embedding it names, e.g. `$vsm_bool`, from being
+expanded on the way. See `plugins/model_smt/defs_reader.h`.
+
+Both files are ordered so that a symbol follows the ones its cases name, which
+is why neither needs a forward declaration. Adding, changing or removing a
+symbol is a change to one block and does not require rebuilding `ethos-eoc`.
+
+A block may name a symbol of the *input* rather than of the embedding, as the
+transformation of `@quantifiers_skolemize` names `forall` in the pattern it
+matches. Trimming a signature to one proof rule has to keep such a symbol, so
+the driver reads those dependencies off the blocks and tells `trim-defs`; see
+`Pipeline.defs_depends` in `tools/eoc/driver.py`.
+
+A block may also say that the compilation has no place for its symbol at all:
+SMT-LIB gives a proof-level binder no meaning, so `lambda` and everything that
+reduces an application of one are left out rather than modelled. A block says
+so with directives of the following forms:
+
+```lisp
+(echo "eoc-exclude symbol lambda")
+(echo "eoc-exclude method $beta_reduce")
+(echo "eoc-exclude rule beta-reduce")
+```
+
+`Pipeline.defs_excludes` collects them and gives them to the desugar stage,
+which is what drops what they name. The names are matched
+literally: the compiler neither checks that a name exists nor computes a
+dependency closure, so the block has to name every declaration that goes with
+the one it omits.
+
+## Why the generated Lean terminates
+
+Lean has to be told why a recursive definition terminates whenever it cannot
+see this for itself, and no measure the compiler could guess would do for the
+programs that need one. So the clause is stated as the Lean text it is, and the
+`lean-meta` stage appends it to the definition of the program it names:
+
+```text
+plugins/lean_meta/termination.lean   the programs of the deep embedding, which
+                                     every input is compiled through
+--lean-config <file>                 the programs of the input signature, e.g.
+                                     plugins/lean_meta/cpc_termination.lean
+```
+
+A block runs from a line naming one or more programs, written `-- $name ...`,
+to the next comment line, and what lies between is the clause. An input whose
+programs all recurse structurally needs no file of its own, so `--lean-config`
+is optional; without it the generated Lean simply carries no clause for them,
+which Lean will reject if one was needed.
+
+## Building `ethos-eoc`
+
+`ethos-eoc` is built by the standalone CMake project in `plugins/`, which
+compiles the ethos core sources together with the plugins. The main ethos
+build is unaffected. From the repository root:
+
+```bash
+cmake -S plugins -B build-eoc
+cmake --build build-eoc --target ethos-eoc -j4
+```
+
+Pass `-DCMAKE_BUILD_TYPE=Debug` to the configure step for a debug build with
+assertions and tracing. The driver configures the build directory
+automatically if it does not exist yet.
+
+`--build-dir` defaults to the current working directory, so pass it explicitly
+whenever you invoke the driver from somewhere other than the build tree. The
+examples below all use `build-eoc`.
+
+## One important path rule
+
+The driver resolves input paths relative to the directory where you invoke
+`python3 tools/eoc/driver.py`, not relative to the build directory.
+
+For example, from the repository root:
+
+```bash
+python3 tools/eoc/driver.py lean --build-dir build-eoc tests/Booleans-rules.eo and_intro
+```
+
+The input path `tests/Booleans-rules.eo` is interpreted relative to the
+repository root. The driver writes its EO stage files and final published
+outputs under `tools/eoc/out` by default.
+
+## Output layout
+
+The driver uses two output trees:
+
+- `tools/eoc/out/` for stage EO files and final published outputs, unless
+  overridden with `--final-out-dir` or `EOC_FINAL_OUT_DIR`
+- `<build-dir>/out/plugins/` for plugin-private generated files consumed by the
+  driver
+
+Published and stage files:
+
+```text
+tools/eoc/out/
+  trim-*.eo
+  desugar.eo
+  lean-*-trim.eo
+  lean-*-desugar.eo
+  lean-*-defs.eo
+  lean-*-final.eo
+  trim_defs/trim_gen.eo
+  lean/
+    Logos.lean
+    LogosTerm.lean
+    Parser.lean
+    SmtEval.lean
+    SmtModelDefs.lean
+    SmtValueOrder.lean
+    SmtModel.lean
+    Spec.lean
+    RuleLemmas.lean
+    Rules/
+      <Rule>.lean
+```
+
+Plugin-private files:
+
+```text
+<build-dir>/out/plugins/
+  desugar/
+  lean_meta/
+  model_smt/
+  trim_defs/
+```
+
+## Quick start
+
+Generate Lean for selected rules:
+
+```bash
+python3 tools/eoc/driver.py lean --build-dir build-eoc tests/Booleans-rules.eo and_intro contra
+```
+
+Generate Lean for the whole signature:
+
+```bash
+python3 tools/eoc/driver.py lean --build-dir build-eoc --all ../../cvc5-ajr/proofs/eo/cpc/Cpc.eo
+```
+
+A declaration the signature of the input leaves out of the compilation is
+dropped by this run without anything being said on the command line; see "The
+signatures written in the deep embedding" above.
+
+List all rules declared by a signature and its includes:
+
+```bash
+python3 tools/eoc/driver.py list-rules ../../cvc5-ajr/proofs/eo/cpc/Cpc.eo
+```
+## Command reference
+
+### `lean`
+
+Generate Lean output either for selected rules or for the full signature.
+
+Selected rules:
+
+```bash
+python3 tools/eoc/driver.py lean --build-dir build-eoc INPUT RULE1 RULE2
+```
+
+Whole signature:
+
+```bash
+python3 tools/eoc/driver.py lean --build-dir build-eoc --all INPUT
+```
+
+Pass `--no-parser` to omit the signature-specific `Parser.lean` artifact while
+still generating the remaining Lean modules and per-rule files. This also
+removes a stale `Parser.lean` from the selected final output directory.
+
+Pass `--lean-config FILE` to name the termination clauses of the input's own
+programs; see "Why the generated Lean terminates" above.
+
+Generated files are written to `tools/eoc/out/lean/` by default, including
+per-rule files in `tools/eoc/out/lean/Rules/`. `Parser.lean` is the minimal
+calculus-specific instantiation of the generic Logos proof parser: it contains
+only the generated operator/rule tables, indexed-operator constructors, and
+surface desugaring configuration.
+
+The operator tables also cover the identifiers the input introduces with
+`define`. Eunoia inlines a definition, so it has no counterpart in the compiled
+signature, but a proof may still use it. The desugar stage therefore re-emits
+each definition it can under the name `$parse_<name>`, which the later stages
+reparse and otherwise ignore. By convention a definition whose own name begins
+with `$` is a helper of the signature and is not preserved, since a proof never
+mentions one. A preserved definition contributes to the parser only, never to a
+verification condition or to the generated proof checker. A definition that
+takes arguments becomes a macro of the parser, and one that takes none becomes a
+nullary operator, or an alias of the operator it names so that it inherits its
+indices and argument-list attribute.
+
+### `desugar`
+
+Generate the desugared EO form of an input.
+
+```bash
+python3 tools/eoc/driver.py desugar --build-dir build-eoc INPUT
+```
+
+Output:
+
+```text
+tools/eoc/out/desugar.eo
+```
+
+### `trim-defs`
+
+Run only the trim stage.
+
+```bash
+python3 tools/eoc/driver.py trim-defs --build-dir build-eoc INPUT TARGET1 TARGET2
+```
+
+Output:
+
+```text
+tools/eoc/out/trim_defs/trim_gen.eo
+```
+
+### `list-rules`
+
+Print discovered rules without running the pipeline.
+
+```bash
+python3 tools/eoc/driver.py list-rules INPUT
+```
+
+This walks `include` chains and preserves declaration order.
+
+## Common workflows
+
+### Generate Lean and then copy files elsewhere
+
+```bash
+python3 tools/eoc/driver.py lean --build-dir build-eoc --all INPUT
+ls tools/eoc/out/lean
+```
+
+### Manually inspect or debug intermediate files
+
+The driver writes the staged EO files into `tools/eoc/out/`. You can pass those
+directly to `ethos-eoc` if you want to debug a later stage manually.
+
+Examples:
+
+```bash
+build-eoc/ethos-eoc tools/eoc/out/lean-booleans-rules-final.eo
+build-eoc/ethos-eoc --plugin.lean-meta tools/eoc/out/lean-booleans-rules-final.eo
+```
+
+## Troubleshooting
+
+### `Couldn't open file: ...`
+
+Check which directory you ran the driver from. Input paths are resolved
+relative to the current shell directory, not to `--build-dir`.
+
+### I want to inspect the generated artifacts directly
+
+Look in `tools/eoc/out/` for both the staged EO artifacts and the final
+published outputs. The plugin-private scratch files remain under
+`<build-dir>/out/plugins/`.

--- a/tools/eoc/README.md
+++ b/tools/eoc/README.md
@@ -35,13 +35,15 @@ plugins/model_smt/smt_defs.eo   the SMT-LIB signature, written in the embedding
 ```
 
 ```text
-python3 tools/eoc/driver.py lean \
+python3 tools/eoc/driver.py lean --all \
   --defs plugins/model_smt/cpc_defs.eo <cvc5>/proofs/eo/cpc/Cpc.eo
 ```
 
 Only the `model-smt` stage reads them; no stage before it sees either. A symbol
 the input declares that the file says nothing about is an error rather than a
-term the model would silently say nothing about.
+term the model would silently say nothing about. A run that names no `--defs`
+reads `plugins/model_smt/cpc_defs.eo`, which is what the examples below that
+compile a signature of CPC symbols rely on.
 
 Each is a sequence of blocks, one per symbol, opened by a `; -- X` line. For a
 symbol X, `smt_defs.eo` gives the constructor `$emb_sm.X` and the macro
@@ -185,6 +187,17 @@ tools/eoc/out/
     Rules/
       <Rule>.lean
 ```
+
+`out/lean/` is what a run publishes, not a Lean package that builds on its own:
+the generated modules import `<Calc>.Proofs.CheckerCore` and
+`<Calc>.Proofs.RuleSupport.Support`, which the compiler never writes and which
+belong to the package the files are installed into. That package holds the
+proof-side modules under `Proofs/`, and the published tree is it with that one
+component dropped, uniformly: `RuleLemmas.lean` is installed as
+`Proofs/RuleLemmas.lean` and `Rules/<Rule>.lean` as `Proofs/Rules/<Rule>.lean`,
+which is what the `import <Calc>.Proofs.Rules.<Rule>` lines that the former
+carries name. Every other file is installed at the root of the package, where
+its name already is its import.
 
 Plugin-private files:
 

--- a/tools/eoc/driver.py
+++ b/tools/eoc/driver.py
@@ -1,0 +1,679 @@
+#!/usr/bin/env python3
+"""
+Unified driver for the optional Eunoia-to-Lean compilation pipeline.
+
+This is the canonical source-tree entrypoint for the EOC workflow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+DEFAULT_FINAL_OUT_DIR = SCRIPT_DIR / "out"
+LEAN_CALC_PLACEHOLDER = "$EO_CALC$"
+
+# The signature-wide Lean files written by the lean subcommand, in module
+# dependency order. Each entry is (source relative to plugins/, name written
+# under <final out dir>/lean, whether the source is rendered by the Lean
+# backend rather than copied verbatim from the plugin source tree). The
+# per-rule files under lean/Rules/ are published separately, see
+# publish_generated_lean_rule_outputs.
+LEAN_OUTPUTS: tuple[tuple[str, str, bool], ...] = (
+    ("lean_meta/lean_meta_checker_gen.lean", "Logos.lean", True),
+    ("lean_meta/lean_meta_checker_term_gen.lean", "LogosTerm.lean", True),
+    ("lean_meta/lean_meta_parser_gen.lean", "Parser.lean", True),
+    ("lean_meta/lean_meta_smt_eval.lean", "SmtEval.lean", False),
+    ("lean_meta/lean_meta_smt_model_defs_gen.lean", "SmtModelDefs.lean", True),
+    ("lean_meta/lean_meta_smt_value_order_gen.lean", "SmtValueOrder.lean", True),
+    ("lean_meta/lean_meta_smt_model_gen.lean", "SmtModel.lean", True),
+    ("lean_meta/lean_meta_spec_gen.lean", "Spec.lean", True),
+    ("lean_meta/lean_meta_rule_lemmas_gen.lean", "RuleLemmas.lean", True),
+)
+
+DECLARE_RULE_RE = re.compile(r"^\(declare-rule\s+([^\s(]+)")
+INCLUDE_RE = re.compile(r'^\(include\s+"([^"]+)"\s*\)')
+# Any directive a block of a signature written in the deep embedding gives to a
+# stage of the compiler, rather than something it says about the model.
+DEFS_DIRECTIVE = re.compile(r'\(echo\s+"[^"]*"\)')
+# The one of those that leaves what it names out of the compilation altogether.
+DEFS_EXCLUDE = re.compile(r'\(echo\s+"eoc-exclude\s+(\S+)\s+(\S+)"\s*\)')
+
+LEAN_ALL_DEPS = (
+    "$eot_Bool $eot_Type $eot_fun_type $eot_apply $eo_mk_apply "
+    "$eo_eq $eo_ite $eo_requires $eo_and $eo_to_smt $smtx_model_eval "
+    "$eo_checker_is_refutation and $eot_UConst $eot_USort "
+    "$smtx_typeof $smtx_typeof_value $smtx_value_canonical_bool "
+    "$smtx_msm_lookup $emb_UOp"
+)
+
+LEAN_SINGLE_DEPS = (
+    "$eot_Bool $eot_Type $eot_fun_type $eot_apply $eo_mk_apply "
+    "$eo_eq $eo_ite $eo_requires $eo_and $eo_to_smt $smtx_model_eval "
+    "$eo_checker_is_refutation and => $eot_UConst $eot_USort "
+    "$smtx_model_eval_apply $smtx_typeof $smtx_typeof_value "
+    "$smtx_value_canonical_bool $smtx_msm_lookup $emb_UOp"
+)
+
+
+def resolve_path_arg(path_arg: str, *, cwd: Path) -> Path:
+    candidate = Path(path_arg).expanduser()
+    if candidate.is_absolute():
+        return candidate.resolve()
+    return (cwd / candidate).resolve()
+
+
+def strip_comment(line: str) -> str:
+    return line.split(";", 1)[0].strip()
+
+
+def input_base_name(input_file: Path) -> str:
+    """The name of the calculus an input file compiles.
+
+    This is the file name up to its first dot, so that a qualifier may be
+    appended to the name of a calculus without renaming what it produces. Keep
+    this in sync with eoc_lean_calc_name in tools/eoc/cpc/common.sh.
+    """
+    return input_file.name.split(".", 1)[0]
+
+
+def lean_calc_name(input_file: Path) -> str:
+    parts = re.findall(r"[A-Za-z0-9]+", input_base_name(input_file))
+    if not parts:
+        return "EoCalc"
+    calc = "".join(part[:1].upper() + part[1:] for part in parts)
+    if not calc[0].isalpha():
+        calc = f"Calc{calc}"
+    return calc
+
+
+def discover_rules(input_file: Path) -> list[str]:
+    seen_files: set[Path] = set()
+    seen_rules: set[str] = set()
+    ordered_rules: list[str] = []
+
+    def visit(path: Path) -> None:
+        resolved = path.resolve()
+        if resolved in seen_files:
+            return
+        if not resolved.exists():
+            raise RuntimeError(f"input file not found while scanning rules: {resolved}")
+        seen_files.add(resolved)
+        for raw_line in resolved.read_text().splitlines():
+            line = strip_comment(raw_line)
+            if not line:
+                continue
+            include_match = INCLUDE_RE.match(line)
+            if include_match:
+                include_path = resolve_path_arg(include_match.group(1), cwd=resolved.parent)
+                visit(include_path)
+                continue
+            declare_match = DECLARE_RULE_RE.match(line)
+            if declare_match:
+                rule_name = declare_match.group(1)
+                if rule_name not in seen_rules:
+                    seen_rules.add(rule_name)
+                    ordered_rules.append(rule_name)
+
+    visit(input_file)
+    return ordered_rules
+
+
+def replace_all(path: Path, replacements: list[tuple[str, str]]) -> None:
+    text = path.read_text()
+    for old, new in replacements:
+        text = text.replace(old, new)
+    path.write_text(text)
+
+
+def inline_include(path: Path, include_name: str, include_path: Path) -> None:
+    marker = f'(include "{include_name}")'
+    replacement = include_path.read_text()
+    text = path.read_text()
+    text = text.replace(marker, replacement)
+    path.write_text(text)
+
+
+def splice_matching_line(path: Path, needle: str, replacement_path: Path) -> None:
+    replacement = replacement_path.read_text()
+    if replacement and not replacement.endswith("\n"):
+        replacement += "\n"
+    out_lines: list[str] = []
+    for line in path.read_text().splitlines(keepends=True):
+        if needle in line:
+            out_lines.append(replacement)
+        else:
+            out_lines.append(line)
+    path.write_text("".join(out_lines))
+
+
+class Pipeline:
+    def __init__(
+        self,
+        build_dir: Path,
+        final_out_dir: Path,
+        jobs: int,
+        defs_file: Optional[Path],
+        lean_config: Optional[Path],
+    ):
+        self.build_dir = build_dir.resolve()
+        self.final_out_dir = final_out_dir.resolve()
+        self.jobs = jobs
+        self.defs_file = defs_file.resolve() if defs_file else None
+        self.lean_config = lean_config.resolve() if lean_config else None
+        self.binary = self.build_dir / "ethos-eoc"
+        self.stage_out_dir = self.final_out_dir
+        self.plugin_out_dir = self.build_dir / "out" / "plugins"
+
+    def run(
+        self,
+        cmd: list[str],
+        *,
+        quiet: bool = False,
+        cwd: Optional[Path] = None,
+    ) -> None:
+        stdout = subprocess.DEVNULL if quiet else None
+        subprocess.run(
+            cmd,
+            cwd=str(cwd or self.build_dir),
+            check=True,
+            stdout=stdout,
+        )
+
+    def build(self) -> None:
+        # ethos-eoc is built by the standalone plugins/ project; configure the
+        # build directory against it if this has not been done yet
+        if not (self.build_dir / "CMakeCache.txt").exists():
+            self.run(
+                [
+                    "cmake",
+                    "-S",
+                    str(REPO_ROOT / "plugins"),
+                    "-B",
+                    str(self.build_dir),
+                ],
+                cwd=REPO_ROOT,
+            )
+        self.run(
+            ["cmake", "--build", ".", "--target", "ethos-eoc", f"-j{self.jobs}"]
+        )
+
+    def ethos(self, args: Iterable[str], *, quiet: bool = False) -> None:
+        self.run([str(self.binary), *args], quiet=quiet)
+
+    def relative_input_from_out(self, input_name: str) -> str:
+        target = Path(input_name)
+        if not target.is_absolute():
+            target = self.build_dir / target
+        try:
+            return os.path.relpath(str(target), str(self.stage_out_dir))
+        except ValueError:
+            return str(target)
+
+    def binary_path_arg(self, filename: Path) -> str:
+        resolved = filename.resolve()
+        try:
+            return str(resolved.relative_to(self.build_dir))
+        except ValueError:
+            return str(resolved)
+
+    def plugin_generated(self, relative_path: str) -> Path:
+        return self.plugin_out_dir / relative_path
+
+    def clean_generated_lean_rule_outputs(self) -> None:
+        plugin_rule_dir = self.plugin_out_dir / "lean_meta" / "rules"
+        if not plugin_rule_dir.exists():
+            return
+        for child in plugin_rule_dir.iterdir():
+            if child.is_file() and child.name.startswith("lean_meta_rule_") and child.name.endswith("_gen.lean"):
+                child.unlink()
+
+    def publish_generated_lean_rule_outputs(self, lean_dir: Path) -> None:
+        plugin_rule_dir = self.plugin_out_dir / "lean_meta" / "rules"
+        final_rule_dir = lean_dir / "Rules"
+        if final_rule_dir.exists():
+            shutil.rmtree(final_rule_dir)
+        if not plugin_rule_dir.exists():
+            return
+        rule_files = sorted(plugin_rule_dir.glob("lean_meta_rule_*_gen.lean"))
+        if not rule_files:
+            return
+        final_rule_dir.mkdir(parents=True, exist_ok=True)
+        for rule_file in rule_files:
+            rule_name = rule_file.name[len("lean_meta_rule_") : -len("_gen.lean")]
+            if not rule_name:
+                continue
+            module_name = rule_name[:1].upper() + rule_name[1:]
+            shutil.copyfile(rule_file, final_rule_dir / f"{module_name}.lean")
+
+    def materialize_lean_calc(self, lean_dir: Path, calc_name: str) -> None:
+        for lean_file in lean_dir.rglob("*.lean"):
+            replace_all(lean_file, [(LEAN_CALC_PLACEHOLDER, calc_name)])
+
+    def stage_name(self, input_name: str) -> str:
+        return input_base_name(Path(input_name)).lower()
+
+    def trim_defs(self, input_name: str, targets: list[str], output_file: Path) -> Path:
+        temp_trim = self.stage_out_dir / "temp_trim.eo"
+        temp_trim.parent.mkdir(parents=True, exist_ok=True)
+        pieces = [f'(include "{self.relative_input_from_out(input_name)}")\n']
+        pieces.extend(self.defs_depends())
+        for target in targets:
+            pieces.append(f'(echo "trim-defs {target}")\n')
+        temp_trim.write_text("".join(pieces))
+        try:
+            self.ethos(["--plugin.trim-defs", self.binary_path_arg(temp_trim)], quiet=True)
+            output_file.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(self.plugin_generated("trim_defs/trim_gen.eo"), output_file)
+            return output_file
+        finally:
+            if temp_trim.exists():
+                temp_trim.unlink()
+
+    def defs_blocks(self) -> list[tuple[str, str]]:
+        """The blocks of the signature of the input, as (symbol, body) pairs.
+
+        A block runs from the `; -- X` line naming the symbol it is of to the
+        next such line, which is the same split the model-smt stage makes, see
+        DefsFile::read in plugins/model_smt/defs_reader.cpp.
+        """
+        if self.defs_file is None or not self.defs_file.exists():
+            return []
+        out: list[tuple[str, str]] = []
+        for block in re.split(r"\n; -- ", self.defs_file.read_text())[1:]:
+            sym, _, body = block.partition("\n")
+            out.append((sym.strip(), body))
+        return out
+
+    def defs_excludes(self) -> list[tuple[str, str]]:
+        """What the signature of the input leaves out of the compilation.
+
+        A block may say that the compilation has no place for the symbol it is
+        of, as the one for lambda does: SMT-LIB gives a proof-level binder no
+        meaning, so rather than a model the block gives eoc-exclude directives.
+        The desugar stage is what reads those and drops what they name, see
+        Desugar::echo, so they are collected here and given to it. Saying it in
+        the signature is what keeps a symbol left out of the compilation from
+        also having to be listed apart from it.
+
+        Each is returned as the kind it excludes, one of rule, method or
+        symbol, and the name of what it excludes.
+        """
+        out: list[tuple[str, str]] = []
+        for _sym, body in self.defs_blocks():
+            out.extend((m.group(1), m.group(2)) for m in DEFS_EXCLUDE.finditer(body))
+        return out
+
+    def defs_excluded_rules(self) -> set[str]:
+        """Those of the exclusions that are proof rules.
+
+        The compilation has nothing to say about such a rule: no verification
+        condition to generate and no Lean file to write. So a run over every
+        rule of the input leaves it out, and a run that names it says why
+        rather than failing further down.
+        """
+        return {name for kind, name in self.defs_excludes() if kind == "rule"}
+
+    def defs_depends(self) -> list[str]:
+        """What trim-defs must keep for the model of each symbol to make sense.
+
+        A block of the signature of the input may name a symbol of that input,
+        as the transformation of @quantifiers_skolemize names forall in the
+        pattern it matches. Trimming the input to one proof rule has to keep
+        such a symbol, or the case the model-smt stage emits for the block
+        would name something the trimmed signature no longer declares. The
+        dependency is read off the block itself, so nothing states it twice.
+
+        A symbol of the input is a name in head position that no program of the
+        block binds and that is neither of the embedding, which is written with
+        a leading dollar, nor of Eunoia, which is written eo::.
+        """
+        out: list[str] = []
+        for sym, body in self.defs_blocks():
+            body = DEFS_DIRECTIVE.sub("", body)
+            body = re.sub(r";[^\n]*", "", body)
+            bound = {sym, "program", "define", "declare-const",
+                     "declare-parameterized-const"}
+            for params in re.findall(r"\(\((?:[^()]|\([^()]*\))*\)\)", body):
+                bound.update(re.findall(r"\(([^\s()]+)", params))
+            heads = set(re.findall(r"\(([A-Za-z@_][^\s()]*)", body))
+            names = {h for h in heads - bound if not h.startswith("eo::")}
+            if names:
+                out.append('(echo "trim-defs-cmd (depends %s %s)")\n'
+                           % (sym, " ".join(sorted(names))))
+        return out
+
+    def desugar(
+        self,
+        input_name: str,
+        output_file: Path,
+        *,
+        deps: Optional[str],
+        plugin_label: Optional[str],
+    ) -> Path:
+        args = ["--plugin.desugar"]
+        # What the signature of the input leaves out of the compilation, which
+        # this stage is what applies, see defs_excludes.
+        excludes = self.defs_excludes()
+        temp_excludes = self.stage_out_dir / "temp_excludes.eo"
+        if excludes:
+            temp_excludes.parent.mkdir(parents=True, exist_ok=True)
+            temp_excludes.write_text(
+                "".join('(echo "eoc-exclude %s %s")\n' % e for e in excludes)
+            )
+            args.append(f"--include={self.binary_path_arg(temp_excludes)}")
+        args.append(input_name)
+        try:
+            self.ethos(args, quiet=True)
+        finally:
+            if excludes and temp_excludes.exists():
+                temp_excludes.unlink()
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(self.plugin_generated("desugar/eo_desugar_gen.eo"), output_file)
+        replacements: list[tuple[str, str]] = []
+        if deps is not None:
+            replacements.append(("eo-desugar-deps", deps))
+        if plugin_label is not None:
+            replacements.append(("eo-desugar", plugin_label))
+        if replacements:
+            replace_all(output_file, replacements)
+        inline_include(
+            output_file,
+            "eo_desugar_native.eo",
+            self.plugin_generated("desugar/eo_desugar_native.eo"),
+        )
+        inline_include(
+            output_file,
+            "native_embed.eo",
+            self.plugin_generated("desugar/native_embed.eo"),
+        )
+        return output_file
+
+    def model_smt(self, input_file: Path, output_file: Path) -> Path:
+        # The signature of the input written in the deep embedding, which says
+        # what its symbols mean to the model. This stage alone reads it, so it
+        # is named here rather than being part of the input; see the
+        # "signatures written in the deep embedding" section of
+        # tools/eoc/README.md.
+        args = ["--plugin.model-smt"]
+        if self.defs_file is not None:
+            args.append(f"--defs={self.binary_path_arg(self.defs_file)}")
+        args.append(self.binary_path_arg(input_file))
+        self.ethos(args, quiet=True)
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(input_file, output_file)
+        splice_matching_line(
+            output_file,
+            'include model_smt',
+            self.plugin_generated("model_smt/model_smt_gen.eo"),
+        )
+        return output_file
+
+    def lean(
+        self,
+        input_file: Path,
+        *,
+        calc_name: str,
+        generate_parser: bool,
+    ) -> Path:
+        out_lean = self.final_out_dir / "lean"
+        out_lean.mkdir(parents=True, exist_ok=True)
+        self.clean_generated_lean_rule_outputs()
+        parser_outputs = (
+            self.plugin_generated("lean_meta/lean_meta_parser_gen.lean"),
+            out_lean / "Parser.lean",
+        )
+        if not generate_parser:
+            for parser_output in parser_outputs:
+                if parser_output.exists():
+                    parser_output.unlink()
+        args = ["--plugin.lean-meta"]
+        if not generate_parser:
+            args.append("--no-parser")
+        # What the input signature needs said about its generated Lean that the
+        # compiler cannot derive, namely why each of its recursive programs
+        # terminates; see plugins/lean_meta/termination.lean.
+        if self.lean_config is not None:
+            args.append(f"--lean-config={self.binary_path_arg(self.lean_config)}")
+        args.append(self.binary_path_arg(input_file))
+        self.ethos(args, quiet=True)
+        for source, name, generated in LEAN_OUTPUTS:
+            if not generate_parser and name == "Parser.lean":
+                continue
+            source_path = (
+                self.plugin_generated(source)
+                if generated
+                else REPO_ROOT / "plugins" / source
+            )
+            shutil.copyfile(source_path, out_lean / name)
+        self.publish_generated_lean_rule_outputs(out_lean)
+        self.materialize_lean_calc(out_lean, calc_name)
+        return out_lean
+
+    def parse_file(self, filename: Path) -> None:
+        self.ethos([self.binary_path_arg(filename)], quiet=True)
+
+    def run_lean(
+        self,
+        input_name: str,
+        targets: list[str],
+        *,
+        all_targets: bool,
+        build_first: bool,
+        generate_parser: bool,
+    ) -> Path:
+        if build_first:
+            self.build()
+        left_out = sorted(set(targets) & self.defs_excluded_rules())
+        if left_out:
+            raise RuntimeError(
+                f"{' '.join(left_out)} is left out of the compilation by "
+                f"{self.defs_file}, so there is no Lean to generate for it"
+            )
+        calc_name = lean_calc_name(Path(input_name))
+        stem = self.stage_name(input_name)
+        print(
+            f"********* Generating Lean for {input_name if all_targets else ' '.join(targets) + ' in ' + input_name} *********"
+        )
+        if all_targets:
+            init_desugar = self.stage_out_dir / f"lean-{stem}-desugar.eo"
+            final_defs = self.stage_out_dir / f"lean-{stem}-final.eo"
+            print(f"**** lean_meta: Run ethos + desugar on {input_name} to generate {init_desugar}")
+            self.desugar(
+                input_name,
+                init_desugar,
+                deps=LEAN_ALL_DEPS,
+                plugin_label="lean-meta",
+            )
+            print(f"**** lean_meta: Run ethos + model-smt on {init_desugar} to generate {final_defs}")
+            self.model_smt(init_desugar, final_defs)
+            print(f"**** lean_meta: Verify ethos parses {final_defs}")
+            self.parse_file(final_defs)
+            print(f"**** lean_meta: Generate Lean from {final_defs} to {self.final_out_dir / 'lean'}")
+            return self.lean(
+                final_defs,
+                calc_name=calc_name,
+                generate_parser=generate_parser,
+            )
+
+        init_trim = self.stage_out_dir / f"lean-{stem}-trim.eo"
+        init_desugar = self.stage_out_dir / f"lean-{stem}-desugar.eo"
+        vcm_defs = self.stage_out_dir / f"lean-{stem}-defs.eo"
+        final_defs = self.stage_out_dir / f"lean-{stem}-final.eo"
+        print(
+            f'**** lean_meta: Run ethos + trim-defs on {input_name} and "{" ".join(targets)}" to {init_trim}'
+        )
+        self.trim_defs(input_name, list(targets) + ["and", "=>"], init_trim)
+        print(f"**** lean_meta: Run ethos + desugar on {init_trim} to generate {init_desugar}")
+        self.desugar(
+            self.binary_path_arg(init_trim),
+            init_desugar,
+            deps=LEAN_SINGLE_DEPS,
+            plugin_label="lean-meta",
+        )
+        print(f"**** lean_meta: Run ethos + model-smt on {init_desugar} to generate {vcm_defs}")
+        self.model_smt(init_desugar, vcm_defs)
+        # The generated proof parser expands parameterized n-ary syntax with
+        # the calculus' own nil/type utilities. Keep those utilities even when
+        # compiling only a small set of rules; parser metadata echoes are
+        # intentionally preserved by trim-defs as well.
+        target_progs = [f"$eo_prog_{target}" for target in targets]
+        target_progs.extend(["$eo_nil", "$eo_typeof"])
+        print(f"**** lean_meta: Run ethos + trim-deps on {vcm_defs} to generate {final_defs}")
+        self.trim_defs(self.binary_path_arg(vcm_defs), target_progs, final_defs)
+        print(f"**** lean_meta: Verify ethos parses {final_defs}")
+        self.parse_file(final_defs)
+        print(f"**** lean_meta: Generate Lean from {final_defs} to {self.final_out_dir / 'lean'}")
+        return self.lean(
+            final_defs,
+            calc_name=calc_name,
+            generate_parser=generate_parser,
+        )
+
+    def run_desugar(self, input_name: str, *, build_first: bool) -> Path:
+        if build_first:
+            self.build()
+        output = self.final_out_dir / "desugar.eo"
+        print(f"**** desugar: Run ethos + desugar on {input_name} to generate {output}")
+        self.desugar(input_name, output, deps=None, plugin_label=None)
+        print("**** desugar: Verify it parses")
+        self.parse_file(output)
+        return output
+
+    def run_trim_only(self, input_name: str, targets: list[str], *, build_first: bool) -> Path:
+        if build_first:
+            self.build()
+        output = self.final_out_dir / "trim_defs" / "trim_gen.eo"
+        print(f"**** run_trim_defs: Run ethos + trim-defs on {input_name}")
+        self.trim_defs(input_name, targets, output)
+        return output
+
+def add_common_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--build-dir",
+        default=os.getcwd(),
+        help="Build directory for the plugins/ project, containing ethos-eoc and out/.",
+    )
+    parser.add_argument(
+        "--final-out-dir",
+        default=None,
+        help="Directory for final published outputs. Defaults to $EOC_FINAL_OUT_DIR or tools/eoc/out.",
+    )
+    parser.add_argument("--jobs", type=int, default=4, help="Parallel build jobs.")
+    parser.add_argument(
+        "--no-build",
+        action="store_true",
+        help="Do not rebuild ethos-eoc before running the pipeline.",
+    )
+    parser.add_argument(
+        "--defs",
+        default=None,
+        help=(
+            "EO file of the signature of the input written in the deep "
+            "embedding, read by the model-smt stage."
+        ),
+    )
+    parser.add_argument(
+        "--lean-config",
+        default=None,
+        help=(
+            "Lean file of the termination clauses of the input's programs, "
+            "read by the lean-meta stage."
+        ),
+    )
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    lean = subparsers.add_parser("lean", help="Generate Lean output for selected rules.")
+    add_common_args(lean)
+    lean.add_argument("input")
+    lean.add_argument("targets", nargs="*")
+    lean.add_argument("--all", action="store_true", help="Compile the entire signature.")
+    lean.add_argument(
+        "--no-parser",
+        action="store_true",
+        help="Do not generate or publish the signature-specific Logos parser.",
+    )
+
+    desugar = subparsers.add_parser("desugar", help="Generate a desugared EO file.")
+    add_common_args(desugar)
+    desugar.add_argument("input")
+
+    trim = subparsers.add_parser("trim-defs", help="Run the trim-defs plugin only.")
+    add_common_args(trim)
+    trim.add_argument("input")
+    trim.add_argument("targets", nargs="+")
+
+    list_rules = subparsers.add_parser(
+        "list-rules", help="Print declared rules from a signature and its includes."
+    )
+    list_rules.add_argument("input")
+
+    args = parser.parse_args(argv)
+    invocation_cwd = Path.cwd().resolve()
+
+    if hasattr(args, "input"):
+        args.input = str(resolve_path_arg(args.input, cwd=invocation_cwd))
+
+    if getattr(args, "final_out_dir", None) is not None:
+        final_out_dir = resolve_path_arg(args.final_out_dir, cwd=invocation_cwd)
+    else:
+        final_out_env = os.environ.get("EOC_FINAL_OUT_DIR")
+        if final_out_env:
+            final_out_dir = resolve_path_arg(final_out_env, cwd=invocation_cwd)
+        else:
+            final_out_dir = DEFAULT_FINAL_OUT_DIR
+
+    pipeline = Pipeline(
+        Path(getattr(args, "build_dir", os.getcwd())),
+        final_out_dir,
+        getattr(args, "jobs", 4),
+        Path(args.defs) if getattr(args, "defs", None) else None,
+        Path(args.lean_config) if getattr(args, "lean_config", None) else None,
+    )
+    build_first = not getattr(args, "no_build", False)
+
+    try:
+        if args.command == "lean":
+            if not args.all and not args.targets:
+                parser.error("lean requires at least one target unless --all is passed")
+            pipeline.run_lean(
+                args.input,
+                list(args.targets),
+                all_targets=args.all,
+                build_first=build_first,
+                generate_parser=not args.no_parser,
+            )
+        elif args.command == "desugar":
+            pipeline.run_desugar(args.input, build_first=build_first)
+        elif args.command == "trim-defs":
+            pipeline.run_trim_only(
+                args.input,
+                list(args.targets),
+                build_first=build_first,
+            )
+        else:
+            for rule in discover_rules(Path(args.input)):
+                print(rule)
+        return 0
+    except subprocess.CalledProcessError as err:
+        return err.returncode
+    except RuntimeError as err:
+        print(err, file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/eoc/driver.py
+++ b/tools/eoc/driver.py
@@ -28,6 +28,17 @@ LEAN_CALC_PLACEHOLDER = "$EO_CALC$"
 # backend rather than copied verbatim from the plugin source tree). The
 # per-rule files under lean/Rules/ are published separately, see
 # publish_generated_lean_rule_outputs.
+#
+# <final out dir>/lean is what a run publishes, not a Lean package that builds
+# on its own: the generated modules import <Calc>.Proofs.CheckerCore and
+# <Calc>.Proofs.RuleSupport.Support, which the compiler never writes and which
+# belong to the package the files are installed into. That package holds the
+# proof-side modules under Proofs/, and the published tree is it with that one
+# component dropped, uniformly: RuleLemmas.lean is installed as
+# Proofs/RuleLemmas.lean and Rules/<Rule>.lean as Proofs/Rules/<Rule>.lean,
+# which is what the import <Calc>.Proofs.Rules.<Rule> lines that the former
+# carries name. Everything else is installed at the root of the package, where
+# its name already is its import.
 LEAN_OUTPUTS: tuple[tuple[str, str, bool], ...] = (
     ("lean_meta/lean_meta_checker_gen.lean", "Logos.lean", True),
     ("lean_meta/lean_meta_checker_term_gen.lean", "LogosTerm.lean", True),
@@ -80,8 +91,7 @@ def input_base_name(input_file: Path) -> str:
     """The name of the calculus an input file compiles.
 
     This is the file name up to its first dot, so that a qualifier may be
-    appended to the name of a calculus without renaming what it produces. Keep
-    this in sync with eoc_lean_calc_name in tools/eoc/cpc/common.sh.
+    appended to the name of a calculus without renaming what it produces.
     """
     return input_file.name.split(".", 1)[0]
 
@@ -238,6 +248,12 @@ class Pipeline:
                 child.unlink()
 
     def publish_generated_lean_rule_outputs(self, lean_dir: Path) -> None:
+        """Publish the file of each rule the run compiled.
+
+        These go under lean/Rules, which is Proofs/Rules of the package they
+        are installed into with the leading component dropped, as the rest of
+        the published tree is; see LEAN_OUTPUTS.
+        """
         plugin_rule_dir = self.plugin_out_dir / "lean_meta" / "rules"
         final_rule_dir = lean_dir / "Rules"
         if final_rule_dir.exists():
@@ -286,10 +302,15 @@ class Pipeline:
         next such line, which is the same split the model-smt stage makes, see
         DefsFile::read in plugins/model_smt/defs_reader.cpp.
         """
-        if self.defs_file is None or not self.defs_file.exists():
+        if self.defs_file is None:
             return []
         out: list[tuple[str, str]] = []
-        for block in re.split(r"\n; -- ", self.defs_file.read_text())[1:]:
+        # Prepending a newline lets the same marker recognize a block on line
+        # one, which is what DefsFile::read does for the same reason. Without
+        # it this side and the model-smt stage would read the same file
+        # differently.
+        text = "\n" + self.defs_file.read_text()
+        for block in re.split(r"\n; -- ", text)[1:]:
             sym, _, body = block.partition("\n")
             out.append((sym.strip(), body))
         return out
@@ -579,7 +600,8 @@ def add_common_args(parser: argparse.ArgumentParser) -> None:
         default=None,
         help=(
             "EO file of the signature of the input written in the deep "
-            "embedding, read by the model-smt stage."
+            "embedding, read by the model-smt stage. Defaults to "
+            "plugins/model_smt/cpc_defs.eo."
         ),
     )
     parser.add_argument(
@@ -636,19 +658,45 @@ def main(argv: list[str]) -> int:
         else:
             final_out_dir = DEFAULT_FINAL_OUT_DIR
 
+    def resolve_file_arg(name: str, flag: str) -> Optional[Path]:
+        """The file the given option names, resolved as the input is.
+
+        It has to exist: read as empty, a mistyped --defs would quietly
+        compile a signature with no exclusions and no dependencies instead of
+        saying that the file it was pointed at is not there.
+        """
+        value = getattr(args, name, None)
+        if value is None:
+            return None
+        resolved = resolve_path_arg(value, cwd=invocation_cwd)
+        if not resolved.is_file():
+            parser.error(f"{flag} file not found: {resolved}")
+        return resolved
+
+    build_dir_arg = getattr(args, "build_dir", None) or os.getcwd()
     pipeline = Pipeline(
-        Path(getattr(args, "build_dir", os.getcwd())),
+        resolve_path_arg(build_dir_arg, cwd=invocation_cwd),
         final_out_dir,
         getattr(args, "jobs", 4),
-        Path(args.defs) if getattr(args, "defs", None) else None,
-        Path(args.lean_config) if getattr(args, "lean_config", None) else None,
+        resolve_file_arg("defs", "--defs"),
+        resolve_file_arg("lean_config", "--lean-config"),
     )
     build_first = not getattr(args, "no_build", False)
+    if not build_first and not pipeline.binary.is_file():
+        parser.error(
+            f"ethos-eoc not found at {pipeline.binary}; drop --no-build or "
+            "name the build directory it is in with --build-dir"
+        )
 
     try:
         if args.command == "lean":
             if not args.all and not args.targets:
                 parser.error("lean requires at least one target unless --all is passed")
+            if args.all and args.targets:
+                parser.error(
+                    "lean --all compiles the whole signature; it takes no targets, "
+                    f"but was given {' '.join(args.targets)}"
+                )
             pipeline.run_lean(
                 args.input,
                 list(args.targets),


### PR DESCRIPTION
This introduces the Eunoia compiler "eoc" which orchestrates the combination of 4 plugins to compile Eunoia to various targets (including Lean).

Further targets for smt2, sygus, desugared eo are forthcoming.

Followup will add further installation, documentation, testing.

Co-Authored-By: GPT 5.6 <noreply@openai.com>